### PR TITLE
How Gmail knows your email is taken, instantly

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Header } from "@/components/nav/Header";
 import { Footer } from "@/components/nav/Footer";
+import { MotionConfigProvider } from "@/components/providers/motion-config";
 
 const plexSerif = IBM_Plex_Serif({
   variable: "--font-plex-serif",
@@ -59,9 +60,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Header />
-          <main className="flex-1">{children}</main>
-          <Footer />
+          <MotionConfigProvider>
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </MotionConfigProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/posts/how-gmail-knows-your-email-is-taken/metadata.ts
+++ b/app/posts/how-gmail-knows-your-email-is-taken/metadata.ts
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+
+const SITE = "https://bytesize.vercel.app";
+const SLUG = "how-gmail-knows-your-email-is-taken";
+const TITLE = "How Gmail knows your email is taken, instantly";
+const HOOK = "the pipeline that tells you 'already taken' before your finger lifts.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: HOOK,
+  openGraph: {
+    title: TITLE,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -1,0 +1,259 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  Callout,
+  Dots,
+  Em,
+  Aside,
+  A,
+} from "@/components/prose";
+import {
+  FlowDemo,
+  NormalisationMap,
+  BloomProbe,
+  SignupRace,
+} from "./widgets";
+import { metadata } from "./metadata";
+
+export { metadata };
+
+export default function HowGmailKnowsYourEmailIsTaken() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <H1>How Gmail knows your email is taken, instantly</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-19">apr 19, 2026</time>
+          <span className="mx-2">·</span>
+          <span>12 min read</span>
+        </p>
+
+        {/* §1 — Scene */}
+        <P>
+          You type an email on the Gmail sign-up page, reach for Tab, and — before your finger
+          lifts — the form says <Em>already taken</Em>. It doesn&apos;t feel like a check. It
+          feels like Gmail already knew.
+        </P>
+        <P>
+          Pick a scenario below and step through what actually happens. Then we&apos;ll zoom in
+          on the parts that earn their keep.
+        </P>
+      </div>
+
+      <FlowDemo />
+
+      <div>
+        <P>
+          Three things to notice in the widget. First, the answer can come out of any of several
+          layers — not just the database. Second, the very first thing the server does is
+          rewrite your email into a form you didn&apos;t type. Third, whatever the flow above
+          says while you&apos;re typing, it&apos;s not what decides anything when you actually
+          click <Em>Sign up</Em>. We&apos;ll work through each.
+        </P>
+      </div>
+
+      {/* §2 — Canonical form */}
+      <div>
+        <Dots />
+        <H2>Your email gets rewritten</H2>
+        <P>
+          Before the accounts table is consulted, your address is lowered, stripped of dots in
+          the local part, and trimmed of anything after a plus. So{" "}
+          <Code>J.Ohn.Doe+promo@gmail.com</Code> becomes <Code>johndoe@gmail.com</Code>. That
+          canonical string is what every layer below actually checks.
+        </P>
+      </div>
+
+      <NormalisationMap />
+
+      <div>
+        <P>
+          Google&apos;s own help docs confirm this for consumer <Code>@gmail.com</Code>{" "}
+          addresses. It&apos;s why <Code>j.o.h.n.d.o.e@gmail.com</Code> can&apos;t register if{" "}
+          <Code>johndoe@gmail.com</Code> already exists. The thing you typed was discarded.
+        </P>
+        <Aside>
+          Workspace accounts — Google Workspace on a custom domain — don&apos;t follow this
+          rule. Each tenant admin decides whether dots matter. Only consumer{" "}
+          <Code>@gmail.com</Code> and <Code>@googlemail.com</Code> normalise this way.
+        </Aside>
+      </div>
+
+      {/* §3 — The cache tier (the Redis question, answered honestly) */}
+      <div>
+        <Dots />
+        <H2>Two caches before the database</H2>
+        <P>
+          A <Em>very</Em> common question about this flow: what&apos;s the cache doing in front
+          of the database? Most real identity systems put at least one — often two — in-memory
+          cache tiers between the request and the authoritative store, and Gmail is no
+          exception.
+        </P>
+        <P>
+          The first one is an <Em>in-process</Em> near-cache, right inside the Gaia frontend
+          that handles your request. If the same canonical email was asked about in the last few
+          seconds on the same shard (which happens a lot — popular names get typed constantly),
+          the answer is still in memory. No further work.
+        </P>
+        <P>
+          The second is a <Em>distributed</Em> cache that spans many frontends, so a warm
+          answer from one shard can serve another. In the FlowDemo widget above, the{" "}
+          <Em>someone just checked this name</Em> scenario lights this up: the request
+          terminates at the near-cache and never reaches the Bloom filter or Spanner.
+        </P>
+        <Callout tone="note">
+          Google&apos;s internal stack uses in-house Memcache-class caches (see{" "}
+          <A href="https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/">
+            Zanzibar
+          </A>
+          &apos;s Leopard), not Redis. Outside Google it&apos;s usually{" "}
+          <A href="https://engineering.shopify.com/blogs/engineering/identitycache-improving-performance-one-cached-model-at-a-time">
+            Memcached
+          </A>{" "}
+          or Redis — different names, same job.
+        </Callout>
+      </div>
+
+      {/* §4 — Bloom filter */}
+      <div>
+        <Dots />
+        <H2>The Bloom filter: a cheap, one-sided answer</H2>
+        <P>
+          When both caches miss, the server asks one more cheap thing before touching the
+          database: a <Em>Bloom filter</Em>. A row of bits, all zero to start. When an account
+          is created, a few hash functions of the canonical email each pick a bit, and those
+          bits get flipped on. To check an email, hash it the same way and look at those bits:
+          if any one of them is <Code>0</Code>, it&apos;s definitely not in the set. If
+          they&apos;re all <Code>1</Code>, it <Em>might</Em> be.
+        </P>
+        <P>
+          Step through a handful of inserts and queries below.
+        </P>
+      </div>
+
+      <BloomProbe />
+
+      <div>
+        <P>
+          The filter can lie about <Em>yes</Em>, never about <Em>no</Em>. A <Em>no</Em> alone is
+          enough to answer the user — no database round-trip needed. A <Em>maybe</Em> has to go
+          to Spanner to be sure.
+        </P>
+      </div>
+
+      {/* §5 — The two paths after Bloom */}
+      <div>
+        <Dots />
+        <H2>Three fast paths, one slow one</H2>
+        <P>
+          Put those pieces together. The same request can end at four different places
+          depending on what each layer knows:
+        </P>
+        <ul
+          className="mt-[var(--spacing-sm)] pl-[var(--spacing-md)] list-disc flex flex-col gap-[var(--spacing-2xs)]"
+          style={{ color: "var(--color-text)" }}
+        >
+          <li>
+            <Em>Near-cache hit</Em> — a few microseconds. The fastest path.
+          </li>
+          <li>
+            <Em>Distributed-cache hit</Em> — a millisecond or two. Still fast.
+          </li>
+          <li>
+            <Em>Bloom filter says no</Em> — a couple of milliseconds. Saves the database trip
+            entirely.
+          </li>
+          <li>
+            <Em>Bloom filter says maybe</Em> — point-read on Spanner. Google&apos;s published
+            target for Spanner point reads is under 5 ms at the median. The only path that
+            actually talks to the authoritative store.
+          </li>
+        </ul>
+        <P>
+          Scroll back to the top widget and switch between scenarios. The diagram re-routes to
+          match.
+        </P>
+      </div>
+
+      {/* §6 — Submit moment / race */}
+      <div>
+        <Dots />
+        <H2>Submit — the check you didn&apos;t see</H2>
+        <P>
+          Everything above was the check that runs <Em>while you&apos;re typing</Em>. It&apos;s
+          a UX hint, and it&apos;s allowed to be wrong, stale, or racing someone else.
+        </P>
+        <P>
+          When you actually click Sign up, a different thing happens. A database transaction
+          tries to <Code>INSERT</Code> a new row keyed on your canonical email, against a column
+          with a uniqueness constraint enforced by Spanner itself. If another person&apos;s
+          transaction committed first, yours fails with a constraint violation and the server
+          returns <Code>EMAIL_EXISTS</Code> — the official &ldquo;someone else already owns this
+          canonical email&rdquo; signal, which is what the UI renders as <Em>already taken</Em>.
+          Try it below with the two sliders.
+        </P>
+      </div>
+
+      <SignupRace />
+
+      <div>
+        <P>
+          The winner is whichever INSERT Spanner committed first — not whichever user clicked
+          Submit first in their browser. Both clients saw <Em>available</Em> while typing; only
+          the database&apos;s serial ordering at commit decides who actually got the address.
+        </P>
+        <Callout tone="note">
+          The one rule to remember: the pre-check (cache, Bloom, point-read) is for UX. The
+          uniqueness constraint at INSERT time is for truth. If you&apos;re building something
+          similar, put the constraint in the database and let the INSERT fail — never rely on a
+          check-then-insert in application code.
+        </Callout>
+      </div>
+
+      {/* §7 — Netflix dot-scam */}
+      <div>
+        <Dots />
+        <H2>When it goes wrong: the Netflix dot-scam</H2>
+        <P>
+          The reason the rewrite step mattered is that other services don&apos;t always do it
+          the same way Gmail does. In 2018, an engineer{" "}
+          <A href="https://jameshfisher.com/2018/04/07/the-dots-do-matter-how-to-scam-a-gmail-user/">
+            described a scam
+          </A>{" "}
+          that worked like this. An attacker signs up for Netflix using a dotted variant of
+          your Gmail — say <Code>j.ohn.doe@gmail.com</Code> — with a bad card. Netflix treats
+          the dotted version as a new customer, because Netflix doesn&apos;t normalise the way
+          Gmail does. The card fails. Netflix sends <Em>you</Em> a polite email about it —
+          both addresses land in your inbox. You, confused, helpfully pay.
+        </P>
+        <P>
+          Google knew there was one canonical form; Netflix didn&apos;t. That gap is the attack
+          surface. If you&apos;re storing emails, normalise on write, put your uniqueness
+          constraint on the normalised column, and keep the raw version only for display.
+        </P>
+      </div>
+
+      {/* §8 — Wrap */}
+      <div>
+        <Dots />
+        <H2>Sticking the landing</H2>
+        <P>
+          So: a pause, a trip through Google&apos;s edge, a rewrite, two caches, a Bloom filter,
+          maybe a database — and, at Submit, a real transaction against a uniqueness constraint
+          that does the only check that actually matters. Two different questions on two
+          different versions of your email. The fast one is for the UI. The slow one is for the
+          truth.
+        </P>
+      </div>
+    </Prose>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/BitArray.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/BitArray.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Block, type BlockState } from "@/components/viz/Block";
+
+type Props = {
+  /** Bit-array width. */
+  m: number;
+  /** Per-cell state; indexes past bits.length default to "empty". */
+  bits?: BlockState[];
+  /** Labels override the default (index). Pass an empty string to hide a single label. */
+  labels?: (string | number | undefined)[];
+  /** Cell size in SVG units. */
+  cellSize?: number;
+  /** Gap between cells in SVG units. */
+  gap?: number;
+  /** Columns before the array wraps to a new row. Default 32. */
+  wrap?: number;
+  /** Force label visibility. Default: labels shown when m <= 32. */
+  showLabels?: boolean;
+  /** Render as a <g> group expecting a parent <svg>. Default false → own <svg>. */
+  asGroup?: boolean;
+  /** Translate origin when asGroup is true. */
+  x?: number;
+  y?: number;
+};
+
+/**
+ * BitArray — the shared bit-strip substrate. Renders `m` cells as rows of
+ * `<Block>`s. Used standalone for the "stamp bits" section and embedded inside
+ * HashLane / FalsePositiveLab / FNVTrace as a <g>.
+ */
+export function BitArray({
+  m,
+  bits,
+  labels,
+  cellSize = 24,
+  gap = 2,
+  wrap = 32,
+  showLabels,
+  asGroup = false,
+  x = 0,
+  y = 0,
+}: Props) {
+  const cols = Math.min(m, wrap);
+  const rows = Math.ceil(m / cols);
+  const width = cols * (cellSize + gap) - gap;
+  const height = rows * (cellSize + gap) - gap;
+  const labelsOn = showLabels ?? m <= 32;
+
+  const cells = [];
+  for (let i = 0; i < m; i++) {
+    const row = Math.floor(i / cols);
+    const col = i % cols;
+    const cx = x + col * (cellSize + gap);
+    const cy = y + row * (cellSize + gap);
+    const state: BlockState = bits?.[i] ?? "empty";
+    const explicit = labels?.[i];
+    const label = explicit !== undefined ? explicit : labelsOn ? i : undefined;
+    cells.push(<Block key={i} x={cx} y={cy} size={cellSize} state={state} label={label} />);
+  }
+
+  if (asGroup) return <g>{cells}</g>;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      style={{ maxWidth: width, height: "auto" }}
+      role="img"
+      aria-label={`Bit array of ${m} cells`}
+    >
+      {cells}
+    </svg>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/BloomProbe.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/BloomProbe.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { HashLane } from "./HashLane";
+
+// Scripted walk-through of a Bloom filter used as the pre-check in front of
+// the accounts table. Two inserts to establish state, then three queries —
+// one definitely-not, one true-maybe, one false-positive-maybe.
+const BLOOM_SCRIPT = [
+  {
+    kind: "insert" as const,
+    key: "johndoe@gmail.com",
+    bitIndices: [2, 7, 11] as [number, number, number],
+    caption:
+      "Start with an empty filter. When an account is created, three hashes of the canonical email each pick a bit, and those bits are flipped on. Nothing about the email itself is stored.",
+  },
+  {
+    kind: "insert" as const,
+    key: "alice@gmail.com",
+    bitIndices: [4, 9, 13] as [number, number, number],
+    caption:
+      "Another account is added. Different hashes, different bits. The filter remembers that two addresses exist — without storing either of them.",
+  },
+  {
+    kind: "query" as const,
+    key: "zxcvb123@gmail.com",
+    bitIndices: [0, 5, 14] as [number, number, number],
+    caption:
+      "Now someone types a brand-new email. The filter hashes it the same way and checks its three bits. At least one of them is zero, so the answer is definitely not — nobody who was inserted could have left a zero on a bit that their own hashes would have flipped.",
+  },
+  {
+    kind: "query" as const,
+    key: "johndoe@gmail.com",
+    bitIndices: [2, 7, 11] as [number, number, number],
+    caption:
+      "Query an email that actually exists. All three bits are on — the filter says maybe, and this time it's correct. The real answer will come from the database.",
+  },
+  {
+    kind: "query" as const,
+    key: "different@gmail.com",
+    bitIndices: [2, 7, 13] as [number, number, number],
+    caption:
+      "Query a brand-new email whose three hashes happen to land on bits that were set by other people. The filter says maybe — but it's wrong. That's a false positive. It still doesn't let a taken email through as new, so the correctness guarantee holds.",
+  },
+];
+
+type Props = {
+  initialStep?: number;
+};
+
+/**
+ * BloomProbe — §"bloom filter" zoom. Thin wrapper around HashLane (lifted
+ * from the bloom-filters WIP post) with a script tailored to the pre-check
+ * story: two inserts, then three queries showing "definitely not",
+ * "maybe-correct", and "maybe-false-positive".
+ */
+export function BloomProbe({ initialStep = 0 }: Props) {
+  return <HashLane m={16} script={BLOOM_SCRIPT} initialStep={initialStep} />;
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/FlowDemo.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/FlowDemo.tsx
@@ -1,0 +1,465 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type StageId =
+  | "input"
+  | "edge"
+  | "frontend"
+  | "normalise"
+  | "nearCache"
+  | "distCache"
+  | "bloom"
+  | "spanner"
+  | "respond";
+
+type BranchId = "nearCacheHit" | "distCacheHit" | "bloomNo";
+
+type Scenario = {
+  id: "fresh" | "hotTaken" | "dottedCold";
+  label: string;
+  typed: string;
+  canonical: string;
+  /** Which branch exits early (if any). undefined means no fast-path; the flow reaches Spanner. */
+  earlyExit?: BranchId;
+  /** Final answer. */
+  finalAnswer: "available" | "taken";
+};
+
+const SCENARIOS: Scenario[] = [
+  {
+    id: "fresh",
+    label: "brand-new email",
+    typed: "zxcvb12345@gmail.com",
+    canonical: "zxcvb12345@gmail.com",
+    earlyExit: "bloomNo",
+    finalAnswer: "available",
+  },
+  {
+    id: "hotTaken",
+    label: "someone just checked this name",
+    typed: "johndoe@gmail.com",
+    canonical: "johndoe@gmail.com",
+    earlyExit: "nearCacheHit",
+    finalAnswer: "taken",
+  },
+  {
+    id: "dottedCold",
+    label: "dotted variant, nothing cached",
+    typed: "J.ohn.Doe+promo@gmail.com",
+    canonical: "johndoe@gmail.com",
+    earlyExit: undefined,
+    finalAnswer: "taken",
+  },
+];
+
+type Stage = {
+  id: StageId;
+  label: string;
+  sublabel?: string;
+  /** Caption shown below canvas when this stage is active. */
+  caption: (s: Scenario) => string;
+  /** If this stage can short-circuit, the branch id + label. */
+  branch?: { id: BranchId; label: string; to: (s: Scenario) => string };
+};
+
+const TRUNK_STAGES: Stage[] = [
+  {
+    id: "input",
+    label: "you type the email",
+    caption: (s) =>
+      `The browser has the full string ${s.typed} once you pause for ~300 ms. It doesn't fire one request per keystroke.`,
+  },
+  {
+    id: "edge",
+    label: "Google Front End",
+    sublabel: "Maglev + GFE + abuse",
+    caption: () =>
+      "The request arrives at the closest Google edge. Maglev routes the TCP flow, GFE terminates TLS, and Cloud-Armor-class rules cap abuse and feed a reCAPTCHA score in.",
+  },
+  {
+    id: "frontend",
+    label: "identity frontend shard",
+    sublabel: "ALTS over Stubby · Slicer",
+    caption: () =>
+      "An internal RPC routes to a specific Gaia frontend. Slicer hashes on the canonical email so the same address always lands on the same warm shard.",
+  },
+  {
+    id: "normalise",
+    label: "normalise → canonical",
+    caption: (s) =>
+      s.typed === s.canonical
+        ? `The server looks at ${s.canonical}. It's already canonical, so nothing to rewrite.`
+        : `The server rewrites ${s.typed} into ${s.canonical}: lowercase, dots stripped, +tag discarded. This canonical string is what every layer below actually sees.`,
+  },
+  {
+    id: "nearCache",
+    label: "in-process near-cache",
+    sublabel: "hot entries, per-shard",
+    caption: (s) =>
+      s.earlyExit === "nearCacheHit"
+        ? `The cache hits. This email was asked about recently on the same shard — the answer is already in memory. The server responds without touching the distributed tier or the database.`
+        : `The cache misses. Nothing recent for this canonical email on this shard. The server asks the distributed cache next.`,
+    branch: {
+      id: "nearCacheHit",
+      label: "hit",
+      to: (s) => s.finalAnswer,
+    },
+  },
+  {
+    id: "distCache",
+    label: "distributed cache",
+    sublabel: "Memcache-class (not Redis)",
+    caption: (s) =>
+      s.earlyExit === "distCacheHit"
+        ? `The distributed cache hits. Another shard saw this email recently and stashed the answer. The server responds.`
+        : `The distributed cache misses. No one's seen this email recently, anywhere. The server asks the Bloom filter next.`,
+    branch: {
+      id: "distCacheHit",
+      label: "hit",
+      to: (s) => s.finalAnswer,
+    },
+  },
+  {
+    id: "bloom",
+    label: "Bloom filter",
+    sublabel: "in-memory pre-check",
+    caption: (s) =>
+      s.earlyExit === "bloomNo"
+        ? `The filter says no. One of the three hashed bits is zero — nobody with this canonical email could have been inserted. The server responds without touching the database.`
+        : `The filter says maybe. All three hashed bits are on. Could be a real account, could be a coincidence. The server asks the database.`,
+    branch: {
+      id: "bloomNo",
+      label: "no",
+      to: () => "available",
+    },
+  },
+  {
+    id: "spanner",
+    label: "Spanner point read",
+    sublabel: "primary-key lookup",
+    caption: (s) =>
+      `The server reads the row keyed on ${s.canonical}. Google's published target for Spanner point reads is under 5 ms at the median. Inside the storage engine, an SSTable-level Bloom filter avoids a disk seek if the row isn't there.`,
+  },
+  {
+    id: "respond",
+    label: "respond",
+    caption: (s) => `The server returns "${s.finalAnswer}". The UI updates under your cursor.`,
+  },
+];
+
+type Props = {
+  initialScenario?: Scenario["id"];
+  initialStep?: number;
+};
+
+/**
+ * FlowDemo — the post's integrated pipeline widget. Nine stages in a vertical
+ * trunk with three branch-off "respond" exits: near-cache hit, distributed
+ * cache hit, and Bloom-filter "definitely not". Three scenarios each exercise
+ * a different path:
+ *   - fresh       → trunk to Bloom, Bloom says "no", respond fast
+ *   - hotTaken    → trunk to near-cache, hit, respond fastest
+ *   - dottedCold  → trunk all the way to Spanner, respond
+ */
+export function FlowDemo({ initialScenario = "fresh", initialStep = 0 }: Props) {
+  const [scenarioId, setScenarioId] = useState<Scenario["id"]>(initialScenario);
+  const scenario = SCENARIOS.find((s) => s.id === scenarioId) ?? SCENARIOS[0];
+
+  // Visible stages: if earlyExit fires at stage S, stop after S (drop later trunk stages).
+  const visibleStages = useMemo(() => {
+    if (!scenario.earlyExit) return TRUNK_STAGES;
+    const exitStageIndex = TRUNK_STAGES.findIndex(
+      (s) => s.branch?.id === scenario.earlyExit,
+    );
+    if (exitStageIndex < 0) return TRUNK_STAGES;
+    return TRUNK_STAGES.slice(0, exitStageIndex + 1);
+  }, [scenario.earlyExit]);
+
+  const [step, setStep] = useState(initialStep);
+  const clamped = Math.max(0, Math.min(step, visibleStages.length - 1));
+  const current = visibleStages[clamped];
+
+  // Layout
+  const WIDTH = 820;
+  const TOP_PAD = 16;
+  const NODE_W = 280;
+  const NODE_H = 50;
+  const ROW_GAP = 22;
+  const TRUNK_X = 160;
+  const BRANCH_X = TRUNK_X + NODE_W + 60;
+  const BRANCH_W = 240;
+
+  const rowY = (i: number) => TOP_PAD + i * (NODE_H + ROW_GAP);
+
+  // Height: we render ALL TRUNK_STAGES (dimmed when not visible) so the geometry stays stable.
+  const totalRows = TRUNK_STAGES.length;
+  const HEIGHT = TOP_PAD + totalRows * (NODE_H + ROW_GAP) + 24;
+
+  const visibleIds = new Set(visibleStages.map((s) => s.id));
+  const isActive = (id: StageId) => current.id === id;
+  const isPast = (id: StageId) => {
+    const i = visibleStages.findIndex((s) => s.id === id);
+    return i >= 0 && i < clamped;
+  };
+  const isVisible = (id: StageId) => visibleIds.has(id);
+
+  const answerTone =
+    scenario.finalAnswer === "available" ? "var(--color-accent)" : "var(--color-text)";
+
+  // Detect whether the current stage triggered the early exit (to show the branch arrow)
+  const branchFired = (stg: Stage): boolean => {
+    return (
+      !!stg.branch &&
+      scenario.earlyExit === stg.branch.id &&
+      // Branch only after reader reaches that stage
+      (clamped >= TRUNK_STAGES.findIndex((s) => s.id === stg.id))
+    );
+  };
+
+  return (
+    <WidgetShell
+      title="FlowDemo · end-to-end"
+      measurements={`scenario = ${scenario.label} · step = ${clamped + 1}/${visibleStages.length}`}
+      caption={current.caption(scenario)}
+      controls={
+        <div className="flex items-center gap-[var(--spacing-md)] flex-wrap">
+          <Stepper value={clamped} total={visibleStages.length} onChange={setStep} />
+          <div
+            className="flex items-center gap-[var(--spacing-2xs)] font-sans"
+            style={{ fontSize: "var(--text-ui)" }}
+          >
+            {SCENARIOS.map((s, i) => {
+              const active = scenarioId === s.id;
+              return (
+                <span key={s.id} className="flex items-center">
+                  {i > 0 ? (
+                    <span className="mx-1" style={{ color: "var(--color-text-muted)" }}>
+                      ·
+                    </span>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setScenarioId(s.id);
+                      setStep(0);
+                    }}
+                    aria-pressed={active}
+                    className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] transition-colors hover:text-[color:var(--color-accent)] inline-flex items-center gap-[var(--spacing-2xs)]"
+                    style={{
+                      color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                      textDecoration: active ? "underline" : "none",
+                    }}
+                  >
+                    <span
+                      aria-hidden
+                      style={{
+                        display: "inline-block",
+                        width: 6,
+                        height: 6,
+                        borderRadius: 1,
+                        background: active ? "var(--color-accent)" : "transparent",
+                        border: active ? "none" : "1px solid var(--color-rule)",
+                      }}
+                    />
+                    {s.label}
+                  </button>
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`Flow demo, scenario: ${scenario.label}, step ${clamped + 1}: ${current.label}`}
+      >
+        {/* Trunk: render every stage (grey out the ones not visible this scenario) */}
+        {TRUNK_STAGES.map((stg, i) => {
+          const y = rowY(i);
+          const active = isActive(stg.id);
+          const past = isPast(stg.id);
+          const vis = isVisible(stg.id);
+          const opacity = vis ? (active ? 1 : past ? 0.9 : 0.6) : 0.22;
+          const borderColor = active
+            ? "var(--color-accent)"
+            : past
+              ? "var(--color-text-muted)"
+              : "var(--color-rule)";
+
+          // Bracket shape for the branch-capable stages (nearCache/distCache/bloom) — small indicator on the right edge
+          return (
+            <motion.g
+              key={stg.id}
+              initial={false}
+              animate={{ opacity }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={TRUNK_X}
+                y={y}
+                width={NODE_W}
+                height={NODE_H}
+                rx={3}
+                fill={
+                  active
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : past
+                      ? "color-mix(in oklab, var(--color-surface) 60%, transparent)"
+                      : "transparent"
+                }
+                stroke={borderColor}
+                strokeWidth={active ? 1.6 : 1}
+              />
+              <text
+                x={TRUNK_X + 14}
+                y={y + (stg.sublabel ? 20 : NODE_H / 2)}
+                dominantBaseline={stg.sublabel ? "central" : "central"}
+                fontFamily="var(--font-sans)"
+                fontSize={13}
+                fill={active || past ? "var(--color-text)" : "var(--color-text-muted)"}
+              >
+                {stg.label}
+              </text>
+              {stg.sublabel ? (
+                <text
+                  x={TRUNK_X + 14}
+                  y={y + 36}
+                  fontFamily="var(--font-mono)"
+                  fontSize={10}
+                  fill="var(--color-text-muted)"
+                >
+                  {stg.sublabel}
+                </text>
+              ) : null}
+
+              {/* Downstream edge (vertical line between trunk nodes). Only draw if next stage is visible. */}
+              {i < TRUNK_STAGES.length - 1 && isVisible(TRUNK_STAGES[i + 1].id) ? (
+                <line
+                  x1={TRUNK_X + NODE_W / 2}
+                  x2={TRUNK_X + NODE_W / 2}
+                  y1={y + NODE_H}
+                  y2={y + NODE_H + ROW_GAP}
+                  stroke="var(--color-text-muted)"
+                  strokeWidth={1.2}
+                  opacity={0.5}
+                />
+              ) : null}
+            </motion.g>
+          );
+        })}
+
+        {/* Branch-out nodes — rendered for each stage with a branch, but only "active" when the scenario took this path. */}
+        {TRUNK_STAGES.filter((s) => s.branch).map((stg, branchIdx) => {
+          const trunkIdx = TRUNK_STAGES.findIndex((s) => s.id === stg.id);
+          const y = rowY(trunkIdx) + NODE_H / 2 - 22;
+          const fired = branchFired(stg);
+          const label = stg.branch!.to(scenario);
+          // 60 ms stagger on non-fired branches so they fade down in order rather than as a block.
+          const staggerDelay = fired ? 0 : branchIdx * 0.06;
+          return (
+            <motion.g
+              key={`branch-${stg.id}`}
+              initial={false}
+              animate={{ opacity: fired ? 1 : 0.25 }}
+              transition={{ ...SPRING.smooth, delay: staggerDelay }}
+            >
+              {/* Arrow from trunk out to the branch box */}
+              <line
+                x1={TRUNK_X + NODE_W}
+                y1={rowY(trunkIdx) + NODE_H / 2}
+                x2={BRANCH_X}
+                y2={rowY(trunkIdx) + NODE_H / 2}
+                stroke={fired ? "var(--color-accent)" : "var(--color-rule)"}
+                strokeWidth={fired ? 1.6 : 1}
+              />
+              {/* Branch label (hit / no) */}
+              <text
+                x={TRUNK_X + NODE_W + 32}
+                y={rowY(trunkIdx) + NODE_H / 2 - 8}
+                fontFamily="var(--font-mono)"
+                fontSize={11}
+                fill={fired ? "var(--color-accent)" : "var(--color-text-muted)"}
+              >
+                {stg.branch!.label}
+              </text>
+              {/* Branch-out box */}
+              <rect
+                x={BRANCH_X}
+                y={y}
+                width={BRANCH_W}
+                height={44}
+                rx={3}
+                fill={fired ? "color-mix(in oklab, var(--color-accent) 16%, transparent)" : "transparent"}
+                stroke={fired ? "var(--color-accent)" : "var(--color-rule)"}
+                strokeWidth={fired ? 1.6 : 1}
+                strokeDasharray={fired ? undefined : "4 3"}
+              />
+              <text
+                x={BRANCH_X + BRANCH_W / 2}
+                y={y + 22}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill={fired ? "var(--color-text)" : "var(--color-text-muted)"}
+              >
+                {label}
+              </text>
+            </motion.g>
+          );
+        })}
+
+        {/* Final-answer emphasis under the bottom node when scenario reaches the trunk's end */}
+        {!scenario.earlyExit && clamped === visibleStages.length - 1 ? (
+          <motion.g
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...SPRING.smooth, delay: 0.2 }}
+          >
+            <text
+              x={TRUNK_X + NODE_W / 2}
+              y={HEIGHT - 6}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={13}
+              fill={answerTone}
+            >
+              answer: <tspan fontWeight={600}>{scenario.finalAnswer}</tspan>
+            </text>
+          </motion.g>
+        ) : null}
+
+        {/* Canonical form label under "normalise" */}
+        {(() => {
+          const idx = TRUNK_STAGES.findIndex((s) => s.id === "normalise");
+          if (idx < 0 || clamped < visibleStages.findIndex((s) => s.id === "normalise")) return null;
+          return (
+            <motion.text
+              key={`can-${scenario.id}`}
+              x={TRUNK_X + NODE_W / 2}
+              y={rowY(idx) + NODE_H + 14}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-accent)"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={SPRING.smooth}
+            >
+              → {scenario.canonical}
+            </motion.text>
+          );
+        })()}
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { Arrow } from "@/components/viz/Arrow";
+import { Stepper } from "@/components/viz/Stepper";
+import { SvgDefs } from "@/components/viz/SvgDefs";
+import type { BlockState } from "@/components/viz/Block";
+import { SPRING } from "@/lib/motion";
+import { BitArray } from "./BitArray";
+import { WidgetShell } from "./WidgetShell";
+
+type HashLaneStep = {
+  kind: "insert" | "query" | "remove";
+  key: string;
+  bitIndices: [number, number, number];
+  caption: string;
+};
+
+type Props = {
+  m?: number;
+  script?: HashLaneStep[];
+  initialStep?: number;
+};
+
+// Default script — the authored-aha deletion-breakage moment.
+const DEFAULT_SCRIPT: HashLaneStep[] = [
+  {
+    kind: "insert",
+    key: "foo",
+    bitIndices: [2, 7, 11],
+    caption:
+      "Insert foo. Three hashes, three bits. The filter now remembers that it's seen foo — though, as we'll see, not exactly what it saw.",
+  },
+  {
+    kind: "insert",
+    key: "baz",
+    bitIndices: [5, 7, 13],
+    caption:
+      "Insert baz. Notice bit 7 was already set by foo. Nobody asked permission; the bit belongs to both of them now.",
+  },
+  {
+    kind: "remove",
+    key: "baz",
+    bitIndices: [5, 7, 13],
+    caption:
+      "Remove baz. We clear the three bits baz set. But bit 7 was also foo's — and the filter has no way to know that.",
+  },
+  {
+    kind: "query",
+    key: "foo",
+    bitIndices: [2, 7, 11],
+    caption:
+      "Now query foo. Bit 7 is zero. The filter answers \"no\" — for a key we definitely inserted. That's a false negative, which Bloom filters promise never to produce. Which is why they don't support remove.",
+  },
+];
+
+const HASH_NAMES = ["h₁", "h₂", "h₃"] as const;
+// Three shapes so hash identity survives colorblindness; tint carries identity too.
+const HASH_SHAPES = ["circle", "triangle", "square"] as const;
+
+/**
+ * HashLane — opening widget. Three hash lanes above a 16-bit array, stepping
+ * through the foo/baz/remove/query script that manufactures the deletion-
+ * impossibility aha.
+ */
+export function HashLane({ m = 16, script = DEFAULT_SCRIPT, initialStep = 0 }: Props) {
+  const [step, setStep] = useState(initialStep);
+  const current = script[Math.max(0, Math.min(step, script.length - 1))];
+
+  // Compute cumulative bit state through step `step`.
+  const bits = useMemo(() => {
+    const state: BlockState[] = Array(m).fill("empty");
+    for (let i = 0; i <= step; i++) {
+      const s = script[i];
+      if (!s) continue;
+      if (s.kind === "insert") s.bitIndices.forEach((b) => (state[b] = "set"));
+      else if (s.kind === "remove") s.bitIndices.forEach((b) => (state[b] = "empty"));
+      // query doesn't change state
+    }
+    return state;
+  }, [script, step, m]);
+
+  // Geometry: 16 cells × 34px = 544. Plus padding → 576 wide canvas.
+  const CELL = 28;
+  const GAP = 4;
+  const rowWidth = m * (CELL + GAP) - GAP;
+  const PADDING_X = 32;
+  const WIDTH = rowWidth + PADDING_X * 2;
+  const LANE_Y = 48;
+  const LANE_LABEL_Y = 28;
+  const ARRAY_Y = 168;
+  const HEIGHT = ARRAY_Y + CELL + 28;
+
+  // Lane x positions — evenly distributed across the canvas.
+  const laneXs = HASH_NAMES.map(
+    (_, i) => PADDING_X + ((i + 1) / (HASH_NAMES.length + 1)) * rowWidth,
+  );
+
+  const bitCenter = (i: number) => ({
+    x: PADDING_X + i * (CELL + GAP) + CELL / 2,
+    y: ARRAY_Y,
+  });
+
+  const isQuery = current.kind === "query";
+  const lineTone = isQuery ? "muted" : "active";
+  const arrowKey = `${step}-${current.kind}-${current.key}`;
+
+  const setCount = bits.filter((b) => b === "set").length;
+  const measurements = `m = ${m} · set = ${setCount} · step = ${step + 1}/${script.length}`;
+
+  const queryAnswer = (() => {
+    if (!isQuery) return null;
+    const [a, b, c] = current.bitIndices;
+    const allSet = bits[a] === "set" && bits[b] === "set" && bits[c] === "set";
+    return allSet ? "maybe" : "no";
+  })();
+
+  return (
+    <WidgetShell
+      title={`HashLane · ${current.kind} ${current.key}`}
+      measurements={measurements}
+      caption={current.caption}
+      controls={<Stepper value={step} total={script.length} onChange={setStep} />}
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`Hash-lane demo, step ${step + 1} of ${script.length}: ${current.kind} ${current.key}`}
+      >
+        <defs>
+          <SvgDefs />
+        </defs>
+
+        {/* Lane labels + shapes (hash identity) */}
+        {HASH_NAMES.map((name, i) => (
+          <g key={name} transform={`translate(${laneXs[i]}, ${LANE_LABEL_Y})`}>
+            <LaneShape shape={HASH_SHAPES[i]} />
+            <text
+              x={18}
+              y={4}
+              fontFamily="var(--font-mono)"
+              fontSize={12}
+              fill="var(--color-text-muted)"
+              dominantBaseline="central"
+            >
+              {name}
+            </text>
+          </g>
+        ))}
+
+        {/* Key label at centre-top, animated through step changes */}
+        <motion.text
+          key={arrowKey}
+          x={WIDTH / 2}
+          y={LANE_Y + 8}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={14}
+          fill={isQuery ? "var(--color-text-muted)" : "var(--color-text)"}
+          initial={{ opacity: 0, y: LANE_Y + 2 }}
+          animate={{ opacity: 1, y: LANE_Y + 8 }}
+          transition={SPRING.smooth}
+        >
+          {current.kind === "remove" ? `remove("${current.key}")` :
+           current.kind === "insert" ? `insert("${current.key}")` :
+           `query("${current.key}")`}
+        </motion.text>
+
+        {/* Arrows: hash → bit. Re-keyed so they draw-in on each step. */}
+        {current.bitIndices.map((bitIdx, i) => {
+          const laneX = laneXs[i];
+          const from = { x: laneX, y: LANE_Y + 16 };
+          const to = bitCenter(bitIdx);
+          const curvature = (i - 1) * 18;
+          return (
+            <Arrow
+              key={`${arrowKey}-${i}`}
+              x1={from.x}
+              y1={from.y}
+              x2={to.x}
+              y2={to.y - CELL / 2 - 4}
+              tone={lineTone}
+              curvature={curvature}
+              animateIn
+              strokeWidth={1.5}
+            />
+          );
+        })}
+
+        {/* Query pulse rings — drawn over bits for query steps */}
+        {isQuery
+          ? current.bitIndices.map((bitIdx) => {
+              const { x, y } = bitCenter(bitIdx);
+              const isMiss = bits[bitIdx] !== "set";
+              return (
+                <motion.circle
+                  key={`pulse-${bitIdx}-${arrowKey}`}
+                  cx={x}
+                  cy={y + CELL / 2}
+                  r={CELL * 0.6}
+                  fill="none"
+                  stroke={isMiss ? "var(--color-text)" : "var(--color-accent)"}
+                  strokeWidth={1.5}
+                  initial={{ scale: 0.7, opacity: 0 }}
+                  animate={{ scale: 1, opacity: isMiss ? 0.9 : 0.6 }}
+                  transition={SPRING.smooth}
+                />
+              );
+            })
+          : null}
+
+        {/* Bit array */}
+        <BitArray
+          m={m}
+          bits={bits}
+          cellSize={CELL}
+          gap={GAP}
+          asGroup
+          x={PADDING_X}
+          y={ARRAY_Y - CELL / 2 + CELL / 2}
+        />
+
+        {/* Query answer — shown only for query steps */}
+        {queryAnswer !== null ? (
+          <motion.text
+            key={`ans-${arrowKey}`}
+            x={WIDTH / 2}
+            y={HEIGHT - 8}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={13}
+            fill={queryAnswer === "no" ? "var(--color-text-muted)" : "var(--color-accent)"}
+            initial={{ opacity: 0, y: HEIGHT - 2 }}
+            animate={{ opacity: 1, y: HEIGHT - 8 }}
+            transition={{ ...SPRING.smooth, delay: 0.35 }}
+          >
+            answer: <tspan fontWeight={600}>{queryAnswer === "maybe" ? "maybe" : "no"}</tspan>
+          </motion.text>
+        ) : null}
+      </svg>
+    </WidgetShell>
+  );
+}
+
+function LaneShape({ shape }: { shape: (typeof HASH_SHAPES)[number] }) {
+  const fill = "none";
+  const stroke = "var(--color-text-muted)";
+  const sw = 1.4;
+  if (shape === "circle")
+    return <circle cx={0} cy={4} r={6} fill={fill} stroke={stroke} strokeWidth={sw} />;
+  if (shape === "triangle")
+    return (
+      <polygon
+        points="-6,10 6,10 0,-2"
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={sw}
+        strokeLinejoin="round"
+      />
+    );
+  return <rect x={-6} y={-2} width={12} height={12} fill={fill} stroke={stroke} strokeWidth={sw} />;
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormalisationMap.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormalisationMap.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SvgDefs } from "@/components/viz/SvgDefs";
+import { Arrow } from "@/components/viz/Arrow";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Row = {
+  typed: string;
+  /** One-line caption that appears below the canvas when this row becomes active. */
+  caption: string;
+  /** If true, this row does NOT map to the default canonical form. */
+  separate?: boolean;
+  /** When separate=true, the alternate canonical form. */
+  alternate?: string;
+};
+
+const DEFAULT_CANONICAL = "johndoe@gmail.com";
+
+const DEFAULT_ROWS: Row[] = [
+  {
+    typed: "johndoe@gmail.com",
+    caption: "The canonical form itself. Obviously taken.",
+  },
+  {
+    typed: "JohnDoe@Gmail.com",
+    caption: "Case doesn't matter. Same account.",
+  },
+  {
+    typed: "j.o.h.n.d.o.e@gmail.com",
+    caption: "Dots don't matter — inside @gmail.com. Same account.",
+  },
+  {
+    typed: "john.doe+newsletters@gmail.com",
+    caption: "Everything after the plus is a tag you made up. Same account.",
+  },
+  {
+    typed: "j.ohn.doe+work@googlemail.com",
+    caption: "googlemail.com is gmail.com — old branding, same inbox. Same account.",
+  },
+  {
+    typed: "johndoe@company.com",
+    separate: true,
+    alternate: "johndoe@company.com",
+    caption:
+      "Workspace addresses play by the tenant admin's rules, not Gmail's — so @company.com is its own namespace.",
+  },
+];
+
+type Props = {
+  rows?: Row[];
+  canonical?: string;
+  initialStep?: number;
+};
+
+/**
+ * NormalisationMap — §4. Several typed inputs collapse by curved arrows into
+ * one canonical form (with one intentional exception for the Workspace row).
+ */
+export function NormalisationMap({
+  rows = DEFAULT_ROWS,
+  canonical = DEFAULT_CANONICAL,
+  initialStep = 0,
+}: Props) {
+  const [step, setStep] = useState(initialStep);
+  const current = rows[Math.max(0, Math.min(step, rows.length - 1))];
+
+  // Geometry
+  const WIDTH = 680;
+  const ROW_H = 34;
+  const ROW_GAP = 4;
+  const PAD_T = 12;
+  const PAD_B = 12;
+  const PAD_L = 18;
+  const PAD_R = 28;
+  const LEFT_W = 280;
+  const RIGHT_X = WIDTH - PAD_R - 220;
+  const HEIGHT = PAD_T + rows.length * (ROW_H + ROW_GAP) - ROW_GAP + PAD_B;
+  const CANONICAL_Y = HEIGHT / 2;
+
+  return (
+    <WidgetShell
+      title="NormalisationMap"
+      measurements={`step = ${step + 1}/${rows.length}`}
+      caption={current.caption}
+      controls={<Stepper value={step} total={rows.length} onChange={setStep} />}
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`Normalisation map, step ${step + 1} of ${rows.length}: ${current.typed}`}
+      >
+        <defs>
+          <SvgDefs />
+        </defs>
+
+        {/* Typed inputs on the left */}
+        {rows.map((row, i) => {
+          const y = PAD_T + i * (ROW_H + ROW_GAP) + ROW_H / 2;
+          const revealed = i <= step;
+          const active = i === step;
+          return (
+            <motion.g
+              key={`row-${i}`}
+              initial={false}
+              animate={{ opacity: revealed ? 1 : 0.15 }}
+              transition={SPRING.smooth}
+            >
+              {active ? (
+                <rect
+                  x={PAD_L - 6}
+                  y={y - ROW_H / 2}
+                  width={LEFT_W + 8}
+                  height={ROW_H}
+                  rx={2}
+                  fill="color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                />
+              ) : null}
+              <text
+                x={PAD_L}
+                y={y}
+                dominantBaseline="central"
+                fontFamily="var(--font-mono)"
+                fontSize={13}
+                fill={active ? "var(--color-text)" : "var(--color-text-muted)"}
+              >
+                {row.typed}
+              </text>
+            </motion.g>
+          );
+        })}
+
+        {/* Canonical form on the right */}
+        <g>
+          <rect
+            x={RIGHT_X}
+            y={CANONICAL_Y - 20}
+            width={220}
+            height={40}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-accent) 18%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={1.2}
+          />
+          <text
+            x={RIGHT_X + 110}
+            y={CANONICAL_Y - 2}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={14}
+            fill="var(--color-text)"
+          >
+            {canonical}
+          </text>
+          <text
+            x={RIGHT_X + 110}
+            y={CANONICAL_Y + 12}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+            letterSpacing="0.08em"
+          >
+            CANONICAL FORM
+          </text>
+        </g>
+
+        {/* Workspace alternate target — only visible once the separate row is reached */}
+        {(() => {
+          const separateRow = rows.find((r) => r.separate);
+          const separateIdx = rows.findIndex((r) => r.separate);
+          if (!separateRow || separateIdx === -1) return null;
+          const revealed = step >= separateIdx;
+          const altY = PAD_T + separateIdx * (ROW_H + ROW_GAP) + ROW_H / 2;
+          return (
+            <motion.g
+              initial={false}
+              animate={{ opacity: revealed ? 1 : 0 }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={RIGHT_X}
+                y={altY - 16}
+                width={220}
+                height={32}
+                rx={3}
+                fill="none"
+                stroke="var(--color-text-muted)"
+                strokeWidth={1}
+                strokeDasharray="4 4"
+              />
+              <text
+                x={RIGHT_X + 110}
+                y={altY + 3}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-text-muted)"
+              >
+                {separateRow.alternate ?? separateRow.typed}
+              </text>
+            </motion.g>
+          );
+        })()}
+
+        {/* Arrows from each revealed typed row to its destination */}
+        {rows.map((row, i) => {
+          if (i > step) return null;
+          const y = PAD_T + i * (ROW_H + ROW_GAP) + ROW_H / 2;
+          const toY = row.separate ? y : CANONICAL_Y;
+          const curvature = row.separate ? 0 : (i - rows.length / 2) * 5;
+          const tone = i === step ? "active" : "muted";
+          return (
+            <Arrow
+              key={`arr-${i}-${row.typed}`}
+              x1={PAD_L + LEFT_W + 6}
+              y1={y}
+              x2={RIGHT_X - 4}
+              y2={toY}
+              tone={tone}
+              curvature={curvature}
+              animateIn={i === step}
+              strokeWidth={1.2}
+            />
+          );
+        })}
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/SignupRace.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/SignupRace.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "motion/react";
+import { Scrubber } from "@/components/viz/Scrubber";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Props = {
+  initialAMs?: number;
+  initialBMs?: number;
+  /** Timeline width in ms. */
+  scaleMs?: number;
+  canonical?: string;
+};
+
+/**
+ * SignupRace — §8. Two clients, same canonical email, racing to Submit.
+ * Reader drags two scrubbers to set each user's Submit time. The UI shows
+ * both optimistic pre-checks returning "available"; the database decides who
+ * actually commits based on which INSERT transaction wins the UNIQUE index.
+ */
+export function SignupRace({
+  initialAMs = 20,
+  initialBMs = 28,
+  scaleMs = 60,
+  canonical = "alice@gmail.com",
+}: Props) {
+  const [aMs, setAMs] = useState(initialAMs);
+  const [bMs, setBMs] = useState(initialBMs);
+
+  // Winner: whichever Submit landed first. Tie → A wins by stable ordering
+  // (matches the "database picks one" behaviour — there IS a winner, even on a tie).
+  const aWins = aMs <= bMs;
+  const winnerMs = Math.min(aMs, bMs);
+  const loserMs = Math.max(aMs, bMs);
+
+  // Geometry
+  const WIDTH = 680;
+  const HEIGHT = 300;
+  const PAD_L = 68;
+  const PAD_R = 110;
+  const PAD_T = 28;
+  const PAD_B = 48;
+  const timelineW = WIDTH - PAD_L - PAD_R;
+  const scale = timelineW / scaleMs;
+  const xAt = (ms: number) => PAD_L + ms * scale;
+  const ROW_A_Y = PAD_T + 32;
+  const DB_Y = PAD_T + 112;
+  const ROW_B_Y = PAD_T + 196;
+  const MILE_R = 8;
+
+  const keyRowStart = 2;
+  const precheckAt = 8;
+
+  const renderRow = (
+    yBase: number,
+    userLabel: string,
+    submitMs: number,
+    isWinner: boolean,
+  ) => {
+    const commitMs = submitMs + 3; // small constant delay for INSERT landing at DB
+    return (
+      <g>
+        {/* Row axis */}
+        <line
+          x1={PAD_L}
+          x2={WIDTH - PAD_R}
+          y1={yBase}
+          y2={yBase}
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+
+        {/* User label */}
+        <text
+          x={PAD_L - 8}
+          y={yBase}
+          textAnchor="end"
+          dominantBaseline="central"
+          fontFamily="var(--font-sans)"
+          fontSize={11}
+          fill="var(--color-text-muted)"
+        >
+          {userLabel}
+        </text>
+
+        {/* Typing start */}
+        <circle cx={xAt(keyRowStart)} cy={yBase} r={MILE_R / 2} fill="var(--color-text-muted)" />
+        <text
+          x={xAt(keyRowStart)}
+          y={yBase - 12}
+          textAnchor="middle"
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+        >
+          typing
+        </text>
+
+        {/* Pre-check "available" */}
+        <g>
+          <circle
+            cx={xAt(precheckAt)}
+            cy={yBase}
+            r={MILE_R / 2}
+            fill="var(--color-accent)"
+            opacity={0.5}
+          />
+          <text
+            x={xAt(precheckAt)}
+            y={yBase - 12}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+          >
+            pre-check: available
+          </text>
+        </g>
+
+        {/* Submit click */}
+        <motion.g
+          initial={false}
+          animate={{ x: xAt(submitMs) - xAt(0) }}
+          transition={SPRING.smooth}
+        >
+          <circle cx={xAt(0)} cy={yBase} r={MILE_R} fill="var(--color-accent)" stroke="var(--color-bg)" strokeWidth={2} />
+          <text
+            x={xAt(0)}
+            y={yBase - 14}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill="var(--color-accent)"
+          >
+            submit
+          </text>
+        </motion.g>
+
+        {/* Commit landing at DB */}
+        <motion.g
+          initial={false}
+          animate={{ x: xAt(commitMs) - xAt(0) }}
+          transition={SPRING.smooth}
+        >
+          {isWinner ? (
+            <rect
+              x={xAt(0) - MILE_R}
+              y={yBase - MILE_R}
+              width={MILE_R * 2}
+              height={MILE_R * 2}
+              fill="var(--color-accent)"
+              stroke="var(--color-bg)"
+              strokeWidth={1.5}
+            />
+          ) : (
+            <g>
+              <rect
+                x={xAt(0) - MILE_R}
+                y={yBase - MILE_R}
+                width={MILE_R * 2}
+                height={MILE_R * 2}
+                fill="none"
+                stroke="var(--color-text)"
+                strokeWidth={1.5}
+              />
+              {/* Cross-hatch X inside the reject cell */}
+              <line
+                x1={xAt(0) - MILE_R + 2}
+                y1={yBase - MILE_R + 2}
+                x2={xAt(0) + MILE_R - 2}
+                y2={yBase + MILE_R - 2}
+                stroke="var(--color-text)"
+                strokeWidth={1.2}
+              />
+              <line
+                x1={xAt(0) + MILE_R - 2}
+                y1={yBase - MILE_R + 2}
+                x2={xAt(0) - MILE_R + 2}
+                y2={yBase + MILE_R - 2}
+                stroke="var(--color-text)"
+                strokeWidth={1.2}
+              />
+            </g>
+          )}
+        </motion.g>
+
+        {/* Result label, right of timeline */}
+        <text
+          x={WIDTH - PAD_R + 12}
+          y={yBase}
+          dominantBaseline="central"
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill={isWinner ? "var(--color-accent)" : "var(--color-text-muted)"}
+        >
+          {isWinner ? "commit" : "already taken"}
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title="SignupRace"
+      measurements={`t(A) = ${aMs} ms · t(B) = ${bMs} ms · winner: ${aWins ? "A" : "B"}`}
+      caption={
+        aMs === bMs ? (
+          <>
+            Exact tie. The database still has to pick one — some serial order is always imposed.
+            Here, A wins the tie. The loser's INSERT hits the UNIQUE constraint on{" "}
+            <span className="font-mono">{canonical}</span> and returns{" "}
+            <span className="font-mono">EMAIL_EXISTS</span>. Which user "went first" in the UI
+            doesn't matter. The database decides.
+          </>
+        ) : (
+          <>
+            {aWins ? "A" : "B"} submitted first and commits. {aWins ? "B" : "A"}'s INSERT for{" "}
+            <span className="font-mono">{canonical}</span> hits the UNIQUE constraint and returns{" "}
+            <span className="font-mono">EMAIL_EXISTS</span>. Both users saw "available" during
+            typing — that check was advisory. The database is the truth.
+          </>
+        )
+      }
+      controls={
+        <div className="grid grid-cols-1 gap-[var(--spacing-2xs)] md:grid-cols-2 md:gap-[var(--spacing-md)]">
+          <Scrubber
+            label="A submit"
+            value={aMs}
+            min={0}
+            max={scaleMs}
+            step={1}
+            onChange={setAMs}
+            format={(v) => `t = ${v} ms`}
+          />
+          <Scrubber
+            label="B submit"
+            value={bMs}
+            min={0}
+            max={scaleMs}
+            step={1}
+            onChange={setBMs}
+            format={(v) => `t = ${v} ms`}
+          />
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`Signup race: user A submits at ${aMs} ms, user B at ${bMs} ms. ${aWins ? "A" : "B"} commits; the other gets EMAIL_EXISTS.`}
+      >
+        {/* Time axis label */}
+        <text
+          x={PAD_L}
+          y={PAD_T - 10}
+          fontFamily="var(--font-sans)"
+          fontSize={10}
+          fill="var(--color-text-muted)"
+        >
+          time →
+        </text>
+
+        {renderRow(ROW_A_Y, "USER A", aMs, aWins)}
+        {renderRow(ROW_B_Y, "USER B", bMs, !aWins)}
+
+        {/* Database lane in the middle */}
+        <g>
+          <rect
+            x={PAD_L}
+            y={DB_Y - 24}
+            width={WIDTH - PAD_L - PAD_R}
+            height={48}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-surface) 40%, transparent)"
+            stroke="var(--color-rule)"
+            strokeWidth={1}
+          />
+          <text
+            x={PAD_L - 8}
+            y={DB_Y}
+            textAnchor="end"
+            dominantBaseline="central"
+            fontFamily="var(--font-sans)"
+            fontSize={11}
+            fill="var(--color-text-muted)"
+          >
+            DATABASE
+          </text>
+
+          {/* Winner's commit marker */}
+          <motion.g
+            initial={false}
+            animate={{ x: xAt(winnerMs + 3) - xAt(0) }}
+            transition={SPRING.smooth}
+          >
+            <circle
+              cx={xAt(0)}
+              cy={DB_Y}
+              r={6}
+              fill="var(--color-accent)"
+              stroke="var(--color-bg)"
+              strokeWidth={2}
+            />
+            <text
+              x={xAt(0)}
+              y={DB_Y - 14}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-accent)"
+            >
+              {aWins ? "A" : "B"} commits {canonical}
+            </text>
+          </motion.g>
+
+          {/* Loser's reject marker — only if loser is distinct from winner */}
+          {loserMs !== winnerMs ? (
+            <motion.g
+              initial={false}
+              animate={{ x: xAt(loserMs + 3) - xAt(0) }}
+              transition={SPRING.smooth}
+            >
+              <circle
+                cx={xAt(0)}
+                cy={DB_Y}
+                r={6}
+                fill="none"
+                stroke="var(--color-text)"
+                strokeWidth={1.5}
+              />
+              <line
+                x1={xAt(0) - 4}
+                y1={DB_Y - 4}
+                x2={xAt(0) + 4}
+                y2={DB_Y + 4}
+                stroke="var(--color-text)"
+                strokeWidth={1.2}
+              />
+              <line
+                x1={xAt(0) + 4}
+                y1={DB_Y - 4}
+                x2={xAt(0) - 4}
+                y2={DB_Y + 4}
+                stroke="var(--color-text)"
+                strokeWidth={1.2}
+              />
+              <text
+                x={xAt(0)}
+                y={DB_Y + 18}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+              >
+                {aWins ? "B" : "A"} rejected (UNIQUE)
+              </text>
+            </motion.g>
+          ) : null}
+        </g>
+
+        {/* Time ticks along bottom */}
+        <g>
+          {[0, 10, 20, 30, 40, 50, 60]
+            .filter((t) => t <= scaleMs)
+            .map((t) => (
+              <g key={t}>
+                <line
+                  x1={xAt(t)}
+                  x2={xAt(t)}
+                  y1={HEIGHT - PAD_B + 4}
+                  y2={HEIGHT - PAD_B + 10}
+                  stroke="var(--color-text-muted)"
+                  strokeWidth={1}
+                />
+                <text
+                  x={xAt(t)}
+                  y={HEIGHT - PAD_B + 22}
+                  textAnchor="middle"
+                  fontFamily="var(--font-mono)"
+                  fontSize={10}
+                  fill="var(--color-text-muted)"
+                >
+                  {t}
+                </text>
+              </g>
+            ))}
+          <text
+            x={WIDTH - PAD_R}
+            y={HEIGHT - PAD_B + 22}
+            textAnchor="end"
+            fontFamily="var(--font-sans)"
+            fontSize={10}
+            fill="var(--color-text-muted)"
+          >
+            ms
+          </text>
+        </g>
+
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/WidgetShell.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/WidgetShell.tsx
@@ -1,0 +1,65 @@
+import { FullBleed } from "@/components/prose";
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  measurements?: string;
+  caption?: ReactNode;
+  controls?: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * WidgetShell — the canonical skeleton for widgets in this post.
+ * DESIGN.md §7: <FullBleed><Figure><Header><Canvas><Controls></Figure></FullBleed>.
+ * Measurements top-right in Plex Mono tabular-nums. Controls below canvas,
+ * left-aligned. Optional caption below controls, Plex Sans --text-small muted.
+ */
+export function WidgetShell({ title, measurements, caption, controls, children }: Props) {
+  return (
+    <FullBleed>
+      <figcaption className="sr-only">{title}</figcaption>
+      <div
+        className="flex items-baseline justify-between gap-[var(--spacing-sm)] pb-[var(--spacing-sm)]"
+        style={{ fontSize: "var(--text-ui)" }}
+      >
+        <span
+          className="font-sans"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </span>
+        {measurements ? (
+          <span
+            className="font-mono tabular-nums text-right"
+            style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          >
+            {measurements}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className="rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+        }}
+      >
+        {children}
+      </div>
+
+      {controls ? (
+        <div className="pt-[var(--spacing-sm)]">{controls}</div>
+      ) : null}
+
+      {caption ? (
+        <div
+          className="pt-[var(--spacing-sm)] font-sans"
+          style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)", lineHeight: 1.5 }}
+        >
+          {caption}
+        </div>
+      ) : null}
+    </FullBleed>
+  );
+}

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/index.ts
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/index.ts
@@ -1,0 +1,4 @@
+export { FlowDemo } from "./FlowDemo";
+export { NormalisationMap } from "./NormalisationMap";
+export { BloomProbe } from "./BloomProbe";
+export { SignupRace } from "./SignupRace";

--- a/components/providers/motion-config.tsx
+++ b/components/providers/motion-config.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { MotionConfig } from "motion/react";
+import type { ReactNode } from "react";
+
+/**
+ * Forwards `prefers-reduced-motion: reduce` to motion/react's JS-driven springs.
+ * Without this, CSS media queries only silence CSS transitions — JS springs
+ * keep animating. `reducedMotion="user"` reads the OS/browser preference and
+ * disables non-essential transforms across every <motion.*> component.
+ */
+export function MotionConfigProvider({ children }: { children: ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -17,6 +17,14 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "how-gmail-knows-your-email-is-taken",
+    title: "How Gmail knows your email is taken, instantly",
+    date: "2026-04-19",
+    hook: "the pipeline that tells you 'already taken' before your finger lifts.",
+    readingMinutes: 12,
+    tags: ["distributed-systems", "architecture"],
+  },
+  {
     slug: "how-bloom-filters-work",
     title: "How Bloom Filters Work",
     date: "2026-04-19",


### PR DESCRIPTION
## Summary

- New post at `/posts/how-gmail-knows-your-email-is-taken` — a 12-min product-architecture walkthrough of the real-time sign-up availability check.
- Eight sections, four widgets, one closer (Netflix dot-scam). Voice is accessible engineer-story, not paper-academic (per the tone feedback from the prior post-draft).
- Also ships `MotionConfigProvider` so `motion/react` JS springs respect `prefers-reduced-motion` — this was a global gap the layout didn't cover before.

## Widgets shipped (all post-local; lifts noted)

- **`FlowDemo`** *(new)* — 9-stage vertical trunk from "you type" through GFE → identity frontend (Slicer) → canonical normalise → near-cache → distributed cache → Bloom filter → Spanner → respond. Three branch-out "respond" exits (near-cache hit, distributed-cache hit, Bloom "no") across three scenarios: `brand-new email`, `someone just checked this name`, `dotted variant, nothing cached`.
- **`NormalisationMap`** *(new)* — six typed variants (including a `@googlemail.com` and one Workspace outlier) mapped via curved arrows into one canonical key, stepper-reveal one row at a time.
- **`BloomProbe`** *(new wrapper around lifted `HashLane`)* — 2 inserts, 3 queries: definitely-no / maybe-right / maybe-false-positive. The "little details" on how a Bloom filter works, without a deep-dive that would duplicate samwho.
- **`SignupRace`** *(new)* — dual scrubber lets the reader set each user's Submit time, watch the UNIQUE-index loser path visibly reject even though both pre-checks showed "available".
- `WidgetShell`, `BitArray`, `HashLane` lifted from the bloom-filters WIP branch (`posts/how-bloom-filters-work@6c6c977`) as post-local files. Promotion to `components/viz/` deferred to a second post that needs them.

## Primitives composed

`Block`, `Arrow`, `Scrubber`, `Stepper`, `SvgDefs` from `components/viz/`, plus the full `@/components/prose` kit (no new primitives).

## Action items resolved

All P0 + P1 items from `research/.../action-items.md` shipped:

- [P0] MotionConfigProvider added so JS springs respect reduced-motion. Verified via clean `tsc` + `pnpm build`; live DevTools test is on the Checkpoint-4 list.
- [P1] Spanner latency claim hedged to "Google's published target".
- [P1] FlowDemo scenario labels renamed to plain-language first.
- [P1] `EMAIL_EXISTS` unpacked inline on first mention.
- [P1] FlowDemo branch labels unified unquoted; `respond:` prefix dropped.

Six P2 items shipped (Redis Callout tightened, consistent caption voice, trim step-6 caption, drop `respond:` prefix, scenario-button leading dot, 60 ms stagger on branch fades). Two P2 items deferred to a future iteration (BloomProbe free-query mode, FlowDemo mobile sublabel hiding — needs viewport verification). All P3 items deferred.

## Validation highlights (from `validation.md`)

- **Technical correctness:** pass. All claims backed by `facts-1..4`; Gaia-on-Spanner hedged as "almost certainly" in prose.
- **Code correctness:** pass. No runnable snippets; inline `<Code>` fragments match sources.
- **A11y:** pass. Native `<button>` / `<input type="range">`; `aria-label`s on SVGs; every color-carried state also carried by shape / position / label; global 2px terracotta focus ring. Live reduced-motion DevTools check queued for Checkpoint 4.
- **Build:** pass. `tsc --noEmit` clean; `pnpm build` green; prerendered static route.
- **Lighthouse:** deferred to Checkpoint 4 — `lighthouse` not installed locally; target ≥ 95 perf/a11y/SEO verified in-browser.
- **Reading sanity:** pass. Voice consistent, no undefined terms, no flow-breaking widgets. One stale scenario-name reference caught and fixed.

## Open questions

- Whether to promote `WidgetShell` to `components/viz/` now (it's a shared skeleton) or wait for a third post. Recommend waiting — two post-local copies don't hurt yet.
- The bloom-filters WIP branch (`posts/how-bloom-filters-work@6c6c977`) is preserved and unmerged. We may cherry-pick widgets out of it later, or ship it after a voice-rework. Not in scope here.

## Test plan

- [ ] Click through `/posts/how-gmail-knows-your-email-is-taken` at desktop
- [ ] Exercise every scenario in FlowDemo; verify each branch lights up
- [ ] Step through NormalisationMap end to end; the Workspace outlier should point to a dashed alternate, not the canonical form
- [ ] Step through BloomProbe; the three query outcomes should read definitely-no / maybe (right) / maybe (false positive)
- [ ] Drag both SignupRace sliders; try A=20 B=28, A=28 B=20, A=B (tie); confirm the DB lane shows one commit and one reject
- [ ] Toggle theme dark ↔ light; widgets recolor cleanly
- [ ] DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce`; confirm springs snap, state changes still visible
- [ ] Keyboard-only: Tab through widget controls; focus rings visible on every interactive
- [ ] Run Lighthouse; target ≥ 95 perf/a11y/SEO
- [ ] Mobile viewport 375 px check; confirm FlowDemo is still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)