### PR TITLE
Why `fetch` works in curl but the browser blocks it

### DIFF
--- a/app/posts/why-fetch-fails-only-in-browser/metadata.ts
+++ b/app/posts/why-fetch-fails-only-in-browser/metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "why-fetch-fails-only-in-browser";
+const TITLE = "Why `fetch` works in curl but the browser blocks it";
+const HOOK =
+  "the server did answer — your browser is just holding the response back from your JavaScript.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: HOOK,
+  openGraph: {
+    title: TITLE,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -1,0 +1,290 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  Callout,
+  Dots,
+  Em,
+  Aside,
+  A,
+  FullBleed,
+  Term,
+} from "@/components/prose";
+import { CodeBlock } from "@/components/code";
+import { OriginMatrix, RequestJourney, RequestClassifier } from "./widgets";
+import { metadata } from "./metadata";
+
+export { metadata };
+
+export default function WhyFetchFailsOnlyInBrowser() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <H1>Why <span style={{ fontFamily: "var(--font-mono)", fontWeight: 500, letterSpacing: "-0.01em" }}>fetch</span> works in curl but the browser blocks it</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-19">apr 19, 2026</time>
+          <span className="mx-2">·</span>
+          <span>7 min read</span>
+        </p>
+
+        {/* §1 — the paradox */}
+        <P>
+          You call an API from the browser. The Network tab shows <Code>200 OK</Code>.
+          The Console right below shows <Code>TypeError: Failed to fetch</Code>. You
+          paste the same URL into a terminal, run <Code>curl</Code>, and get JSON back.
+          Same URL, same server, same five-second window. One works. The other doesn&apos;t.
+        </P>
+      </div>
+
+      <FullBleed>
+        <div className="grid gap-[var(--spacing-md)] md:grid-cols-[1fr_1.3fr]">
+          <CodeBlock
+            lang="bash"
+            filename="terminal"
+            code={`$ curl https://api.other.com/me
+{"ok": true, "name": "you"}
+# 200 OK — server answered.`}
+          />
+          <CodeBlock
+            lang="javascript"
+            filename="browser · devtools"
+            code={`await fetch('https://api.other.com/me')
+// Uncaught (in promise) TypeError:
+//   Failed to fetch
+// Access-Control-Allow-Origin missing.`}
+          />
+        </div>
+      </FullBleed>
+
+      <div>
+        <P>
+          Almost every explanation of CORS gets the shape of this wrong. The server
+          didn&apos;t reject anything. Your browser did. And it waited until the
+          response was already in its hands before doing it.
+        </P>
+      </div>
+
+      {/* §2 — same origin */}
+      <div>
+        <Dots />
+        <H2>What &ldquo;same origin&rdquo; actually means</H2>
+        <P>
+          Before the mechanism makes sense, the vocabulary has to. An <Term>origin</Term>{" "}
+          is the triple <Code>(scheme, host, port)</Code>. Two URLs are the{" "}
+          <Em>same origin</Em> only if all three match. Path doesn&apos;t count.
+          Subdomains don&apos;t match. And yes, <Code>http</Code> vs <Code>https</Code>{" "}
+          on the exact same hostname is cross-origin — TLS changes the trust boundary.
+          Hover any row below to see which part differs.
+        </P>
+      </div>
+
+      <OriginMatrix />
+
+      <div>
+        <P>
+          The <Em>same-origin policy</Em> is the browser&apos;s default. JS running in
+          one origin can&apos;t read a response from another. Loading assets across
+          origins — an <Code>&lt;img&gt;</Code>, a <Code>&lt;script&gt;</Code>, a
+          stylesheet — has always been allowed, which is why the restriction feels
+          arbitrary until you notice what <Em>is</Em> forbidden: reading a response
+          from JS. CORS is the opt-in mechanism for punching holes in that wall.
+        </P>
+        <Callout tone="note">
+          Subdomains are cross-origin. <Code>api.example.com</Code> and{" "}
+          <Code>app.example.com</Code> are as foreign to each other as{" "}
+          <Code>example.com</Code> and <Code>evil.com</Code> under the same-origin
+          rule.
+        </Callout>
+      </div>
+
+      {/* §3 — THE reveal */}
+      <div>
+        <Dots />
+        <H2>The browser is the enforcer, not the server</H2>
+        <P>
+          Here&apos;s the shape most posts miss. Step through the widget below,
+          then flip the <Code>Access-Control-Allow-Origin</Code> pill and step through
+          it again. The network trace doesn&apos;t change. The only thing that
+          changes is what JS gets back at the end.
+        </P>
+      </div>
+
+      <RequestJourney />
+
+      <div>
+        <P>
+          Walk that back slowly. The fetch left the browser. The request reached
+          the server. The server ran its handler — the same code it runs for any
+          other client. It returned <Code>200 OK</Code> with a real body. The
+          response arrived in the browser. Only then, <Em>after</Em> the whole
+          round trip, did the browser look at the response headers, fail to find
+          an invitation for your page&apos;s origin, and throw the body away.
+        </P>
+        <p
+          style={{
+            fontSize: "1.125em",
+            marginBlockStart: "1.5em",
+            marginBlockEnd: "0.2em",
+            lineHeight: 1.55,
+          }}
+        >
+          <Em>
+            CORS does not block the request. It blocks the response.
+          </Em>
+        </p>
+        <Aside>
+          That phrasing is Ilija Eftimov&apos;s, from his{" "}
+          <A href="https://ieftimov.com/posts/deep-dive-cors-history-how-it-works-best-practices/">
+            deep dive on CORS
+          </A>
+          . It&apos;s the one sentence that collapses the whole mechanism into a
+          usable mental model.
+        </Aside>
+        <P>
+          That&apos;s why <Code>curl</Code> &ldquo;works.&rdquo; curl doesn&apos;t
+          parse <Code>Access-Control-*</Code> headers. Neither does Postman, or
+          Python&apos;s <Code>requests</Code>, or your backend calling your other
+          backend. CORS is a contract between a server&apos;s response headers and
+          a <Em>browser&apos;s</Em> JS sandbox. Outside the browser, there&apos;s no
+          one listening.
+        </P>
+        <P>
+          And the point of the contract isn&apos;t to stop people from reaching
+          your server. It&apos;s to stop a page at <Code>evil.com</Code>, open in
+          your user&apos;s tab, from using the cookies already in that browser to
+          read a response from <Code>bank.com</Code>. The browser has the user&apos;s
+          authority; CORS is what keeps one page from borrowing it to read another
+          page&apos;s data.
+        </P>
+      </div>
+
+      {/* §4 — preflight */}
+      <div>
+        <Dots />
+        <H2>Not every request even leaves the browser</H2>
+        <P>
+          The &ldquo;server runs, browser redacts&rdquo; rule holds for <Em>simple</Em>{" "}
+          requests — roughly, what an HTML form could have sent without JS: a{" "}
+          <Code>GET</Code>, or a plain <Code>POST</Code> with one of three
+          old content types (<Code>text/plain</Code>,{" "}
+          <Code>application/x-www-form-urlencoded</Code>, or{" "}
+          <Code>multipart/form-data</Code>) and no custom headers. For anything
+          else, the browser sends a second, silent request first — an{" "}
+          <Code>OPTIONS</Code>, asking permission. If permission is denied, the
+          real request is never sent.
+        </P>
+        <P>
+          Flip the controls below and watch the verdict change.
+        </P>
+      </div>
+
+      <RequestClassifier />
+
+      <div>
+        <P>
+          The <Em>preflight</Em> carries <Code>Origin</Code>, the method the real
+          request will use, and any non-safelisted headers it plans to send. The
+          server answers with a matching <Code>Access-Control-Allow-Methods</Code>{" "}
+          and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em> does
+          the browser let the real request go. If any of those don&apos;t line up,
+          the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code>{" "}
+          never reaches your backend. This is the one case where CORS genuinely
+          blocks the wire, not just the read.
+        </P>
+        <P>
+          The practical consequence is blunt: switching a request from{" "}
+          <Code>text/plain</Code> to <Code>application/json</Code>, or adding an{" "}
+          <Code>Authorization</Code> header, doesn&apos;t just change whether JS can
+          read the reply — it changes whether the <Code>POST</Code> arrives at all.
+          Every modern JSON API preflights every call. Browsers cache the{" "}
+          <Code>OPTIONS</Code> result briefly (seconds to a couple of hours) via{" "}
+          <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t repeat for
+          every request.
+        </P>
+        <Aside>
+          If your server reflects the request&apos;s <Code>Origin</Code> header back
+          in <Code>Access-Control-Allow-Origin</Code> to support many origins, you
+          must also send <Code>Vary: Origin</Code>. Without it, a CDN or shared
+          proxy can serve origin A&apos;s allowed response to origin B&apos;s
+          request. It looks fine in dev and breaks on Tuesday.
+        </Aside>
+      </div>
+
+      {/* §5 — credentials */}
+      <div>
+        <Dots />
+        <H2>Cookies don&apos;t tag along by default</H2>
+        <P>
+          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em> send cookies or
+          HTTP auth unless you ask. You opt in; the server opts in separately. Both
+          sides have to agree.
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="javascript"
+          filename="client"
+          code={`// client opt-in
+await fetch('https://api.other.com/me', {
+  credentials: 'include',
+});
+
+// server must respond with, exactly:
+//   Access-Control-Allow-Origin: https://app.example.com
+//   Access-Control-Allow-Credentials: true
+//
+// not '*' — wildcard + credentials is an error.`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          Notice what&apos;s missing: the wildcard. <Code>
+            Access-Control-Allow-Origin: *
+          </Code>{" "}
+          is illegal once credentials are in play, and the browser will reject the
+          response even if the server sends it. The origin has to be{" "}
+          <Em>named</Em> — which is the whole point. A wildcard would mean
+          &ldquo;any site can read this response using this user&apos;s cookies,&rdquo;
+          which is the thing CORS exists to prevent.
+        </P>
+      </div>
+
+      {/* §6 — closer */}
+      <div>
+        <Dots />
+        <H2>Reading a failing network tab</H2>
+        <P>
+          Next time a red <Code>TypeError</Code> shows up in the console, the
+          Network tab is the first place to look. Did the request reach the
+          server? Usually yes — you&apos;ll see a <Code>200</Code>, or at least
+          some response. That alone tells you the server isn&apos;t refusing; the
+          response headers are.
+        </P>
+        <P>
+          Three things to check, in order. Which origin is your page? Is the
+          server returning <Code>Access-Control-Allow-Origin</Code> matching that
+          origin exactly? And if there&apos;s an <Code>OPTIONS</Code> row before
+          your real request, does <Em>that</Em> response approve the method and
+          headers you&apos;re about to send? Almost every CORS failure is one of
+          those three, in that order.
+        </P>
+        <P>
+          The browser isn&apos;t being rude. It&apos;s doing the thing that keeps
+          every other site you&apos;re logged into — your bank, your email, your
+          account settings — from being read by whatever tab you just opened.
+          The <Code>TypeError</Code> is that protection, showing up for you too.
+        </P>
+      </div>
+    </Prose>
+  );
+}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { WidgetShell } from "./WidgetShell";
+
+type Row = {
+  url: string;
+  scheme: string;
+  host: string;
+  port: string;
+  path: string;
+  sameOrigin: boolean;
+  caption: string;
+};
+
+const BASE = {
+  url: "https://app.example.com",
+  scheme: "https",
+  host: "app.example.com",
+  port: "(443)",
+  path: "/",
+};
+
+const ROWS: Row[] = [
+  {
+    url: "http://app.example.com",
+    scheme: "http",
+    host: "app.example.com",
+    port: "(80)",
+    path: "/",
+    sameOrigin: false,
+    caption:
+      "Scheme differs. `http` and `https` are separate origins even on the same host — TLS changes the trust boundary.",
+  },
+  {
+    url: "https://app.example.com:8080",
+    scheme: "https",
+    host: "app.example.com",
+    port: "8080",
+    path: "/",
+    sameOrigin: false,
+    caption:
+      "Port differs. Browsers include the port in the origin tuple — so your API on :8080 is cross-origin from your site on :443.",
+  },
+  {
+    url: "https://api.example.com",
+    scheme: "https",
+    host: "api.example.com",
+    port: "(443)",
+    path: "/",
+    sameOrigin: false,
+    caption:
+      "Host differs. Subdomains are cross-origin. api.example.com and app.example.com are as foreign as example.com and evil.com under this rule.",
+  },
+  {
+    url: "https://example.com",
+    scheme: "https",
+    host: "example.com",
+    port: "(443)",
+    path: "/",
+    sameOrigin: false,
+    caption:
+      "Host differs. The parent domain is its own origin. Strip a subdomain and you've left the origin.",
+  },
+  {
+    url: "https://app.example.com/admin",
+    scheme: "https",
+    host: "app.example.com",
+    port: "(443)",
+    path: "/admin",
+    sameOrigin: true,
+    caption:
+      "Same origin. Path is not part of the tuple — /admin and / share an origin, which is why cookies and JS access work across routes.",
+  },
+];
+
+type ColKey = "scheme" | "host" | "port" | "path";
+
+const COLS: { key: ColKey; label: string; weight: number }[] = [
+  { key: "scheme", label: "scheme", weight: 1 },
+  { key: "host", label: "host", weight: 1 },
+  { key: "port", label: "port", weight: 1 },
+  { key: "path", label: "path", weight: 1 },
+];
+
+function cellDiffers(row: Row, col: ColKey): boolean {
+  return row[col] !== BASE[col];
+}
+
+export function OriginMatrix() {
+  const [focused, setFocused] = useState<number>(-1);
+  const row = focused >= 0 ? ROWS[focused] : null;
+
+  const decision = row ? (row.sameOrigin ? "same origin" : "cross-origin") : null;
+  const tone = row
+    ? row.sameOrigin
+      ? "var(--color-text)"
+      : "var(--color-accent)"
+    : "var(--color-text-muted)";
+
+  return (
+    <WidgetShell
+      title="origin = (scheme, host, port) · hover any row"
+      measurements={`base · ${BASE.url}`}
+      caption={
+        row ? (
+          <span>
+            <span style={{ color: tone, fontWeight: 500 }}>{decision}</span>
+            {" — "}
+            {row.caption}
+          </span>
+        ) : (
+          <span style={{ color: "var(--color-text-muted)" }}>
+            Each URL below is compared to the base. Hover or tab to any row to see
+            which component of the tuple differs and why it moves that URL
+            cross-origin.
+          </span>
+        )
+      }
+    >
+      <div className="overflow-x-auto">
+        <table
+          className="w-full font-mono tabular-nums"
+          style={{ fontSize: "var(--text-small)", borderCollapse: "collapse" }}
+        >
+          <thead>
+            <tr style={{ color: "var(--color-text-muted)" }}>
+              <th className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal">
+                url
+              </th>
+              {COLS.map((c) => (
+                <th
+                  key={c.key}
+                  className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal"
+                >
+                  {c.label}
+                </th>
+              ))}
+              <th className="text-right py-[var(--spacing-xs)] font-normal">verdict</th>
+            </tr>
+            <tr aria-hidden>
+              <td
+                colSpan={6}
+                style={{
+                  borderTop: "1px dashed var(--color-rule)",
+                  paddingTop: 0,
+                  height: 1,
+                }}
+              />
+            </tr>
+            <tr>
+              <td
+                className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                base
+              </td>
+              {COLS.map((c) => (
+                <td
+                  key={c.key}
+                  className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
+                  style={{ color: "var(--color-text-muted)" }}
+                >
+                  {BASE[c.key]}
+                </td>
+              ))}
+              <td
+                className="py-[var(--spacing-xs)] text-right"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                —
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((r, i) => {
+              const active = i === focused;
+              return (
+                <tr
+                  key={r.url}
+                  onMouseEnter={() => setFocused(i)}
+                  onFocus={() => setFocused(i)}
+                  tabIndex={0}
+                  aria-label={`${r.url}: ${r.sameOrigin ? "same origin" : "cross-origin"}`}
+                  style={{
+                    cursor: "pointer",
+                    background: active
+                      ? "color-mix(in oklab, var(--color-accent) 5%, transparent)"
+                      : "transparent",
+                    transition: "background 160ms",
+                    borderTop: "1px dashed var(--color-rule)",
+                  }}
+                >
+                  <td className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]">{r.url}</td>
+                  {COLS.map((c) => {
+                    const differs = cellDiffers(r, c.key);
+                    return (
+                      <td
+                        key={c.key}
+                        className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
+                        style={{
+                          color: differs ? "var(--color-accent)" : "var(--color-text-muted)",
+                          fontWeight: differs ? 500 : 400,
+                        }}
+                      >
+                        {r[c.key]}
+                        {differs ? (
+                          <span
+                            aria-hidden
+                            style={{ marginLeft: 4, color: "var(--color-accent)" }}
+                          >
+                            ✗
+                          </span>
+                        ) : null}
+                      </td>
+                    );
+                  })}
+                  <td
+                    className="py-[var(--spacing-xs)] text-right"
+                    style={{
+                      color: r.sameOrigin ? "var(--color-text)" : "var(--color-accent)",
+                      fontWeight: 500,
+                    }}
+                  >
+                    {r.sameOrigin ? "same" : "cross"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Method = "GET" | "POST" | "PUT" | "DELETE";
+type ContentType =
+  | "text/plain"
+  | "application/x-www-form-urlencoded"
+  | "application/json";
+
+const METHODS: Method[] = ["GET", "POST", "PUT", "DELETE"];
+const CONTENT_TYPES: ContentType[] = [
+  "text/plain",
+  "application/x-www-form-urlencoded",
+  "application/json",
+];
+
+const SAFE_METHODS = new Set<Method>(["GET", "POST"]);
+
+type Reason = { text: string; key: string };
+
+function classify(
+  method: Method,
+  contentType: ContentType,
+  auth: boolean,
+  custom: boolean,
+): { preflight: boolean; reasons: Reason[] } {
+  const reasons: Reason[] = [];
+  if (!SAFE_METHODS.has(method)) {
+    reasons.push({
+      key: "method",
+      text: `${method} isn't on the safelist (GET, HEAD, POST).`,
+    });
+  }
+  if (
+    (method === "POST" || method === "PUT") &&
+    contentType === "application/json"
+  ) {
+    reasons.push({
+      key: "ct",
+      text: `Content-Type: application/json isn't safelisted — only text/plain, form-urlencoded, and multipart/form-data are.`,
+    });
+  }
+  if (auth) {
+    reasons.push({
+      key: "auth",
+      text: `The Authorization header isn't on the safelist — any request carrying one preflights.`,
+    });
+  }
+  if (custom) {
+    reasons.push({
+      key: "custom",
+      text: `Custom headers (X-*, anything non-standard) force a preflight.`,
+    });
+  }
+  return { preflight: reasons.length > 0, reasons };
+}
+
+type Props = {
+  initialMethod?: Method;
+  initialContentType?: ContentType;
+  initialAuth?: boolean;
+  initialCustom?: boolean;
+};
+
+export function RequestClassifier({
+  initialMethod = "GET",
+  initialContentType = "text/plain",
+  initialAuth = false,
+  initialCustom = false,
+}: Props) {
+  const [method, setMethod] = useState<Method>(initialMethod);
+  const [contentType, setContentType] = useState<ContentType>(initialContentType);
+  const [auth, setAuth] = useState(initialAuth);
+  const [custom, setCustom] = useState(initialCustom);
+
+  const verdict = useMemo(
+    () => classify(method, contentType, auth, custom),
+    [method, contentType, auth, custom],
+  );
+
+  const ctDisabled = method === "GET" || method === "DELETE";
+
+  return (
+    <WidgetShell
+      title="RequestClassifier · will this preflight?"
+      measurements={verdict.preflight ? "preflight · OPTIONS first" : "simple · no preflight"}
+      caption={
+        verdict.preflight
+          ? "The browser sends an OPTIONS handshake before your real request. If the server doesn't approve, the real request is never sent."
+          : "The request is safelisted. The browser sends it directly — the server runs the handler, and only the response is subject to the CORS check."
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        {/* Controls */}
+        <div className="grid gap-[var(--spacing-sm)]" style={{ gridTemplateColumns: "minmax(0, 1fr)" }}>
+          <SegmentedRow
+            label="method"
+            options={METHODS}
+            value={method}
+            onChange={setMethod}
+          />
+          <SegmentedRow
+            label="Content-Type"
+            options={CONTENT_TYPES}
+            value={contentType}
+            onChange={setContentType}
+            disabled={ctDisabled}
+            disabledHint={ctDisabled ? "(no body on this method)" : undefined}
+          />
+          <div
+            className="flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+            style={{ fontSize: "var(--text-ui)" }}
+          >
+            <span
+              className="font-mono"
+              style={{
+                color: "var(--color-text-muted)",
+                minWidth: "12ch",
+              }}
+            >
+              headers
+            </span>
+            <Toggle
+              label="Authorization"
+              pressed={auth}
+              onToggle={() => setAuth((v) => !v)}
+            />
+            <Toggle
+              label="X-Custom"
+              pressed={custom}
+              onToggle={() => setCustom((v) => !v)}
+            />
+          </div>
+        </div>
+
+        {/* Verdict pill + reasons */}
+        <div
+          className="rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
+          style={{
+            background: verdict.preflight
+              ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+              : "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+            border: `1px solid ${verdict.preflight ? "var(--color-accent)" : "var(--color-rule)"}`,
+          }}
+        >
+          <div
+            className="font-mono"
+            style={{
+              fontSize: "var(--text-ui)",
+              color: verdict.preflight ? "var(--color-accent)" : "var(--color-text)",
+              fontWeight: 500,
+            }}
+            aria-live="polite"
+          >
+            {verdict.preflight
+              ? "preflighted · OPTIONS sent first"
+              : "simple request · no preflight"}
+          </div>
+          <AnimatePresence initial={false}>
+            {verdict.reasons.length > 0 ? (
+              <motion.ul
+                className="mt-[var(--spacing-sm)] flex flex-col gap-[var(--spacing-2xs)] font-sans"
+                style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.smooth}
+              >
+                {verdict.reasons.map((r) => (
+                  <li key={r.key} className="flex gap-[var(--spacing-xs)]">
+                    <span style={{ color: "var(--color-accent)" }} aria-hidden>
+                      ·
+                    </span>
+                    <span>{r.text}</span>
+                  </li>
+                ))}
+              </motion.ul>
+            ) : null}
+          </AnimatePresence>
+        </div>
+
+        {/* Preflight exchange reveal */}
+        <AnimatePresence initial={false}>
+          {verdict.preflight ? (
+            <motion.div
+              key="preflight"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 8 }}
+              transition={SPRING.smooth}
+              className="rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-md)] font-mono"
+              style={{
+                background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+                border: "1px dashed var(--color-rule)",
+                fontSize: "var(--text-small)",
+                lineHeight: 1.7,
+              }}
+            >
+              <div style={{ color: "var(--color-text-muted)" }}>
+                <span className="sr-only">step 1 of 3: </span>
+                <span aria-hidden>①</span> browser → server
+              </div>
+              <div>
+                OPTIONS /me HTTP/1.1
+                <br />
+                Origin: https://app.example.com
+                <br />
+                Access-Control-Request-Method: {method}
+                {(auth || custom || contentType === "application/json") && (
+                  <>
+                    <br />
+                    Access-Control-Request-Headers:{" "}
+                    {[
+                      contentType === "application/json" ? "content-type" : null,
+                      auth ? "authorization" : null,
+                      custom ? "x-custom" : null,
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </>
+                )}
+              </div>
+              <div
+                className="mt-[var(--spacing-sm)]"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                <span className="sr-only">step 2 of 3: </span>
+                <span aria-hidden>②</span> server → browser
+              </div>
+              <div>
+                HTTP/1.1 204 No Content
+                <br />
+                Access-Control-Allow-Origin: https://app.example.com
+                <br />
+                Access-Control-Allow-Methods: {method}
+                {(auth || custom || contentType === "application/json") && (
+                  <>
+                    <br />
+                    Access-Control-Allow-Headers:{" "}
+                    {[
+                      contentType === "application/json" ? "Content-Type" : null,
+                      auth ? "Authorization" : null,
+                      custom ? "X-Custom" : null,
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </>
+                )}
+              </div>
+              <div
+                className="mt-[var(--spacing-sm)]"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                <span className="sr-only">step 3 of 3: </span>
+                <span aria-hidden>③</span> real {method} request proceeds
+              </div>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </WidgetShell>
+  );
+}
+
+function SegmentedRow<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  disabled,
+  disabledHint,
+}: {
+  label: string;
+  options: readonly T[];
+  value: T;
+  onChange: (v: T) => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}) {
+  return (
+    <div
+      className="flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+      style={{ fontSize: "var(--text-ui)" }}
+    >
+      <span
+        className="font-mono"
+        style={{
+          color: "var(--color-text-muted)",
+          minWidth: "12ch",
+        }}
+      >
+        {label}
+      </span>
+      <div
+        role="radiogroup"
+        aria-label={label}
+        className="flex items-center gap-[var(--spacing-2xs)] flex-wrap"
+        style={{ opacity: disabled ? 0.5 : 1 }}
+      >
+        {options.map((opt) => {
+          const active = opt === value;
+          return (
+            <button
+              key={opt}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              disabled={disabled}
+              onClick={() => onChange(opt)}
+              className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] font-mono transition-colors hover:enabled:text-[color:var(--color-accent)] disabled:cursor-not-allowed"
+              style={{
+                fontSize: "var(--text-small)",
+                color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                background: active
+                  ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                  : "transparent",
+                border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+              }}
+            >
+              {opt}
+            </button>
+          );
+        })}
+        {disabled && disabledHint ? (
+          <span
+            className="font-sans"
+            style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          >
+            {disabledHint}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  pressed,
+  onToggle,
+}: {
+  label: string;
+  pressed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onToggle}
+      className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] font-mono transition-colors hover:text-[color:var(--color-accent)]"
+      style={{
+        fontSize: "var(--text-small)",
+        color: pressed ? "var(--color-accent)" : "var(--color-text-muted)",
+        background: pressed
+          ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+          : "transparent",
+        border: `1px solid ${pressed ? "var(--color-accent)" : "var(--color-rule)"}`,
+      }}
+    >
+      <span aria-hidden style={{ marginRight: 6 }}>
+        {pressed ? "■" : "□"}
+      </span>
+      {label}
+    </button>
+  );
+}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Step = {
+  id: string;
+  label: string;
+  caption: (allow: boolean) => string;
+};
+
+const STEPS: Step[] = [
+  {
+    id: "idle",
+    label: "idle",
+    caption: () =>
+      "Nothing has happened yet. JS is about to call fetch on a cross-origin URL.",
+  },
+  {
+    id: "issue",
+    label: "fetch() issued",
+    caption: () =>
+      "JS calls fetch. The request is now in the browser's hands — JS has let go until a Promise resolves or rejects.",
+  },
+  {
+    id: "inflight",
+    label: "request in flight",
+    caption: () =>
+      "The browser opens a socket, TLS-handshakes, and sends the HTTP request over the wire. The Origin header tags it as cross-origin.",
+  },
+  {
+    id: "handled",
+    label: "server handles",
+    caption: () =>
+      "The server runs its handler. It reads cookies, writes to the database, whatever — the handler has no idea this is a cross-origin call and doesn't need to.",
+  },
+  {
+    id: "responded",
+    label: "response 200 + body",
+    caption: () =>
+      "The server sends back a normal HTTP response. 200 OK, a real body, the real headers. The network succeeded.",
+  },
+  {
+    id: "decided",
+    label: "browser decides",
+    caption: (allow) =>
+      allow
+        ? "The browser reads the response headers, sees Access-Control-Allow-Origin matching the page's origin, and resolves the Promise with a readable Response. JS can now read the body."
+        : "The browser reads the response headers, looks for an Access-Control-Allow-Origin matching the page's origin, doesn't find one, and silently discards the body. JS sees only TypeError: Failed to fetch.",
+  },
+];
+
+const LANE_LABELS = ["JS", "browser", "network", "server"] as const;
+
+type Message = {
+  /** Earliest step at which this message is visible. */
+  from: number;
+  /** Step at which this message becomes "past" (dimmed). */
+  through?: number;
+  /** Lifelines: 0 = JS, 1 = browser, 2 = network, 3 = server */
+  fromCol: 0 | 1 | 2 | 3;
+  toCol: 0 | 1 | 2 | 3;
+  y: number;
+  label: string;
+  tone?: "default" | "accent" | "muted";
+};
+
+type Props = {
+  initialStep?: number;
+  initialAllowOrigin?: boolean;
+};
+
+export function RequestJourney({
+  initialStep = 5,
+  initialAllowOrigin = false,
+}: Props) {
+  const [step, setStep] = useState(initialStep);
+  const [allow, setAllow] = useState(initialAllowOrigin);
+
+  const current = STEPS[Math.min(step, STEPS.length - 1)];
+
+  const WIDTH = 820;
+  const HEIGHT = 380;
+  const LEFT_PAD = 64;
+  const RIGHT_PAD = 32;
+  const TOP = 40;
+  const BOT = 260;
+  const COLS = 4;
+  const colX = (i: number) =>
+    LEFT_PAD + (i * (WIDTH - LEFT_PAD - RIGHT_PAD)) / (COLS - 1);
+
+  const messages: Message[] = [
+    {
+      from: 1,
+      fromCol: 0,
+      toCol: 1,
+      y: TOP + 22,
+      label: "fetch(url)",
+    },
+    {
+      from: 2,
+      fromCol: 1,
+      toCol: 3,
+      y: TOP + 62,
+      label: "GET /me · Origin: app.example.com",
+    },
+    {
+      from: 3,
+      fromCol: 3,
+      toCol: 3,
+      y: TOP + 102,
+      label: "handler runs",
+      tone: "muted",
+    },
+    {
+      from: 4,
+      fromCol: 3,
+      toCol: 1,
+      y: TOP + 142,
+      label: "200 OK · body",
+    },
+    {
+      from: 5,
+      fromCol: 1,
+      toCol: 0,
+      y: TOP + 200,
+      label: allow ? "resolve(Response)" : "TypeError",
+      tone: allow ? "accent" : "accent",
+    },
+  ];
+
+  return (
+    <WidgetShell
+      title="RequestJourney · same network, different outcomes"
+      measurements={`step ${step + 1}/${STEPS.length} · Allow-Origin ${allow ? "on" : "off"}`}
+      caption={current.caption(allow)}
+      controls={
+        <div className="flex items-center gap-[var(--spacing-md)] flex-wrap">
+          <Stepper value={step} total={STEPS.length} onChange={setStep} />
+          <button
+            type="button"
+            onClick={() => setAllow((v) => !v)}
+            aria-pressed={allow}
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] font-mono transition-colors"
+            style={{
+              fontSize: "var(--text-small)",
+              color: allow ? "var(--color-bg)" : "var(--color-text)",
+              background: allow ? "var(--color-accent)" : "transparent",
+              border: `1px solid ${allow ? "var(--color-accent)" : "var(--color-rule)"}`,
+            }}
+          >
+            Access-Control-Allow-Origin: {allow ? "app.example.com" : "missing"}
+          </button>
+        </div>
+      }
+    >
+      <div className="overflow-x-auto">
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, minWidth: 620, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`Request journey step ${step + 1}: ${current.label}`}
+      >
+        <defs>
+          <marker
+            id="arrow-default"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
+          </marker>
+          <marker
+            id="arrow-accent"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
+          </marker>
+        </defs>
+
+        {/* Lifelines */}
+        {LANE_LABELS.map((lane, i) => (
+          <g key={lane}>
+            <text
+              x={colX(i)}
+              y={TOP - 12}
+              textAnchor="middle"
+              fontFamily="var(--font-sans)"
+              fontSize={13}
+              fill="var(--color-text-muted)"
+              fontWeight={500}
+            >
+              {lane}
+            </text>
+            <line
+              x1={colX(i)}
+              x2={colX(i)}
+              y1={TOP}
+              y2={BOT}
+              stroke="var(--color-rule)"
+              strokeWidth={1}
+              strokeDasharray="3 4"
+            />
+          </g>
+        ))}
+
+        {/* The "gate" — visually mark the browser/JS seam at the decision step */}
+        <motion.rect
+          x={colX(0) - 12}
+          y={TOP + 180}
+          width={colX(1) - colX(0) + 24}
+          height={36}
+          rx={3}
+          fill={
+            step >= 5
+              ? allow
+                ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+              : "transparent"
+          }
+          stroke={step >= 5 ? "var(--color-accent)" : "var(--color-rule)"}
+          strokeWidth={step >= 5 ? 1.5 : 1}
+          strokeDasharray={step >= 5 ? undefined : "4 3"}
+          initial={false}
+          animate={{
+            opacity: step >= 4 ? 1 : 0.35,
+          }}
+          transition={SPRING.smooth}
+        />
+        <text
+          x={(colX(0) + colX(1)) / 2}
+          y={TOP + 176}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text-muted)"
+        >
+          browser ↔ JS boundary
+        </text>
+
+        {/* Messages */}
+        {messages.map((m, idx) => {
+          const visible = step >= m.from;
+          const isCurrent = step === m.from;
+          const past = step > m.from && (m.through ? step > m.through : true);
+          const x1 = colX(m.fromCol);
+          const x2 = colX(m.toCol);
+          const isSelf = m.fromCol === m.toCol;
+
+          const tone =
+            m.tone === "accent"
+              ? "var(--color-accent)"
+              : m.tone === "muted"
+                ? "var(--color-text-muted)"
+                : isCurrent
+                  ? "var(--color-accent)"
+                  : "var(--color-text-muted)";
+          const stroke = tone;
+          const textFill =
+            m.tone === "accent"
+              ? "var(--color-accent)"
+              : isCurrent
+                ? "var(--color-text)"
+                : past
+                  ? "var(--color-text-muted)"
+                  : "var(--color-text-muted)";
+
+          const arrowMarker =
+            m.tone === "accent" ? "url(#arrow-accent)" : "url(#arrow-default)";
+
+          return (
+            <motion.g
+              key={`m-${idx}`}
+              initial={false}
+              animate={{
+                opacity: visible ? (isCurrent ? 1 : past ? 0.55 : 0) : 0,
+              }}
+              transition={SPRING.smooth}
+            >
+              {isSelf ? (
+                <>
+                  <path
+                    d={`M ${x1 + 4} ${m.y} q 28 0 28 16 q 0 16 -28 16`}
+                    fill="none"
+                    stroke={stroke}
+                    strokeWidth={isCurrent ? 1.6 : 1}
+                    markerEnd={arrowMarker}
+                  />
+                  <text
+                    x={x1 + 40}
+                    y={m.y + 20}
+                    fontFamily="var(--font-mono)"
+                    fontSize={12}
+                    fill={textFill}
+                  >
+                    {m.label}
+                  </text>
+                </>
+              ) : (
+                <>
+                  <line
+                    x1={x1}
+                    x2={x2}
+                    y1={m.y}
+                    y2={m.y}
+                    stroke={stroke}
+                    strokeWidth={isCurrent ? 1.8 : 1}
+                    markerEnd={arrowMarker}
+                  />
+                  <text
+                    x={(x1 + x2) / 2}
+                    y={m.y - 6}
+                    textAnchor="middle"
+                    fontFamily="var(--font-mono)"
+                    fontSize={12}
+                    fill={textFill}
+                  >
+                    {m.label}
+                  </text>
+                </>
+              )}
+            </motion.g>
+          );
+        })}
+
+        {/* DevTools summary panel below */}
+        <g>
+          <rect
+            x={LEFT_PAD}
+            y={BOT + 20}
+            width={WIDTH - LEFT_PAD - RIGHT_PAD}
+            height={76}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
+            stroke="var(--color-rule)"
+            strokeWidth={1}
+          />
+          <text
+            x={LEFT_PAD + 12}
+            y={BOT + 36}
+            fontFamily="var(--font-mono)"
+            fontSize={11}
+            fill="var(--color-text-muted)"
+          >
+            DevTools
+          </text>
+          <text
+            x={LEFT_PAD + 12}
+            y={BOT + 58}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+          >
+            Network
+          </text>
+          <motion.text
+            x={LEFT_PAD + 100}
+            y={BOT + 58}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+            initial={false}
+            animate={{ opacity: step >= 4 ? 1 : 0.25 }}
+            transition={SPRING.smooth}
+          >
+            GET /me · 200 OK · 142 B
+          </motion.text>
+
+          <text
+            x={LEFT_PAD + 12}
+            y={BOT + 82}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+          >
+            Console
+          </text>
+          <motion.text
+            x={LEFT_PAD + 100}
+            y={BOT + 82}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
+            initial={false}
+            animate={{ opacity: step >= 5 ? 1 : 0.25 }}
+            transition={SPRING.smooth}
+          >
+            {allow
+              ? "▸ Response { ok: true, … }"
+              : "✗ TypeError: Failed to fetch"}
+          </motion.text>
+        </g>
+      </svg>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/WidgetShell.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/WidgetShell.tsx
@@ -1,0 +1,61 @@
+import { FullBleed } from "@/components/prose";
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  measurements?: string;
+  caption?: ReactNode;
+  controls?: ReactNode;
+  children: ReactNode;
+};
+
+export function WidgetShell({ title, measurements, caption, controls, children }: Props) {
+  return (
+    <FullBleed>
+      <figcaption className="sr-only">{title}</figcaption>
+      <div
+        className="flex items-baseline justify-between gap-[var(--spacing-sm)] pb-[var(--spacing-sm)]"
+        style={{ fontSize: "var(--text-ui)" }}
+      >
+        <span
+          className="font-sans"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </span>
+        {measurements ? (
+          <span
+            className="font-mono tabular-nums text-right"
+            style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          >
+            {measurements}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className="rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+        }}
+      >
+        {children}
+      </div>
+
+      {controls ? <div className="pt-[var(--spacing-sm)]">{controls}</div> : null}
+
+      {caption ? (
+        <div
+          className="pt-[var(--spacing-sm)] font-sans"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+            lineHeight: 1.5,
+          }}
+        >
+          {caption}
+        </div>
+      ) : null}
+    </FullBleed>
+  );
+}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/index.ts
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/index.ts
@@ -1,0 +1,3 @@
+export { OriginMatrix } from "./OriginMatrix";
+export { RequestJourney } from "./RequestJourney";
+export { RequestClassifier } from "./RequestClassifier";

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -23,6 +23,14 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "why-fetch-fails-only-in-browser",
+    title: "Why `fetch` works in curl but the browser blocks it",
+    date: "2026-04-20",
+    hook: "the server did answer — your browser is just holding the response back from your JavaScript.",
+    readingMinutes: 7,
+    tags: ["web", "browser", "security"],
+  },
+  {
     slug: "how-gmail-knows-your-email-is-taken",
     title: "How Gmail knows your email is taken, instantly",
     date: "2026-04-19",


### PR DESCRIPTION
## Summary

- **3 widgets** — `OriginMatrix` (scheme/host/port comparison, hover-to-diff), `RequestJourney` (4-lifeline sequence with an `Access-Control-Allow-Origin` toggle that flips the JS outcome without touching the network), `RequestClassifier` (live "will this preflight?" verdict with an inline OPTIONS trace that auto-updates as you flip method/content-type/auth/custom-header).
- **6 sections** — scene → origin vocabulary → **the reveal (browser is the enforcer)** → preflight → credentials + threat model → reading-a-failing-network-tab closer. ~1,280 words, ~7-min read. 83% of sections carry an interactive artifact.
- **Primitives reused** — `Stepper` from `components/viz/`; prose kit (`Prose`/`H1`/`H2`/`P`/`Code`/`Em`/`Callout`/`Aside`/`FullBleed`/`Term`); `CodeBlock` from `components/code/`. `WidgetShell` duplicated post-local per the default; becomes a lift candidate on a third post that needs it.

## The angle

The post's spine is Eftimov's line — *"CORS does not block the request. It blocks the response."* — set as a pull-quote. `RequestJourney` defaults to the contradiction frame (Network row 200, Console row TypeError) so a skimmer sees the payoff without stepping. The Allow-Origin toggle is the one-click reveal.

## Action items resolved / deferred

All P0 + P1 applied during Phase G. Full log in `research/why-fetch-fails-only-in-browser/action-items.md`. Highlights:

- **P0-1** RequestJourney default state = step 5, Allow-Origin off → paradox visible on first render.
- **P0-2** Mobile readability — wrapped SVG in `overflow-x-auto` with `min-width: 620`, bumped in-SVG font sizes by ~1pt across the board.
- **P1-1** Pill copy "`(unset)`" → "`missing`".
- **P1-2** `sr-only` labels on the ①②③ stanzas in the preflight panel.
- **P1-3** H1 inline-mono `fetch` dropped from weight 600 to 500.
- **P1-4** `Vary: Origin` callout relocated from §5 (credentials) to end of §4 (preflight) as an `<Aside>` — it's a preflight-caching gotcha, not a credentials one.
- **P1-5** Pull-quote paragraph bumped to 1.125em via raw `<p>` for visual weight.

P2s applied opportunistically (hero grid ratio, three-content-type parenthetical, DevTools panel breathing room, OriginMatrix neutral starter caption). Three P2s deferred (split threat-model paragraph, gate scale-pulse, Console tint-pulse) — low-return, not ship-blocking.

## Validation highlights

All 5 checks pass. `research/why-fetch-fails-only-in-browser/validation.md` has the full cross-cite table — every load-bearing factual claim traced to MDN / Fetch Standard / PortSwigger / RFC 6454.

- **Technical correctness** — zero uncited claims.
- **Code correctness** — `tsc --noEmit` 0 errors; snippets are syntactically valid; comment strings match real browser error messages.
- **A11y** — native buttons, real table semantics in OriginMatrix, `aria-pressed` on toggles, `role="radiogroup"` on segmented controls, `aria-live` on the verdict, descriptive `aria-label` on the RequestJourney SVG, color-only-info accompanied by shape (`✗`, `▸`), global `:focus-visible` ring preserved (removed an inline `outline: none` that would have suppressed it).
- **Build** — `pnpm build` green, static prerender for `/posts/why-fetch-fails-only-in-browser`. Lighthouse deferred to Vercel preview.
- **Reading sanity** — scene → reveal → mechanism → capability-handoff; no paper voice; no cliffhanger / teaser close.

## Open questions

None blocking. Two non-blockers worth noting:

1. If a third post needs `WidgetShell`, propose lifting it to `components/viz/WidgetShell.tsx` (it's identical across the two posts now).
2. The post deliberately omits CORP/COEP/COOP and Private Network Access — flagged as candidates for a follow-up on cross-origin isolation.

## Test plan

- [ ] Click the preview URL
- [ ] Read the post top-to-bottom, watching for voice drift
- [ ] OriginMatrix: hover every row, tab through with keyboard, confirm captions update and focus ring is visible
- [ ] RequestJourney: step forward and back with both Allow-Origin states; confirm Network shows 200 in every state, Console only changes when the toggle flips
- [ ] RequestClassifier: toggle every control combination; confirm the preflight exchange panel animates in/out correctly and reflects the chosen method/headers
- [ ] Toggle dark/light theme — all widgets re-render cleanly
- [ ] Reduced-motion — set `prefers-reduced-motion: reduce` in DevTools → motion collapses, widgets remain functional
- [ ] Mobile viewport (~375px) — RequestJourney scrolls horizontally and remains readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)