### PR TITLE
ship: the function that remembered

### DIFF
--- a/app/posts/the-function-that-remembered/metadata.ts
+++ b/app/posts/the-function-that-remembered/metadata.ts
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "the-function-that-remembered";
+const TITLE = "The function that remembered";
+const HOOK = "how a function outlives the scope it was born in — and why half of your JS bugs start there.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: HOOK,
+  openGraph: {
+    title: TITLE,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -1,0 +1,323 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  Callout,
+  Dots,
+  Em,
+  Aside,
+  A,
+  Term,
+} from "@/components/prose";
+import {
+  LoopTrap,
+  TetherScope,
+  RenderLoom,
+  PredictReveal,
+} from "./widgets";
+import { metadata } from "./metadata";
+
+export { metadata };
+
+export default function TheFunctionThatRemembered() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <H1>The function that remembered</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-19">apr 19, 2026</time>
+          <span className="mx-2">·</span>
+          <span>10 min read</span>
+        </p>
+
+        {/* §1 — Opener */}
+        <P>
+          You&apos;re debugging someone else&apos;s code. The task was simple: log the numbers
+          zero through four, one per second. The loop looks fine. You hit run and watch the
+          console.
+        </P>
+        <pre
+          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
+          style={{
+            background: "var(--color-surface)",
+            padding: "var(--spacing-md)",
+            fontSize: "var(--text-mono)",
+            lineHeight: 1.55,
+          }}
+        >
+{`for (var i = 0; i < 5; i++) {
+  setTimeout(() => console.log(i), 1000);
+}`}
+        </pre>
+        <P>
+          It prints <PredictReveal answer="5 5 5 5 5" />. Not{" "}
+          <Code>0 1 2 3 4</Code>. Five fives. A second late, five times over.
+        </P>
+        <P>
+          Something in that loop remembered the wrong thing. To see <Em>what</Em>, you have to
+          see what the five scheduled callbacks are actually pointing at when they eventually
+          fire.
+        </P>
+      </div>
+
+      {/* §2 — LoopTrap widget */}
+      <div>
+        <Dots />
+        <H2>Five callbacks, one cell</H2>
+        <P>
+          Flip the toggle below between <Code>var</Code> and <Code>let</Code>. In both modes,
+          the loop has already finished by the time the timers fire — the five callbacks are
+          sitting in the queue, each one pointing back at whatever it captured when it was
+          scheduled. Hit play and watch them fire.
+        </P>
+      </div>
+
+      <LoopTrap />
+
+      <div>
+        <P>
+          With <Code>var</Code>, there&apos;s only ever one <Code>i</Code>. The loop walked it
+          from <Code>0</Code> to <Code>5</Code> and stopped. Each callback has a line out to the
+          same cell. When the timers fire, they all look at the cell and they all see{" "}
+          <Code>5</Code>. Five fives.
+        </P>
+        <P>
+          With <Code>let</Code>, the picture is different: five lines, fanning out to five
+          different cells, each frozen at the value <Code>i</Code> had that round. Same five
+          callbacks. Different thing on the other end of the line.
+        </P>
+      </div>
+
+      {/* §3 — TetherScope: name the mechanism */}
+      <div>
+        <Dots />
+        <H2>What the function is actually carrying</H2>
+        <P>
+          Call those lines <Em>tethers</Em>. They&apos;re the reason the post is titled the way
+          it is. Every function in JavaScript, the moment it&apos;s created, gets a pointer
+          back into the scope it was born in — a hidden field on the function object that the
+          spec calls <Code>[[Environment]]</Code>. Wired at creation time; never retargeted
+          after.
+        </P>
+        <P>
+          The reason this matters is that the function can be <Em>taken elsewhere</Em> —
+          returned, passed to <Code>setTimeout</Code>, stored on an object — and the tether
+          comes with it. Parameter frames that would normally vanish when the call returns
+          don&apos;t vanish if a function born inside them is still holding the tether.
+          Consider a factory:
+        </P>
+        <pre
+          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
+          style={{
+            background: "var(--color-surface)",
+            padding: "var(--spacing-md)",
+            fontSize: "var(--text-mono)",
+            lineHeight: 1.55,
+          }}
+        >
+{`function makeAdder(n) {
+  return (x) => x + n;
+}
+
+const add5  = makeAdder(5);
+const add10 = makeAdder(10);`}
+        </pre>
+        <P>
+          Each call to <Code>makeAdder</Code> creates its own frame, with its own{" "}
+          <Code>n</Code>. The returned arrow function carries a tether to that frame.{" "}
+          <Code>add5</Code> and <Code>add10</Code> aren&apos;t copies of <Code>n</Code>; they
+          each own a live pointer to a <Em>different</Em> frame. Step through a single call and
+          watch the mechanics:
+        </P>
+      </div>
+
+      <TetherScope />
+
+      <div>
+        <Callout tone="note">
+          A <Term>closure</Term> is a function, plus the tether it kept. Any function, as long
+          as it can still reach something from an outer scope. That&apos;s it.
+        </Callout>
+        <P>
+          One subtlety worth stating plainly, because it&apos;s the misconception every other
+          closure bug traces back to: the tether is <Em>live</Em>. It doesn&apos;t freeze a
+          copy of the value it reaches; it resolves the name when the function actually runs.
+          If something mutates the cell on the other end, the function sees the new value. The
+          function remembered the <Em>slot</Em>, not the contents.
+        </P>
+      </div>
+
+      {/* §4 — Why one letter fixes the loop */}
+      <div>
+        <Dots />
+        <H2>Why one letter fixed the loop</H2>
+        <P>
+          With that, scroll back up to <Em>LoopTrap</Em> and look at it again. The reason{" "}
+          <Code>var</Code> prints <Code>5 5 5 5 5</Code> isn&apos;t that the loop copied{" "}
+          <Code>i</Code> wrong. It&apos;s that <Code>var</Code> declares one binding for the
+          whole function. The five arrow functions picked up five tethers. All five tethers
+          pointed at the same cell. The loop walked the cell to <Code>5</Code>. Nothing in the
+          callbacks&apos; world said &ldquo;freeze what <Code>i</Code> is right now.&rdquo; When
+          they fired, they read what was there.
+        </P>
+        <P>
+          The one-letter fix isn&apos;t a snapshot, either. When you write{" "}
+          <Code>for (let i = 0; …)</Code>, the language does something specific: every iteration
+          of the loop gets its own fresh <Code>i</Code>. A new binding, an actual new cell on
+          the heap, each round. The five scheduled arrow functions now pick up five tethers to
+          five different cells. Same mechanism. Different topology.
+        </P>
+        <Aside>
+          The spec calls the operation <Code>CreatePerIterationEnvironment</Code>. It only
+          kicks in for the loop-header declaration — a plain <Code>let</Code> inside the body
+          doesn&apos;t magically clone itself each iteration. It&apos;s the <Code>for</Code>{" "}
+          header that&apos;s special.
+        </Aside>
+        <Aside>
+          Kyle Simpson&apos;s{" "}
+          <A href="https://github.com/getify/You-Dont-Know-JS/blob/2nd-ed/scope-closures/ch7.md">
+            You Don&apos;t Know JS
+          </A>
+          {" "}reserves the word <Em>closure</Em> for functions that run somewhere their tether
+          targets aren&apos;t directly in scope — the observable case. MDN and the spec use the
+          word more broadly. Same mechanism — the debate is only about when its effects count
+          as observable.
+        </Aside>
+      </div>
+
+      {/* §5 — React stale closure */}
+      <div>
+        <Dots />
+        <H2>The same bug, a decade later, in React</H2>
+        <P>
+          Fast-forward to a React component. You&apos;ve written this before, and you remember
+          being surprised the first time:
+        </P>
+        <pre
+          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
+          style={{
+            background: "var(--color-surface)",
+            padding: "var(--spacing-md)",
+            fontSize: "var(--text-mono)",
+            lineHeight: 1.55,
+          }}
+        >
+{`function Counter() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount(count + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <h1>{count}</h1>;
+}`}
+        </pre>
+        <P>
+          It goes from <Code>0</Code> to <Code>1</Code> and stops. The interval keeps firing,
+          but the number on the screen never moves past one.
+        </P>
+        <P>
+          This is the loop bug. Same mechanism, different decade. Every time{" "}
+          <Code>Counter</Code> runs, React executes the function body from the top — a new
+          call, a new frame, a new <Code>count</Code> binding. The first render produces a
+          frame where <Code>count</Code> is <Code>0</Code>; the effect runs in that frame, the
+          callback handed to <Code>setInterval</Code> is born in that frame, and its tether is
+          wired back to that frame&apos;s <Code>count</Code>. Empty-array dependencies tell
+          React not to re-run the effect, so the interval never gets re-created. The callback
+          ticking inside <Code>setInterval</Code> is the same callback, forever, still
+          tethered to render zero.
+        </P>
+      </div>
+
+      <RenderLoom />
+
+      <div>
+        <P>
+          Flip the toggle to <Code>c =&gt; c + 1</Code>. The callback no longer reads anything
+          from the enclosing render — it just asks React for the current count at call time.
+          No tether to a stale frame. No frame to go stale.
+        </P>
+        <Callout tone="note">
+          A stale closure isn&apos;t a bug in the closure. It&apos;s a tether to a scope the
+          world has moved past. The question is never &ldquo;is this a closure?&rdquo; — almost
+          everything is. The question is &ldquo;what scope is it tethered to, and does that
+          scope still hold what I need?&rdquo;
+        </Callout>
+        <P>
+          Dan Abramov made the{" "}
+          <A href="https://overreacted.io/a-complete-guide-to-useeffect/">
+            stronger version
+          </A>{" "}
+          of this argument: the capture-per-render behaviour is the feature, not the trap.
+          Class components used to read <Code>this.props</Code> live; an async handler that
+          started on render five could silently read render eight&apos;s props halfway through.
+          Hooks traded that for closures tethered to the render that birthed them. The bugs
+          you hit now are louder, more local, and a lot easier to reason about.
+        </P>
+      </div>
+
+      {/* §6 — Coda: leaks */}
+      <div>
+        <Dots />
+        <H2>What the garbage collector has to honor</H2>
+        <P>
+          One more consequence, and then we&apos;re done. If a closure is holding a tether, the
+          garbage collector can&apos;t clean up what&apos;s on the other end. That&apos;s how
+          closures leak memory. The classic pattern — first spotted in Meteor a decade back —
+          looks like this:
+        </P>
+        <pre
+          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
+          style={{
+            background: "var(--color-surface)",
+            padding: "var(--spacing-md)",
+            fontSize: "var(--text-mono)",
+            lineHeight: 1.55,
+          }}
+        >
+{`let theThing = null;
+function replaceThing() {
+  const prev = theThing;
+  theThing = {
+    big: new Array(1_000_000).join("x"),
+    link: () => { if (prev) { /* never called */ } },
+  };
+}
+setInterval(replaceThing, 1000);`}
+        </pre>
+        <P>
+          Every tick, <Code>theThing</Code> gets replaced with a new megabyte-sized object that
+          carries a closure — <Code>link</Code> — tethered back to <Code>prev</Code>. And{" "}
+          <Code>prev</Code> is last tick&apos;s <Code>theThing</Code>, which has its own{" "}
+          <Code>link</Code>, which holds on to the tick before that, which holds on to the tick
+          before that. A linked list of megabyte strings grows by one every second. The closure
+          is never called. It doesn&apos;t have to be — the tether keeps its promises either
+          way.
+        </P>
+        <P>
+          Fix: don&apos;t create the closure you don&apos;t need. Null references when you
+          finish with them. Return the cleanup from <Code>useEffect</Code>. Pair{" "}
+          <Code>addEventListener</Code> with an <Code>AbortController</Code>.
+        </P>
+        <P>
+          Next time your <Code>setTimeout</Code> prints the wrong number, or your React counter
+          sticks at one, or your heap snapshot lights up a chain that shouldn&apos;t still
+          exist — you&apos;ll know where to look. Closures aren&apos;t about memory. They&apos;re
+          about where a function is still rooted — and whether that ground still holds what
+          you need.
+        </P>
+      </div>
+    </Prose>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/LoopTrap.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopTrap.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SvgDefs } from "@/components/viz/SvgDefs";
+import { Arrow } from "@/components/viz/Arrow";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Mode = "var" | "let";
+
+const N = 5;
+const TOTAL_STEPS = N + 1;
+
+function captionFor(mode: Mode, step: number): string {
+  if (step === 0) {
+    return mode === "var"
+      ? "Loop has finished. i is 5. Five callbacks scheduled — all five with a line back to the same cell."
+      : "Loop has finished. Five callbacks scheduled — each with a line back to its own per-iteration cell. Each cell holds the value i had that round.";
+  }
+  const fired = step;
+  const printed =
+    mode === "var"
+      ? Array(fired).fill(N).join(" ")
+      : Array.from({ length: fired }, (_, i) => i).join(" ");
+  return mode === "var"
+    ? `Timer ${fired} fires. It follows its line to the shared cell — which holds 5. Prints: ${printed}.`
+    : `Timer ${fired} fires. It follows its line to the iteration ${fired - 1} cell. Prints: ${printed}.`;
+}
+
+export function LoopTrap() {
+  const [mode, setMode] = useState<Mode>("var");
+  const [step, setStep] = useState(0);
+
+  // Canvas geometry
+  const WIDTH = 680;
+  const HEIGHT = 300;
+
+  const CB_Y = 36;
+  const CB_W = 84;
+  const CB_H = 40;
+  const CB_GAP = 20;
+  const CB_TOTAL_W = N * CB_W + (N - 1) * CB_GAP;
+  const CB_X0 = (WIDTH - CB_TOTAL_W) / 2;
+
+  const BIND_Y = 180;
+  const BIND_H = 40;
+
+  // In var mode: one wide cell spanning the callback row.
+  const VAR_BIND_W = 140;
+  const VAR_BIND_X = (WIDTH - VAR_BIND_W) / 2;
+
+  // In let mode: five cells aligned under the callbacks.
+  const LET_BIND_W = 60;
+
+  // Current shared-var value (in var mode, after loop = N; while running = loop idx).
+  const sharedVar = N;
+  const letBindings = Array.from({ length: N }, (_, i) => i);
+
+  // Fire state per callback: fired = step >= cbIndex + 1.
+  const firedCount = step;
+  const printedValues = Array.from({ length: firedCount }, (_, i) =>
+    mode === "var" ? sharedVar : i,
+  );
+
+  return (
+    <WidgetShell
+      title="LoopTrap"
+      measurements={`${mode} · ${N} callbacks · ${mode === "var" ? "1 cell" : `${N} cells`}`}
+      caption={captionFor(mode, step)}
+      controls={
+        <div className="flex flex-wrap items-center gap-[var(--spacing-md)]">
+          <ModeToggle
+            mode={mode}
+            onChange={(m) => {
+              setMode(m);
+              setStep(0);
+            }}
+          />
+          <Stepper value={step} total={TOTAL_STEPS} onChange={setStep} playInterval={1100} />
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`LoopTrap: ${mode} mode, ${firedCount} of ${N} callbacks fired`}
+      >
+        <defs>
+          <SvgDefs />
+        </defs>
+
+        {/* Callback boxes */}
+        {Array.from({ length: N }, (_, i) => {
+          const x = CB_X0 + i * (CB_W + CB_GAP);
+          const fired = i < firedCount;
+          const firing = i === firedCount - 1 && firedCount > 0;
+          const fill = firing
+            ? "color-mix(in oklab, var(--color-accent) 18%, transparent)"
+            : fired
+              ? "color-mix(in oklab, var(--color-surface) 60%, transparent)"
+              : "transparent";
+          const stroke = firing
+            ? "var(--color-accent)"
+            : "var(--color-rule)";
+          return (
+            <g key={`cb-${i}`}>
+              <motion.rect
+                x={x}
+                y={CB_Y}
+                width={CB_W}
+                height={CB_H}
+                rx={3}
+                initial={false}
+                animate={{ fill, stroke }}
+                strokeWidth={firing ? 1.5 : 1}
+                transition={SPRING.snappy}
+              />
+              <text
+                x={x + CB_W / 2}
+                y={CB_Y + 16}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={11}
+                fill="var(--color-text-muted)"
+              >
+                cb{i}
+              </text>
+              <text
+                x={x + CB_W / 2}
+                y={CB_Y + 31}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={13}
+                fill={fired ? "var(--color-text)" : "var(--color-text-muted)"}
+              >
+                {fired ? `log(${mode === "var" ? sharedVar : i})` : "log(i)"}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Binding cell(s) — crossfade topology on mode change */}
+        <AnimatePresence mode="wait">
+          {mode === "var" ? (
+            <motion.g
+              key="var-bind"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={VAR_BIND_X}
+                y={BIND_Y}
+                width={VAR_BIND_W}
+                height={BIND_H}
+                rx={3}
+                fill="var(--color-accent)"
+                fillOpacity={0.92}
+              />
+              <text
+                x={VAR_BIND_X + VAR_BIND_W / 2}
+                y={BIND_Y + 16}
+                textAnchor="middle"
+                fontFamily="var(--font-sans)"
+                fontSize={10}
+                fill="var(--color-bg)"
+                opacity={0.85}
+                letterSpacing="0.08em"
+              >
+                i (shared)
+              </text>
+              <text
+                x={VAR_BIND_X + VAR_BIND_W / 2}
+                y={BIND_Y + 32}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={15}
+                fill="var(--color-bg)"
+              >
+                {sharedVar}
+              </text>
+            </motion.g>
+          ) : (
+            <motion.g
+              key="let-bind"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.smooth}
+            >
+              {letBindings.map((val, i) => {
+                const x = CB_X0 + i * (CB_W + CB_GAP) + (CB_W - LET_BIND_W) / 2;
+                return (
+                  <g key={`bind-${i}`}>
+                    <rect
+                      x={x}
+                      y={BIND_Y}
+                      width={LET_BIND_W}
+                      height={BIND_H}
+                      rx={3}
+                      fill="var(--color-accent)"
+                      fillOpacity={0.92}
+                    />
+                    <text
+                      x={x + LET_BIND_W / 2}
+                      y={BIND_Y + 16}
+                      textAnchor="middle"
+                      fontFamily="var(--font-sans)"
+                      fontSize={9}
+                      fill="var(--color-bg)"
+                      opacity={0.85}
+                      letterSpacing="0.06em"
+                    >
+                      i #{i}
+                    </text>
+                    <text
+                      x={x + LET_BIND_W / 2}
+                      y={BIND_Y + 32}
+                      textAnchor="middle"
+                      fontFamily="var(--font-mono)"
+                      fontSize={15}
+                      fill="var(--color-bg)"
+                    >
+                      {val}
+                    </text>
+                  </g>
+                );
+              })}
+            </motion.g>
+          )}
+        </AnimatePresence>
+
+        {/* Lines from each callback down to the cell it captured. */}
+        {Array.from({ length: N }, (_, i) => {
+          const cbCx = CB_X0 + i * (CB_W + CB_GAP) + CB_W / 2;
+          const cbBy = CB_Y + CB_H;
+          const bindX =
+            mode === "var"
+              ? VAR_BIND_X + VAR_BIND_W / 2
+              : CB_X0 + i * (CB_W + CB_GAP) + CB_W / 2;
+          const firing = i === firedCount - 1 && firedCount > 0;
+          const tone = firing ? "active" : "muted";
+          return (
+            <Arrow
+              key={`teth-${i}-${mode}`}
+              x1={cbCx}
+              y1={cbBy + 2}
+              x2={bindX}
+              y2={BIND_Y - 2}
+              tone={tone}
+              strokeWidth={firing ? 2 : 1.2}
+            />
+          );
+        })}
+
+        {/* Console area: what the callbacks have printed so far. */}
+        <g>
+          <text
+            x={WIDTH / 2}
+            y={HEIGHT - 32}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+            letterSpacing="0.08em"
+          >
+            CONSOLE
+          </text>
+          <text
+            x={WIDTH / 2}
+            y={HEIGHT - 8}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={16}
+            fill="var(--color-text)"
+          >
+            {printedValues.length > 0 ? printedValues.join(" ") : "\u00A0"}
+          </text>
+        </g>
+      </svg>
+    </WidgetShell>
+  );
+}
+
+function ModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: Mode;
+  onChange: (m: Mode) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Loop variable declaration"
+      className="inline-flex items-center gap-[2px] rounded-[var(--radius-sm)] p-[2px]"
+      style={{ background: "var(--color-surface)" }}
+    >
+      {(["var", "let"] as const).map((m) => {
+        const active = m === mode;
+        return (
+          <button
+            key={m}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(m)}
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] font-mono transition-colors"
+            style={{
+              fontSize: "var(--text-small)",
+              background: active ? "var(--color-bg)" : "transparent",
+              color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+              fontWeight: active ? 600 : 400,
+            }}
+          >
+            {m}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/PredictReveal.tsx
+++ b/app/posts/the-function-that-remembered/widgets/PredictReveal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { SPRING } from "@/lib/motion";
+
+type Props = {
+  answer: string;
+  label?: string;
+};
+
+/**
+ * Tiny inline beat: the reader guesses first, clicks to reveal. Used at §1 to
+ * plant the scene before the full widget in §2. Keeps the reader's agency
+ * ahead of the explanation.
+ */
+export function PredictReveal({ answer, label = "reveal" }: Props) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span
+      style={{ display: "inline-flex", alignItems: "baseline", gap: "0.5ch" }}
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        {open ? (
+          <motion.span
+            key="answer"
+            layout
+            initial={{ opacity: 0, y: 2 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.snappy}
+            className="font-mono tabular-nums"
+            style={{
+              fontSize: "var(--text-mono)",
+              color: "var(--color-accent)",
+              background: "color-mix(in oklab, var(--color-accent) 10%, transparent)",
+              padding: "0 6px",
+              borderRadius: "var(--radius-sm)",
+            }}
+          >
+            {answer}
+          </motion.span>
+        ) : (
+          <motion.button
+            key="trigger"
+            type="button"
+            layout
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={() => setOpen(true)}
+            className="font-mono rounded-[var(--radius-sm)] transition-colors hover:text-[color:var(--color-accent)]"
+            style={{
+              fontSize: "var(--text-mono)",
+              background: "var(--color-surface)",
+              color: "var(--color-text-muted)",
+              padding: "0 8px",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            {label} →
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </span>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/RenderLoom.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderLoom.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SvgDefs } from "@/components/viz/SvgDefs";
+import { Arrow } from "@/components/viz/Arrow";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Mode = "broken" | "fixed";
+
+const TICK_STEPS = 6;
+
+type Tick = {
+  /** The render that is currently on screen at the start of this tick. */
+  displayedRender: number;
+  /** Bindings created so far. Index = render number; value = count binding. */
+  bindings: number[];
+  /** Which render's binding the effect's callback is tethered to (broken mode). */
+  tetherRender: number | null;
+  /** Last printed value, if any (the callback's log output). */
+  printed: number | null;
+};
+
+function buildTimeline(mode: Mode): Tick[] {
+  const ticks: Tick[] = [];
+  if (mode === "broken") {
+    // Broken: tether stays rooted in render 0 forever. Every tick: read 0, setCount(1).
+    // After the first tick, React produces render 1 with count=1. From then on, no more renders
+    // because setCount(1) is the same as the previous value (but we'll still show renders 1..5
+    // symbolically to emphasise the staleness — each new render has its own count, but the
+    // callback still reads render 0's).
+    // For teaching clarity, we model: tick 0 = initial; tick i (i>=1) = callback fires reading
+    // from render 0 (always 0), then setCount(0+1) = 1. First time it causes a new render
+    // (render 1, count=1). After that, React may bail out. To keep the visual dramatic, show
+    // up to 3 renders stacking, all with count at their captured values.
+    let bindings = [0];
+    ticks.push({ displayedRender: 0, bindings: [...bindings], tetherRender: 0, printed: null });
+    // tick 1: callback fires, reads render 0's count (0), calls setCount(1). New render: count=1.
+    bindings = [...bindings, 1];
+    ticks.push({ displayedRender: 1, bindings: [...bindings], tetherRender: 0, printed: 0 });
+    // tick 2: callback fires again, still reading render 0's count (0). setCount(1) — React may
+    // skip, but we show it as "still 1, tether still broken".
+    ticks.push({ displayedRender: 1, bindings: [...bindings], tetherRender: 0, printed: 0 });
+    // tick 3-5: same story.
+    ticks.push({ displayedRender: 1, bindings: [...bindings], tetherRender: 0, printed: 0 });
+    ticks.push({ displayedRender: 1, bindings: [...bindings], tetherRender: 0, printed: 0 });
+    ticks.push({ displayedRender: 1, bindings: [...bindings], tetherRender: 0, printed: 0 });
+  } else {
+    // Fixed: callback uses setCount(c => c+1). No tether to any render's count binding.
+    // Every tick: React calls the updater with the current count and produces a new render.
+    let bindings = [0];
+    ticks.push({ displayedRender: 0, bindings: [...bindings], tetherRender: null, printed: null });
+    for (let t = 1; t < TICK_STEPS; t++) {
+      bindings = [...bindings, t];
+      ticks.push({ displayedRender: t, bindings: [...bindings], tetherRender: null, printed: null });
+    }
+  }
+  return ticks;
+}
+
+export function RenderLoom() {
+  const [mode, setMode] = useState<Mode>("broken");
+  const [step, setStep] = useState(0);
+
+  const ticks = buildTimeline(mode);
+  const tick = ticks[Math.min(step, ticks.length - 1)];
+
+  // Canvas geometry
+  const WIDTH = 680;
+  const HEIGHT = 360;
+
+  const RENDER_X = 40;
+  const RENDER_Y0 = 40;
+  const RENDER_W = 220;
+  const RENDER_H = 42;
+  const RENDER_GAP = 6;
+  const MAX_RENDERS_VISIBLE = 6;
+
+  const EFFECT_X = 420;
+  const EFFECT_Y = 140;
+  const EFFECT_W = 220;
+  const EFFECT_H = 96;
+
+  const SCREEN_X = 420;
+  const SCREEN_Y = 240;
+  const SCREEN_W = 220;
+  const SCREEN_H = 80;
+
+  return (
+    <WidgetShell
+      title="RenderLoom"
+      measurements={`${mode === "broken" ? "count + 1" : "c => c + 1"} · tick ${step}/${TICK_STEPS - 1}`}
+      caption={
+        mode === "broken"
+          ? step === 0
+            ? "First render. count = 0. The effect runs and creates an interval. The callback captures count from THIS render — see the tether."
+            : step === 1
+              ? "Tick 1. Callback reads from render 0 (count = 0). Calls setCount(0 + 1). Render 1 spawns with count = 1 — but the interval still ticks the old callback, still tethered to render 0."
+              : "More ticks. New renders pile up above with their own bindings, but the interval's tether hasn't moved. It keeps reading render 0's stale 0. The counter on screen stays stuck at 1."
+          : step === 0
+            ? "Same component, but setCount(c => c + 1). The callback doesn't capture count at all — it asks React for the current one. No tether."
+            : `Tick ${step}. React produces render ${step} with count = ${step}. The interval fires, the updater runs, React hands it the current count, and a new render with count + 1 is produced. No staleness to accumulate.`
+      }
+      controls={
+        <div className="flex flex-wrap items-center gap-[var(--spacing-md)]">
+          <ModeToggle
+            mode={mode}
+            onChange={(m) => {
+              setMode(m);
+              setStep(0);
+            }}
+          />
+          <Stepper value={step} total={TICK_STEPS} onChange={setStep} playInterval={1200} />
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`RenderLoom: ${mode} mode, tick ${step} of ${TICK_STEPS - 1}`}
+      >
+        <defs>
+          <SvgDefs />
+        </defs>
+
+        {/* Section labels */}
+        <text
+          x={RENDER_X}
+          y={22}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          RENDERS
+        </text>
+
+        <text
+          x={EFFECT_X}
+          y={22}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          CALLBACK
+        </text>
+
+        {/* Render stack */}
+        {tick.bindings.map((countVal, renderIdx) => {
+          if (renderIdx >= MAX_RENDERS_VISIBLE) return null;
+          const y = RENDER_Y0 + renderIdx * (RENDER_H + RENDER_GAP);
+          const isDisplayed = renderIdx === tick.displayedRender;
+          const isTethered =
+            mode === "broken" && renderIdx === tick.tetherRender;
+          const borderColor = isTethered
+            ? "var(--color-accent)"
+            : isDisplayed
+              ? "var(--color-text-muted)"
+              : "var(--color-rule)";
+          const bgFill = isTethered
+            ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+            : isDisplayed
+              ? "color-mix(in oklab, var(--color-surface) 70%, transparent)"
+              : "transparent";
+          return (
+            <motion.g
+              key={`render-${renderIdx}`}
+              initial={{ opacity: 0, x: -8 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ ...SPRING.smooth, delay: renderIdx === tick.bindings.length - 1 ? 0.06 : 0 }}
+            >
+              <rect
+                x={RENDER_X}
+                y={y}
+                width={RENDER_W}
+                height={RENDER_H}
+                rx={3}
+                fill={bgFill}
+                stroke={borderColor}
+                strokeWidth={isTethered || isDisplayed ? 1.3 : 1}
+                strokeDasharray={isTethered ? "0" : isDisplayed ? "0" : "3 3"}
+              />
+              <text
+                x={RENDER_X + 10}
+                y={y + 16}
+                fontFamily="var(--font-sans)"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+                letterSpacing="0.05em"
+              >
+                render {renderIdx}
+              </text>
+              <text
+                x={RENDER_X + 10}
+                y={y + 32}
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-text)"
+              >
+                count
+              </text>
+              <rect
+                x={RENDER_X + 58}
+                y={y + 20}
+                width={24}
+                height={18}
+                rx={2}
+                fill="var(--color-accent)"
+              />
+              <text
+                x={RENDER_X + 70}
+                y={y + 33}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-bg)"
+              >
+                {countVal}
+              </text>
+              {isTethered || isDisplayed ? (
+                <text
+                  x={RENDER_X + RENDER_W - 10}
+                  y={y + 16}
+                  textAnchor="end"
+                  fontFamily="var(--font-sans)"
+                  fontSize={9}
+                  fill={isTethered ? "var(--color-accent)" : "var(--color-text-muted)"}
+                  letterSpacing="0.08em"
+                >
+                  {isTethered && isDisplayed
+                    ? "TETHERED · ON SCREEN"
+                    : isTethered
+                      ? "TETHERED"
+                      : "ON SCREEN"}
+                </text>
+              ) : null}
+            </motion.g>
+          );
+        })}
+
+        {/* Effect's callback box */}
+        <g>
+          <rect
+            x={EFFECT_X}
+            y={EFFECT_Y}
+            width={EFFECT_W}
+            height={EFFECT_H}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-surface) 80%, transparent)"
+            stroke="var(--color-text-muted)"
+            strokeWidth={1}
+          />
+          <text
+            x={EFFECT_X + 10}
+            y={EFFECT_Y + 18}
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+            letterSpacing="0.08em"
+          >
+            setInterval callback
+          </text>
+          <text
+            x={EFFECT_X + 10}
+            y={EFFECT_Y + 40}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+          >
+            {mode === "broken" ? "() => setCount(" : "() => setCount("}
+          </text>
+          <text
+            x={EFFECT_X + 10}
+            y={EFFECT_Y + 60}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill={mode === "broken" ? "var(--color-accent)" : "var(--color-text)"}
+          >
+            {mode === "broken" ? "  count + 1" : "  c => c + 1"}
+          </text>
+          <text
+            x={EFFECT_X + 10}
+            y={EFFECT_Y + 80}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+          >
+            {")"}
+          </text>
+        </g>
+
+        {/* Tether from callback to render 0 — exits with fade when mode flips to fixed */}
+        <AnimatePresence>
+          {mode === "broken" && tick.tetherRender !== null ? (
+            <motion.g
+              key="tether"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.smooth}
+            >
+              <Arrow
+                x1={EFFECT_X}
+                y1={EFFECT_Y + 50}
+                x2={RENDER_X + RENDER_W + 6}
+                y2={RENDER_Y0 + tick.tetherRender * (RENDER_H + RENDER_GAP) + RENDER_H / 2}
+                tone="active"
+                curvature={-20}
+                strokeWidth={2}
+              />
+            </motion.g>
+          ) : (
+            <motion.text
+              key="no-tether-label"
+              x={EFFECT_X - 10}
+              y={EFFECT_Y + 54}
+              textAnchor="end"
+              fontFamily="var(--font-sans)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.smooth}
+            >
+              (no tether)
+            </motion.text>
+          )}
+        </AnimatePresence>
+
+        {/* "Screen": what the user sees, i.e. the displayed render's count */}
+        <g>
+          <rect
+            x={SCREEN_X}
+            y={SCREEN_Y}
+            width={SCREEN_W}
+            height={SCREEN_H}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-accent) 6%, transparent)"
+            stroke="var(--color-rule)"
+            strokeWidth={1}
+          />
+          <text
+            x={SCREEN_X + 10}
+            y={SCREEN_Y + 18}
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+            letterSpacing="0.08em"
+          >
+            SCREEN
+          </text>
+          <AnimatePresence mode="popLayout">
+            <motion.text
+              key={`screen-${tick.displayedRender}-${mode}`}
+              x={SCREEN_X + SCREEN_W / 2}
+              y={SCREEN_Y + 60}
+              textAnchor="middle"
+              fontFamily="var(--font-sans)"
+              fontSize={44}
+              fontWeight={500}
+              fill="var(--color-text)"
+              initial={{ opacity: 0, y: SCREEN_Y + 50 }}
+              animate={{ opacity: 1, y: SCREEN_Y + 64 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.snappy}
+            >
+              {tick.bindings[tick.displayedRender]}
+            </motion.text>
+          </AnimatePresence>
+        </g>
+      </svg>
+    </WidgetShell>
+  );
+}
+
+function ModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: Mode;
+  onChange: (m: Mode) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Callback form"
+      className="inline-flex items-center gap-[2px] rounded-[var(--radius-sm)] p-[2px]"
+      style={{ background: "var(--color-surface)" }}
+    >
+      {(
+        [
+          { key: "broken" as const, label: "count + 1" },
+          { key: "fixed" as const, label: "c => c + 1" },
+        ]
+      ).map((m) => {
+        const active = m.key === mode;
+        return (
+          <button
+            key={m.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(m.key)}
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] font-mono transition-colors"
+            style={{
+              fontSize: "var(--text-small)",
+              background: active ? "var(--color-bg)" : "transparent",
+              color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+              fontWeight: active ? 600 : 400,
+            }}
+          >
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
+++ b/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Stepper } from "@/components/viz/Stepper";
+import { SvgDefs } from "@/components/viz/SvgDefs";
+import { Arrow } from "@/components/viz/Arrow";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "./WidgetShell";
+
+type Step = {
+  activeLines: number[];
+  caption: string;
+  frameState: "hidden" | "live" | "pinned";
+  showInnerFn: boolean;
+  showTether: boolean;
+  showLookup: boolean;
+  returnValue: number | null;
+};
+
+const CODE_LINES = [
+  "function makeRemember(x) {",
+  "  return () => x;",
+  "}",
+  "",
+  "const remember7 = makeRemember(7);",
+  "",
+  "// time passes. makeRemember returns.",
+  "",
+  "remember7();  //  ?",
+];
+
+const STEPS: Step[] = [
+  {
+    activeLines: [4],
+    caption:
+      "Call makeRemember(7). A new frame is created to run the call — it holds the parameter x bound to 7.",
+    frameState: "live",
+    showInnerFn: false,
+    showTether: false,
+    showLookup: false,
+    returnValue: null,
+  },
+  {
+    activeLines: [1],
+    caption:
+      "Inside the call, an inner arrow function () => x is built. Every function in JavaScript has an internal pointer — [[Environment]] — to the scope it was born in. That pointer gets wired to the current frame.",
+    frameState: "live",
+    showInnerFn: true,
+    showTether: true,
+    showLookup: false,
+    returnValue: null,
+  },
+  {
+    activeLines: [4],
+    caption:
+      "makeRemember returns the inner function. The call finishes. Normally the frame would be collected — but the returned function still points at it. A pointer the GC honors: the frame stays pinned.",
+    frameState: "pinned",
+    showInnerFn: true,
+    showTether: true,
+    showLookup: false,
+    returnValue: null,
+  },
+  {
+    activeLines: [8],
+    caption:
+      "Later, we call remember7(). The call needs x. It walks the tether back into the pinned frame, finds x = 7, and returns it.",
+    frameState: "pinned",
+    showInnerFn: true,
+    showTether: true,
+    showLookup: true,
+    returnValue: 7,
+  },
+];
+
+export function TetherScope() {
+  const [step, setStep] = useState(0);
+  const s = STEPS[step];
+
+  // Canvas layout: 680 wide, ~360 tall.
+  const WIDTH = 680;
+  const HEIGHT = 360;
+  const CODE_X = 24;
+  const CODE_Y = 24;
+  const CODE_LH = 22;
+
+  const HEAP_X = 340;
+  const FRAME_X = HEAP_X + 20;
+  const FRAME_Y = 44;
+  const FRAME_W = 180;
+  const FRAME_H = 68;
+
+  const FN_X = HEAP_X + 40;
+  const FN_Y = 200;
+  const FN_W = 200;
+  const FN_H = 88;
+
+  const returnedText = s.returnValue !== null ? String(s.returnValue) : "";
+
+  return (
+    <WidgetShell
+      title="TetherScope"
+      measurements={`step ${step + 1}/${STEPS.length}`}
+      caption={s.caption}
+      controls={<Stepper value={step} total={STEPS.length} onChange={setStep} playInterval={1500} />}
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`TetherScope: step ${step + 1} of ${STEPS.length}. ${s.caption}`}
+      >
+        <defs>
+          <SvgDefs />
+        </defs>
+
+        {/* Vertical rule between code pane and heap pane */}
+        <line
+          x1={HEAP_X - 10}
+          y1={16}
+          x2={HEAP_X - 10}
+          y2={HEIGHT - 16}
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+          strokeDasharray="2 4"
+        />
+
+        {/* Section labels */}
+        <text
+          x={CODE_X}
+          y={14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          CODE
+        </text>
+        <text
+          x={HEAP_X}
+          y={14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          RUNTIME
+        </text>
+
+        {/* Code lines with per-line active highlighting */}
+        {CODE_LINES.map((line, i) => {
+          const y = CODE_Y + i * CODE_LH;
+          const active = s.activeLines.includes(i);
+          return (
+            <g key={`line-${i}`}>
+              {active ? (
+                <motion.rect
+                  x={CODE_X - 6}
+                  y={y - 2}
+                  width={300}
+                  height={CODE_LH - 2}
+                  rx={2}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={SPRING.snappy}
+                  fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                />
+              ) : null}
+              <text
+                x={CODE_X}
+                y={y + CODE_LH - 8}
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill={active ? "var(--color-text)" : "var(--color-text-muted)"}
+              >
+                {line || "\u00A0"}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Call-site result tag */}
+        <AnimatePresence>
+          {s.returnValue !== null ? (
+            <motion.g
+              key="return-tag"
+              initial={{ opacity: 0, x: -6 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={CODE_X + 128}
+                y={CODE_Y + 8 * CODE_LH - 4}
+                width={46}
+                height={CODE_LH - 2}
+                rx={2}
+                fill="var(--color-accent)"
+              />
+              <text
+                x={CODE_X + 151}
+                y={CODE_Y + 8 * CODE_LH + CODE_LH - 10}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-bg)"
+              >
+                → {returnedText}
+              </text>
+            </motion.g>
+          ) : null}
+        </AnimatePresence>
+
+        {/* The frame: holds the x = 7 binding */}
+        <AnimatePresence>
+          {s.frameState !== "hidden" ? (
+            <motion.g
+              key="frame"
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={FRAME_X}
+                y={FRAME_Y}
+                width={FRAME_W}
+                height={FRAME_H}
+                rx={3}
+                fill={
+                  s.frameState === "pinned"
+                    ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                    : "color-mix(in oklab, var(--color-surface) 70%, transparent)"
+                }
+                stroke={
+                  s.frameState === "pinned"
+                    ? "var(--color-accent)"
+                    : "var(--color-rule)"
+                }
+                strokeWidth={1}
+                strokeDasharray={s.frameState === "pinned" ? "0" : "3 3"}
+              />
+              <text
+                x={FRAME_X + 10}
+                y={FRAME_Y + 16}
+                fontFamily="var(--font-sans)"
+                fontSize={9}
+                fill="var(--color-text-muted)"
+                letterSpacing="0.08em"
+              >
+                FRAME: makeRemember
+              </text>
+              <text
+                x={FRAME_X + 10}
+                y={FRAME_Y + 42}
+                fontFamily="var(--font-mono)"
+                fontSize={13}
+                fill="var(--color-text)"
+              >
+                x
+              </text>
+              <rect
+                x={FRAME_X + 32}
+                y={FRAME_Y + 30}
+                width={30}
+                height={22}
+                rx={2}
+                fill="var(--color-accent)"
+              />
+              <text
+                x={FRAME_X + 47}
+                y={FRAME_Y + 46}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={13}
+                fill="var(--color-bg)"
+              >
+                7
+              </text>
+              {s.frameState === "pinned" ? (
+                <text
+                  x={FRAME_X + FRAME_W - 10}
+                  y={FRAME_Y + 16}
+                  textAnchor="end"
+                  fontFamily="var(--font-sans)"
+                  fontSize={9}
+                  fill="var(--color-accent)"
+                  letterSpacing="0.08em"
+                >
+                  PINNED
+                </text>
+              ) : null}
+            </motion.g>
+          ) : null}
+        </AnimatePresence>
+
+        {/* The returned function object */}
+        <AnimatePresence>
+          {s.showInnerFn ? (
+            <motion.g
+              key="fn"
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={SPRING.smooth}
+            >
+              <rect
+                x={FN_X}
+                y={FN_Y}
+                width={FN_W}
+                height={FN_H}
+                rx={3}
+                fill="color-mix(in oklab, var(--color-surface) 80%, transparent)"
+                stroke="var(--color-text-muted)"
+                strokeWidth={1}
+              />
+              <text
+                x={FN_X + 10}
+                y={FN_Y + 16}
+                fontFamily="var(--font-sans)"
+                fontSize={9}
+                fill="var(--color-text-muted)"
+                letterSpacing="0.08em"
+              >
+                FUNCTION OBJECT
+              </text>
+              <text
+                x={FN_X + 10}
+                y={FN_Y + 38}
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-text)"
+              >
+                code: () =&gt; x
+              </text>
+              <text
+                x={FN_X + 10}
+                y={FN_Y + 62}
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill="var(--color-text)"
+              >
+                [[Environment]]:
+              </text>
+              {/* Slot where the tether starts — ringed attachment point */}
+              <circle
+                cx={FN_X + FN_W - 16}
+                cy={FN_Y + 58}
+                r={9}
+                fill="none"
+                stroke="var(--color-accent)"
+                strokeWidth={1}
+                opacity={0.5}
+              />
+              <motion.circle
+                cx={FN_X + FN_W - 16}
+                cy={FN_Y + 58}
+                fill="var(--color-accent)"
+                initial={false}
+                animate={{ r: s.showTether ? 6 : 3 }}
+                transition={SPRING.snappy}
+              />
+            </motion.g>
+          ) : null}
+        </AnimatePresence>
+
+        {/* The tether — from the [[Environment]] slot to the frame */}
+        {s.showTether && s.showInnerFn ? (
+          <Arrow
+            x1={FN_X + FN_W - 16}
+            y1={FN_Y + 58}
+            x2={FRAME_X + FRAME_W / 2}
+            y2={FRAME_Y + FRAME_H}
+            tone="active"
+            strokeWidth={1.5}
+            curvature={26}
+            animateIn
+          />
+        ) : null}
+
+        {/* Lookup walk — only drawn at call time */}
+        {s.showLookup ? (
+          <motion.g
+            key="lookup"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ ...SPRING.smooth, delay: 0.15 }}
+          >
+            <text
+              x={FN_X + FN_W / 2}
+              y={FN_Y - 8}
+              textAnchor="middle"
+              fontFamily="var(--font-sans)"
+              fontSize={10}
+              fill="var(--color-accent)"
+            >
+              read x → 7
+            </text>
+          </motion.g>
+        ) : null}
+
+        {/* Legend at the very bottom */}
+        <text
+          x={WIDTH / 2}
+          y={HEIGHT - 20}
+          textAnchor="middle"
+          fontFamily="var(--font-sans)"
+          fontSize={10}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          A CLOSURE = FUNCTION + TETHER TO ITS BIRTH SCOPE
+        </text>
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/WidgetShell.tsx
+++ b/app/posts/the-function-that-remembered/widgets/WidgetShell.tsx
@@ -1,0 +1,59 @@
+import { FullBleed } from "@/components/prose";
+import type { ReactNode } from "react";
+
+type Props = {
+  title: string;
+  measurements?: string;
+  caption?: ReactNode;
+  controls?: ReactNode;
+  children: ReactNode;
+};
+
+export function WidgetShell({ title, measurements, caption, controls, children }: Props) {
+  return (
+    <FullBleed>
+      <figcaption className="sr-only">{title}</figcaption>
+      <div
+        className="flex items-baseline justify-between gap-[var(--spacing-sm)] pb-[var(--spacing-sm)]"
+        style={{ fontSize: "var(--text-ui)" }}
+      >
+        <span
+          className="font-sans"
+          style={{ color: "var(--color-text-muted)", letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </span>
+        {measurements ? (
+          <span
+            className="font-mono tabular-nums text-right"
+            style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          >
+            {measurements}
+          </span>
+        ) : null}
+      </div>
+
+      <div
+        className="rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+        }}
+      >
+        {children}
+      </div>
+
+      {controls ? (
+        <div className="pt-[var(--spacing-sm)]">{controls}</div>
+      ) : null}
+
+      {caption ? (
+        <div
+          className="pt-[var(--spacing-sm)] font-sans"
+          style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)", lineHeight: 1.5 }}
+        >
+          {caption}
+        </div>
+      ) : null}
+    </FullBleed>
+  );
+}

--- a/app/posts/the-function-that-remembered/widgets/index.ts
+++ b/app/posts/the-function-that-remembered/widgets/index.ts
@@ -1,0 +1,4 @@
+export { LoopTrap } from "./LoopTrap";
+export { TetherScope } from "./TetherScope";
+export { RenderLoom } from "./RenderLoom";
+export { PredictReveal } from "./PredictReveal";

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -23,6 +23,14 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "the-function-that-remembered",
+    title: "The function that remembered",
+    date: "2026-04-24",
+    hook: "how a function outlives the scope it was born in — and why half of your JS bugs start there.",
+    readingMinutes: 10,
+    tags: ["javascript", "language-internals"],
+  },
+  {
     slug: "why-fetch-fails-only-in-browser",
     title: "Why `fetch` works in curl but the browser blocks it",
     date: "2026-04-20",


### PR DESCRIPTION
## Summary

Post #3 — JavaScript closures reframed as *tethers*: the live pointer a function carries back into the scope it was born in.

- **Arc (6 sections, ~10 min read):** the `5 5 5 5 5` loop bug → name the mechanism via `[[Environment]]` → why one letter (`let`) fixes it → same bug in React as stale closure → Meteor-leak coda.
- **Widgets (3 full + 1 inline beat):**
  - `LoopTrap` — `var`↔`let` toggle, 5 callbacks, topology reveal (shared cell vs fresh per-iteration cells). Crossfade between modes, tethers animate as timers fire.
  - `TetherScope` — step-through of `makeRemember(7)` showing the `[[Environment]]` slot wiring, the frame getting pinned after return, and the lookup walking back to resolve `x`. Ringed attachment point on the slot.
  - `RenderLoom` — React renders stacking up, stale tether staying rooted in render 0; toggle flips to `c => c + 1` and the tether exits with a fade.
  - `PredictReveal` — inline "what prints?" beat opening §1.
- **Composition:** post-local `WidgetShell` (DESIGN.md §7 skeleton); primitives reused from `components/viz/` (Block, Arrow, Stepper, SvgDefs).

## Action items resolved (full list in `research/the-function-that-remembered/action-items.md`)

**P0 — shipped:**
- Cut `MiniFactorySvg` (duplicated TetherScope step 1 + inconsistent tether origin).
- LoopTrap labels de-jargoned: `1 binding` → `1 cell`, `i[i]` → `i #i`; initial `let` caption rewritten to not contradict the live-reference rule.
- TetherScope legend fixed (`A CLOSURE = FUNCTION + TETHER TO ITS BIRTH SCOPE`).
- Closer sharpened to concrete duality: *"Closures aren't about memory. They're about where a function is still rooted — and whether that ground still holds what you need."*

**P1 — shipped:**
- LoopTrap crossfade on `var` ↔ `let`.
- RenderLoom tether exit animation; `(no tether)` label fades in.
- Simpson paragraph moved to `<Aside>` (citation-detour discipline).
- `[[Environment]]` slot = ringed attachment point; inner dot grows when tether binds.
- Combined `TETHERED · ON SCREEN` label so render 0 isn't mis-read at step 0.
- RenderLoom section labels shortened (`RENDERS`, `CALLBACK`).
- Meteor-leak snippet rewritten to make the retention path (`link`) explicit rather than using a misleading `unused` variable name. Mechanism unchanged.
- Multiple microcopy fixes (`slot` jargon before defined, double-hedge removed, apostrophe typo fixed).

**Deferred (noted for follow-up):**
- Shared `<CodeBlock>` component for the four hand-rolled `<pre>` blocks — every post replicates this; worth extracting once the third post ships. Skipping this pass.

## Validation highlights (`research/the-function-that-remembered/validation.md`)

All 5 Phase H checks pass:
- Every factual claim traces to a cited source.
- All 4 JS snippets ran locally — `5 5 5 5 5`, `0 1 2 3 4`, `readX() === 42`, `add5(2) === 7`, `add10(2) === 12`.
- No `<div onClick>` anywhere; real buttons + range inputs; aria-labels on all interactive SVGs.
- `prefers-reduced-motion` honored globally; every widget's end state is the teaching state.
- `pnpm build` clean; `/posts/the-function-that-remembered` is a static route.

## Test plan

- [ ] Click through the post on the Vercel preview URL
- [ ] LoopTrap: flip `var` ↔ `let`, confirm cells crossfade and console output matches each mode
- [ ] TetherScope: step through all 4 steps; confirm slot-dot grows when tether binds and frame reads `PINNED` at step 3
- [ ] RenderLoom: play through ticks in `count + 1` mode (screen sticks at 1); flip to `c => c + 1` and confirm tether fades, counter advances
- [ ] Keyboard-only walk: Tab through the widget controls, confirm focus rings visible, arrow keys advance steppers
- [ ] Toggle theme dark ↔ light, confirm terracotta reads correctly on both
- [ ] Check Lighthouse on preview — target ≥ 95 perf/a11y/SEO

🤖 Generated with [Claude Code](https://claude.com/claude-code)