### PR TITLE
site: anonymize author across website

### DIFF
--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -7,7 +7,7 @@ argument-hint: <topic>
 
 You (Claude) are about to author a new bytesize post on the topic: **$ARGUMENTS**.
 
-This command encodes a 9-phase workflow that fires every time Amartya wants a new post. Read the whole file before acting. The workflow is bounded by four user checkpoints — gate hard at each of them.
+This command encodes a 9-phase workflow that fires every time the author wants a new post. Read the whole file before acting. The workflow is bounded by four user checkpoints — gate hard at each of them.
 
 ## Hard rules (inviolable)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,22 +151,22 @@ Home splits into two columns at ≥ 768px:
 
 ```
 ┌ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ┐
-│ ┌──────────────────────────────────────────────────────────┐ │
-│ │ ■ bytesize                                    [○ theme]  │ │
-│ │                                                          │ │
-│ │                     2026                                 │ │
-│ │   bytesize          ────                                 │ │
-│ │                     [ico] how gmail knows …     apr 19   │ │
-│ │   one question              the pipeline that …    →     │ │
-│ │   per post. ten     ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌   │ │
-│ │   minutes of …      [ico]  (next post)                   │ │
-│ │                                                          │ │
-│ │  [subscribe]                                             │ │
-│ │                                                          │ │
-│ │  ⌂ github     © 2026                                     │ │
-│ │                                                          │ │
-│ │ bytesize · built by amartya           subscribe (rss)    │ │
-│ └──────────────────────────────────────────────────────────┘ │
+│ ┌──────────────────────────────────────────────────────────────┐ │
+│ │ ■ bytesize                                    [○ theme]      │ │
+│ │                                                              │ │
+│ │                     2026                                     │ │
+│ │   bytesize          ────                                     │ │
+│ │                     [ico] how gmail knows …     apr 19       │ │
+│ │   one question              the pipeline that …    →         │ │
+│ │   per post. ten     ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌       │ │
+│ │   minutes of …      [ico]  (next post)                       │ │
+│ │                                                              │ │
+│ │  [subscribe]                                                 │ │
+│ │                                                              │ │
+│ │  ⌂ github     © 2026                                         │ │
+│ │                                                              │ │
+│ │ bytesize · built by An Anonymous Engineer </> subscribe (rss) │ │
+│ └──────────────────────────────────────────────────────────────┘ │
 └ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ┘
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pnpm dev
 
 ## Author
 
-Built by [@iamartyaa](https://github.com/iamartyaa).
+Built by [An Anonymous Engineer](https://github.com/iamartyaa).
 
 ## Design
 

--- a/components/nav/AboutColumn.tsx
+++ b/components/nav/AboutColumn.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import {
   SITE_ABOUT,
-  SITE_AUTHOR,
+  SITE_AUTHOR_DISPLAY,
   SITE_AUTHOR_URL,
   SITE_NAME,
 } from "@/lib/site";
@@ -46,14 +46,7 @@ export function AboutColumn() {
           maxWidth: "26ch",
         }}
       >
-        {SITE_ABOUT}{" "}
-        <Link
-          href={SITE_AUTHOR_URL}
-          className="underline underline-offset-2 decoration-[color:var(--color-rule)] hover:decoration-[color:var(--color-accent)] hover:text-[color:var(--color-accent)] transition-colors"
-          style={{ color: "var(--color-text)" }}
-        >
-          {SITE_AUTHOR}.
-        </Link>
+        {SITE_ABOUT}
       </p>
 
       {/* Subscribe CTA — terracotta pill, primary action */}
@@ -78,7 +71,7 @@ export function AboutColumn() {
           href={SITE_AUTHOR_URL}
           target="_blank"
           rel="noopener noreferrer"
-          aria-label={`${SITE_AUTHOR} on GitHub`}
+          aria-label={`${SITE_AUTHOR_DISPLAY} on GitHub`}
           className="transition-colors hover:text-[color:var(--color-text)]"
         >
           <GitHubIcon />

--- a/components/nav/Footer.tsx
+++ b/components/nav/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { SITE_AUTHOR_DISPLAY, SITE_AUTHOR_URL } from "@/lib/site";
 
 export function Footer() {
   return (
@@ -14,13 +15,16 @@ export function Footer() {
         <span>
           bytesize · built by{" "}
           <a
-            href="https://github.com/iamartyaa"
+            href={SITE_AUTHOR_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-[color:var(--color-text)] transition-colors"
           >
-            amartya
+            {SITE_AUTHOR_DISPLAY}
           </a>
+          <span aria-hidden className="ml-[0.25em] opacity-70">
+            {"</>"}
+          </span>
         </span>
         <Link
           href="/rss.xml"

--- a/docs/voice-profile.md
+++ b/docs/voice-profile.md
@@ -1,6 +1,6 @@
 # bytesize — voice profile
 
-The reference document for how every bytesize post should *sound* and *feel*. Derived from Amartya's edits on post #1 ("How Gmail knows your email is taken, instantly") and captured here so future drafts don't drift.
+The reference document for how every bytesize post should *sound* and *feel*. Derived from the author's edits on post #1 ("How Gmail knows your email is taken, instantly") and captured here so future drafts don't drift.
 
 This doc is loaded at Phase E of the `/new-post` workflow. When any rule here conflicts with a one-off kernel.md decision, this doc wins unless the conflict is explicitly resolved at Checkpoint 2 or 3.
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -8,9 +8,13 @@ export const SITE_URL = "https://bytesize.vercel.app";
 
 export const SITE_NAME = "bytesize";
 
+/** SEO / metadata truth. Used by `app/layout.tsx` metadata.authors only. */
 export const SITE_AUTHOR = "Amartya";
 
 export const SITE_AUTHOR_URL = "https://github.com/iamartyaa";
+
+/** User-visible label. Every rendered surface (footer, nav, aria) uses this. */
+export const SITE_AUTHOR_DISPLAY = "An Anonymous Engineer";
 
 /** Meta description, RSS channel description, OG default subtitle. */
 export const SITE_DESCRIPTION =


### PR DESCRIPTION
## Summary

- Footer now reads **"bytesize · built by An Anonymous Engineer </>"** — link wraps the name, `</>` is a static muted signature (`aria-hidden`).
- Home `AboutColumn` drops the inline name from the about paragraph; GitHub icon in the bottom-left meta stays as the only owner hint (aria-label updated).
- `lib/site.ts` adds `SITE_AUTHOR_DISPLAY` for rendered surfaces; `SITE_AUTHOR` stays for SEO truth (`app/layout.tsx` metadata.authors intact).
- README, voice profile, `/new-post` command, and DESIGN.md ASCII mockup updated for voice consistency.

Search engines still get the real name via `<meta>`; only user-visible surfaces go anonymous. The github href continues to point at the real account — ownership is discoverable via a click, not advertised in text.

## Test plan

- [ ] `pnpm build` passes (verified locally)
- [ ] `rg -i amartya` only matches the `SITE_AUTHOR` constant, `SITE_AUTHOR_URL`, and the README href (verified locally)
- [ ] Vercel preview: footer on `/` and `/posts/*` renders "An Anonymous Engineer </>"; hover underlines the name only, not the glyph
- [ ] Home page AboutColumn paragraph ends cleanly at "abstractions."
- [ ] View source on `/` — `<meta>` author still resolves to the real name (SEO intact)
- [ ] Screen-reader spot check: footer link announces "An Anonymous Engineer"; AboutColumn github icon announces "An Anonymous Engineer on GitHub"
- [ ] Dark/light theme toggle — `</>` glyph legible in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)