### PR TITLE
phases 3–4 deferred: dot SSR + RJ flip + RC cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -226,6 +226,45 @@ body {
   }
 }
 
+/* RequestClassifier — below --flip-narrow each control surface becomes a
+   small bordered card with its label as a caption on top, so each option
+   group reads as a discrete Q/A pane instead of an inline label + chips
+   row. Wide keeps the side-by-side label + options layout. */
+@container widget (max-width: 560px) {
+  .bs-classifier-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-2xs);
+    padding: var(--spacing-sm);
+    border: 1px solid var(--color-rule);
+    border-radius: var(--radius-md);
+  }
+  .bs-classifier-label {
+    min-width: 0;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+    font-size: var(--text-small);
+  }
+}
+
+/* RequestJourney — orientation flip. Wide (≥ --flip-wide) keeps the
+   conventional sequence-diagram layout with actors as columns. Below the
+   flip point we swap to horizontal lifelines (actors as rows, time flowing
+   left-to-right) so long message labels like "GET /me · Origin: …" have
+   room to breathe instead of being scaled into illegibility. Both SVGs
+   render in SSR; the container query picks which one to show. */
+.bs-rj-narrow {
+  display: none;
+}
+@container widget (max-width: 640px) {
+  .bs-rj-wide {
+    display: none;
+  }
+  .bs-rj-narrow {
+    display: block;
+  }
+}
+
 @keyframes ring-pulse {
   0% {
     box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-accent) 35%, transparent);

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -112,11 +112,11 @@ export function RequestClassifier({
             disabledHint={ctDisabled ? "(no body on this method)" : undefined}
           />
           <div
-            className="flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+            className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
             style={{ fontSize: "var(--text-ui)" }}
           >
             <span
-              className="font-mono"
+              className="bs-classifier-label font-mono"
               style={{
                 color: "var(--color-text-muted)",
                 minWidth: "12ch",
@@ -124,16 +124,18 @@ export function RequestClassifier({
             >
               headers
             </span>
-            <Toggle
-              label="Authorization"
-              pressed={auth}
-              onToggle={() => setAuth((v) => !v)}
-            />
-            <Toggle
-              label="X-Custom"
-              pressed={custom}
-              onToggle={() => setCustom((v) => !v)}
-            />
+            <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
+              <Toggle
+                label="Authorization"
+                pressed={auth}
+                onToggle={() => setAuth((v) => !v)}
+              />
+              <Toggle
+                label="X-Custom"
+                pressed={custom}
+                onToggle={() => setCustom((v) => !v)}
+              />
+            </div>
           </div>
         </div>
 
@@ -283,11 +285,11 @@ function SegmentedRow<T extends string>({
 }) {
   return (
     <div
-      className="flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+      className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
       style={{ fontSize: "var(--text-ui)" }}
     >
       <span
-        className="font-mono"
+        className="bs-classifier-label font-mono"
         style={{
           color: "var(--color-text-muted)",
           minWidth: "12ch",
@@ -298,7 +300,7 @@ function SegmentedRow<T extends string>({
       <div
         role="radiogroup"
         aria-label={label}
-        className="flex items-center gap-[var(--spacing-2xs)] flex-wrap"
+        className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap"
         style={{ opacity: disabled ? 0.5 : 1 }}
       >
         {options.map((opt) => {

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -55,16 +55,19 @@ const STEPS: Step[] = [
 
 const LANE_LABELS = ["JS", "browser", "network", "server"] as const;
 
+type Actor = 0 | 1 | 2 | 3;
+
 type Message = {
   /** Earliest step at which this message is visible. */
   from: number;
-  /** Step at which this message becomes "past" (dimmed). */
-  through?: number;
   /** Lifelines: 0 = JS, 1 = browser, 2 = network, 3 = server */
-  fromCol: 0 | 1 | 2 | 3;
-  toCol: 0 | 1 | 2 | 3;
+  fromCol: Actor;
+  toCol: Actor;
+  /** Row offset (in wide layout). In narrow layout the message's x is
+   *  derived from its `from` step. */
   y: number;
   label: string;
+  shortLabel?: string;
   tone?: "default" | "accent" | "muted";
 };
 
@@ -82,23 +85,14 @@ export function RequestJourney({
 
   const current = STEPS[Math.min(step, STEPS.length - 1)];
 
-  const WIDTH = 820;
-  const HEIGHT = 380;
-  const LEFT_PAD = 64;
-  const RIGHT_PAD = 32;
-  const TOP = 40;
-  const BOT = 260;
-  const COLS = 4;
-  const colX = (i: number) =>
-    LEFT_PAD + (i * (WIDTH - LEFT_PAD - RIGHT_PAD)) / (COLS - 1);
-
-  const messages: Message[] = [
+  const buildMessages = (TOP: number): Message[] => [
     {
       from: 1,
       fromCol: 0,
       toCol: 1,
       y: TOP + 22,
       label: "fetch(url)",
+      shortLabel: "fetch",
     },
     {
       from: 2,
@@ -106,6 +100,7 @@ export function RequestJourney({
       toCol: 3,
       y: TOP + 62,
       label: "GET /me · Origin: app.example.com",
+      shortLabel: "GET /me",
     },
     {
       from: 3,
@@ -113,6 +108,7 @@ export function RequestJourney({
       toCol: 3,
       y: TOP + 102,
       label: "handler runs",
+      shortLabel: "handler",
       tone: "muted",
     },
     {
@@ -121,6 +117,7 @@ export function RequestJourney({
       toCol: 1,
       y: TOP + 142,
       label: "200 OK · body",
+      shortLabel: "200 OK",
     },
     {
       from: 5,
@@ -128,7 +125,8 @@ export function RequestJourney({
       toCol: 0,
       y: TOP + 200,
       label: allow ? "resolve(Response)" : "TypeError",
-      tone: allow ? "accent" : "accent",
+      shortLabel: allow ? "resolve" : "TypeError",
+      tone: "accent",
     },
   ];
 
@@ -158,251 +156,565 @@ export function RequestJourney({
         </div>
       }
     >
-      <svg
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        width="100%"
-        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
-        role="img"
-        aria-label={`Request journey step ${step + 1}: ${current.label}`}
+      {/* Two orientations rendered; CSS container query picks which shows.
+          Pure-CSS flip so there's no hydration mismatch and no JS work
+          beyond the existing state changes. */}
+      <div className="bs-rj-wide">
+        <WideJourney
+          step={step}
+          allow={allow}
+          current={current}
+          messages={buildMessages(40)}
+        />
+      </div>
+      <div className="bs-rj-narrow">
+        <NarrowJourney
+          step={step}
+          allow={allow}
+          current={current}
+          messages={buildMessages(40)}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                 Wide layout                                */
+/* -------------------------------------------------------------------------- */
+
+function WideJourney({
+  step,
+  allow,
+  current,
+  messages,
+}: {
+  step: number;
+  allow: boolean;
+  current: Step;
+  messages: Message[];
+}) {
+  const WIDTH = 820;
+  const HEIGHT = 380;
+  const LEFT_PAD = 64;
+  const RIGHT_PAD = 32;
+  const TOP = 40;
+  const BOT = 260;
+  const COLS = 4;
+  const colX = (i: number) =>
+    LEFT_PAD + (i * (WIDTH - LEFT_PAD - RIGHT_PAD)) / (COLS - 1);
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`Request journey step ${step + 1}: ${current.label}`}
+    >
+      <defs>
+        <marker
+          id="arrow-default"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
+        </marker>
+        <marker
+          id="arrow-accent"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
+        </marker>
+      </defs>
+
+      {/* Lifelines */}
+      {LANE_LABELS.map((lane, i) => (
+        <g key={lane}>
+          <text
+            x={colX(i)}
+            y={TOP - 12}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={13}
+            fill="var(--color-text-muted)"
+            fontWeight={500}
+          >
+            {lane}
+          </text>
+          <line
+            x1={colX(i)}
+            x2={colX(i)}
+            y1={TOP}
+            y2={BOT}
+            stroke="var(--color-rule)"
+            strokeWidth={1}
+            strokeDasharray="3 4"
+          />
+        </g>
+      ))}
+
+      {/* Gate */}
+      <motion.rect
+        x={colX(0) - 12}
+        y={TOP + 180}
+        width={colX(1) - colX(0) + 24}
+        height={36}
+        rx={3}
+        fill={
+          step >= 5
+            ? allow
+              ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+              : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+            : "transparent"
+        }
+        stroke={step >= 5 ? "var(--color-accent)" : "var(--color-rule)"}
+        strokeWidth={step >= 5 ? 1.5 : 1}
+        strokeDasharray={step >= 5 ? undefined : "4 3"}
+        initial={false}
+        animate={{ opacity: step >= 4 ? 1 : 0.35 }}
+        transition={SPRING.smooth}
+      />
+      <text
+        x={(colX(0) + colX(1)) / 2}
+        y={TOP + 176}
+        textAnchor="middle"
+        fontFamily="var(--font-mono)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
       >
-        <defs>
-          <marker
-            id="arrow-default"
-            viewBox="0 0 10 10"
-            refX="9"
-            refY="5"
-            markerWidth="6"
-            markerHeight="6"
-            orient="auto-start-reverse"
-          >
-            <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
-          </marker>
-          <marker
-            id="arrow-accent"
-            viewBox="0 0 10 10"
-            refX="9"
-            refY="5"
-            markerWidth="6"
-            markerHeight="6"
-            orient="auto-start-reverse"
-          >
-            <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
-          </marker>
-        </defs>
+        browser ↔ JS boundary
+      </text>
 
-        {/* Lifelines */}
-        {LANE_LABELS.map((lane, i) => (
-          <g key={lane}>
-            <text
-              x={colX(i)}
-              y={TOP - 12}
-              textAnchor="middle"
-              fontFamily="var(--font-sans)"
-              fontSize={13}
-              fill="var(--color-text-muted)"
-              fontWeight={500}
-            >
-              {lane}
-            </text>
-            <line
-              x1={colX(i)}
-              x2={colX(i)}
-              y1={TOP}
-              y2={BOT}
-              stroke="var(--color-rule)"
-              strokeWidth={1}
-              strokeDasharray="3 4"
-            />
-          </g>
-        ))}
+      {/* Messages */}
+      {messages.map((m, idx) => {
+        const visible = step >= m.from;
+        const isCurrent = step === m.from;
+        const past = step > m.from;
+        const x1 = colX(m.fromCol);
+        const x2 = colX(m.toCol);
+        const isSelf = m.fromCol === m.toCol;
 
-        {/* The "gate" — visually mark the browser/JS seam at the decision step */}
-        <motion.rect
-          x={colX(0) - 12}
-          y={TOP + 180}
-          width={colX(1) - colX(0) + 24}
-          height={36}
+        const tone =
+          m.tone === "accent"
+            ? "var(--color-accent)"
+            : m.tone === "muted"
+              ? "var(--color-text-muted)"
+              : isCurrent
+                ? "var(--color-accent)"
+                : "var(--color-text-muted)";
+        const stroke = tone;
+        const textFill =
+          m.tone === "accent"
+            ? "var(--color-accent)"
+            : isCurrent
+              ? "var(--color-text)"
+              : "var(--color-text-muted)";
+
+        const arrowMarker =
+          m.tone === "accent" ? "url(#arrow-accent)" : "url(#arrow-default)";
+
+        return (
+          <motion.g
+            key={`m-${idx}`}
+            initial={false}
+            animate={{ opacity: visible ? (isCurrent ? 1 : past ? 0.55 : 0) : 0 }}
+            transition={SPRING.smooth}
+          >
+            {isSelf ? (
+              <>
+                <path
+                  d={`M ${x1 + 4} ${m.y} q 28 0 28 16 q 0 16 -28 16`}
+                  fill="none"
+                  stroke={stroke}
+                  strokeWidth={isCurrent ? 1.6 : 1}
+                  markerEnd={arrowMarker}
+                />
+                <text
+                  x={x1 + 40}
+                  y={m.y + 20}
+                  fontFamily="var(--font-mono)"
+                  fontSize={12}
+                  fill={textFill}
+                >
+                  {m.label}
+                </text>
+              </>
+            ) : (
+              <>
+                <line
+                  x1={x1}
+                  x2={x2}
+                  y1={m.y}
+                  y2={m.y}
+                  stroke={stroke}
+                  strokeWidth={isCurrent ? 1.8 : 1}
+                  markerEnd={arrowMarker}
+                />
+                <text
+                  x={(x1 + x2) / 2}
+                  y={m.y - 6}
+                  textAnchor="middle"
+                  fontFamily="var(--font-mono)"
+                  fontSize={12}
+                  fill={textFill}
+                >
+                  {m.label}
+                </text>
+              </>
+            )}
+          </motion.g>
+        );
+      })}
+
+      {/* DevTools panel */}
+      <g>
+        <rect
+          x={LEFT_PAD}
+          y={BOT + 20}
+          width={WIDTH - LEFT_PAD - RIGHT_PAD}
+          height={76}
           rx={3}
-          fill={
-            step >= 5
-              ? allow
-                ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
-              : "transparent"
-          }
-          stroke={step >= 5 ? "var(--color-accent)" : "var(--color-rule)"}
-          strokeWidth={step >= 5 ? 1.5 : 1}
-          strokeDasharray={step >= 5 ? undefined : "4 3"}
-          initial={false}
-          animate={{
-            opacity: step >= 4 ? 1 : 0.35,
-          }}
-          transition={SPRING.smooth}
+          fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
         />
         <text
-          x={(colX(0) + colX(1)) / 2}
-          y={TOP + 176}
-          textAnchor="middle"
+          x={LEFT_PAD + 12}
+          y={BOT + 36}
           fontFamily="var(--font-mono)"
           fontSize={11}
           fill="var(--color-text-muted)"
         >
-          browser ↔ JS boundary
+          DevTools
         </text>
+        <text
+          x={LEFT_PAD + 12}
+          y={BOT + 58}
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill="var(--color-text)"
+        >
+          Network
+        </text>
+        <motion.text
+          x={LEFT_PAD + 100}
+          y={BOT + 58}
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill="var(--color-text)"
+          initial={false}
+          animate={{ opacity: step >= 4 ? 1 : 0.25 }}
+          transition={SPRING.smooth}
+        >
+          GET /me · 200 OK · 142 B
+        </motion.text>
 
-        {/* Messages */}
-        {messages.map((m, idx) => {
-          const visible = step >= m.from;
-          const isCurrent = step === m.from;
-          const past = step > m.from && (m.through ? step > m.through : true);
-          const x1 = colX(m.fromCol);
-          const x2 = colX(m.toCol);
-          const isSelf = m.fromCol === m.toCol;
+        <text
+          x={LEFT_PAD + 12}
+          y={BOT + 82}
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill="var(--color-text)"
+        >
+          Console
+        </text>
+        <motion.text
+          x={LEFT_PAD + 100}
+          y={BOT + 82}
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
+          initial={false}
+          animate={{ opacity: step >= 5 ? 1 : 0.25 }}
+          transition={SPRING.smooth}
+        >
+          {allow ? "▸ Response { ok: true, … }" : "✗ TypeError: Failed to fetch"}
+        </motion.text>
+      </g>
+    </svg>
+  );
+}
 
-          const tone =
-            m.tone === "accent"
-              ? "var(--color-accent)"
-              : m.tone === "muted"
-                ? "var(--color-text-muted)"
-                : isCurrent
-                  ? "var(--color-accent)"
-                  : "var(--color-text-muted)";
-          const stroke = tone;
-          const textFill =
-            m.tone === "accent"
-              ? "var(--color-accent)"
-              : isCurrent
-                ? "var(--color-text)"
-                : past
-                  ? "var(--color-text-muted)"
-                  : "var(--color-text-muted)";
+/* -------------------------------------------------------------------------- */
+/*                               Narrow layout                                */
+/* -------------------------------------------------------------------------- */
 
-          const arrowMarker =
-            m.tone === "accent" ? "url(#arrow-accent)" : "url(#arrow-default)";
+/**
+ * Horizontal-lifelines layout for narrow containers. Actors become rows
+ * stacked vertically, time flows left-to-right, and each message is a
+ * vertical connector at its own time-step column. Long message labels —
+ * which would collide at narrow widths — are replaced by short tokens on
+ * past / future messages; the full label only shows on the current step,
+ * rendered below the timeline where it has room to breathe.
+ */
+function NarrowJourney({
+  step,
+  allow,
+  current,
+  messages,
+}: {
+  step: number;
+  allow: boolean;
+  current: Step;
+  messages: Message[];
+}) {
+  const WIDTH = 380;
+  const LEFT_PAD = 68;
+  const RIGHT_PAD = 16;
+  const TOP_PAD = 24;
+  const ROW_H = 44;
+  const ROWS = 4;
+  const LIFELINE_BOT = TOP_PAD + ROWS * ROW_H;
+  const LABEL_BAND = 56;
+  const DEVTOOLS_H = 64;
+  const HEIGHT = LIFELINE_BOT + LABEL_BAND + DEVTOOLS_H + 16;
+  const rowY = (i: number) => TOP_PAD + i * ROW_H + ROW_H / 2;
 
-          return (
-            <motion.g
-              key={`m-${idx}`}
-              initial={false}
-              animate={{
-                opacity: visible ? (isCurrent ? 1 : past ? 0.55 : 0) : 0,
-              }}
-              transition={SPRING.smooth}
-            >
-              {isSelf ? (
-                <>
-                  <path
-                    d={`M ${x1 + 4} ${m.y} q 28 0 28 16 q 0 16 -28 16`}
-                    fill="none"
-                    stroke={stroke}
-                    strokeWidth={isCurrent ? 1.6 : 1}
-                    markerEnd={arrowMarker}
-                  />
-                  <text
-                    x={x1 + 40}
-                    y={m.y + 20}
-                    fontFamily="var(--font-mono)"
-                    fontSize={12}
-                    fill={textFill}
-                  >
-                    {m.label}
-                  </text>
-                </>
-              ) : (
-                <>
-                  <line
-                    x1={x1}
-                    x2={x2}
-                    y1={m.y}
-                    y2={m.y}
-                    stroke={stroke}
-                    strokeWidth={isCurrent ? 1.8 : 1}
-                    markerEnd={arrowMarker}
-                  />
-                  <text
-                    x={(x1 + x2) / 2}
-                    y={m.y - 6}
-                    textAnchor="middle"
-                    fontFamily="var(--font-mono)"
-                    fontSize={12}
-                    fill={textFill}
-                  >
-                    {m.label}
-                  </text>
-                </>
-              )}
-            </motion.g>
-          );
-        })}
+  const timelineW = WIDTH - LEFT_PAD - RIGHT_PAD;
+  // One x-step per message.
+  const msgX = (i: number) =>
+    LEFT_PAD + 24 + (i * (timelineW - 40)) / Math.max(messages.length - 1, 1);
 
-        {/* DevTools summary panel below */}
-        <g>
-          <rect
-            x={LEFT_PAD}
-            y={BOT + 20}
-            width={WIDTH - LEFT_PAD - RIGHT_PAD}
-            height={76}
-            rx={3}
-            fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
-            stroke="var(--color-rule)"
-            strokeWidth={1}
-          />
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`Request journey step ${step + 1}: ${current.label}`}
+    >
+      <defs>
+        <marker
+          id="arrow-default-n"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
+        </marker>
+        <marker
+          id="arrow-accent-n"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
+        </marker>
+      </defs>
+
+      {/* Actor rows: label on left + horizontal dashed lifeline */}
+      {LANE_LABELS.map((lane, i) => (
+        <g key={lane}>
           <text
-            x={LEFT_PAD + 12}
-            y={BOT + 36}
-            fontFamily="var(--font-mono)"
-            fontSize={11}
+            x={LEFT_PAD - 10}
+            y={rowY(i)}
+            textAnchor="end"
+            dominantBaseline="central"
+            fontFamily="var(--font-sans)"
+            fontSize={12}
+            fontWeight={500}
             fill="var(--color-text-muted)"
           >
-            DevTools
+            {lane}
           </text>
-          <text
-            x={LEFT_PAD + 12}
-            y={BOT + 58}
-            fontFamily="var(--font-mono)"
-            fontSize={12}
-            fill="var(--color-text)"
-          >
-            Network
-          </text>
-          <motion.text
-            x={LEFT_PAD + 100}
-            y={BOT + 58}
-            fontFamily="var(--font-mono)"
-            fontSize={12}
-            fill="var(--color-text)"
-            initial={false}
-            animate={{ opacity: step >= 4 ? 1 : 0.25 }}
-            transition={SPRING.smooth}
-          >
-            GET /me · 200 OK · 142 B
-          </motion.text>
-
-          <text
-            x={LEFT_PAD + 12}
-            y={BOT + 82}
-            fontFamily="var(--font-mono)"
-            fontSize={12}
-            fill="var(--color-text)"
-          >
-            Console
-          </text>
-          <motion.text
-            x={LEFT_PAD + 100}
-            y={BOT + 82}
-            fontFamily="var(--font-mono)"
-            fontSize={12}
-            fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
-            initial={false}
-            animate={{ opacity: step >= 5 ? 1 : 0.25 }}
-            transition={SPRING.smooth}
-          >
-            {allow
-              ? "▸ Response { ok: true, … }"
-              : "✗ TypeError: Failed to fetch"}
-          </motion.text>
+          <line
+            x1={LEFT_PAD}
+            x2={WIDTH - RIGHT_PAD}
+            y1={rowY(i)}
+            y2={rowY(i)}
+            stroke="var(--color-rule)"
+            strokeWidth={1}
+            strokeDasharray="3 4"
+          />
         </g>
-      </svg>
-    </WidgetShell>
+      ))}
+
+      {/* Time axis label */}
+      <text
+        x={LEFT_PAD}
+        y={TOP_PAD - 8}
+        fontFamily="var(--font-sans)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        time →
+      </text>
+
+      {/* Browser ↔ JS boundary: highlighted band between rows 0 and 1 at the
+          last message's x position when the request reaches the decide step. */}
+      {(() => {
+        const lastX = msgX(messages.length - 1);
+        const gateActive = step >= 5;
+        const y0 = rowY(0);
+        const y1 = rowY(1);
+        return (
+          <motion.g
+            initial={false}
+            animate={{ opacity: step >= 4 ? 1 : 0.3 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={lastX - 22}
+              y={y0 - 8}
+              width={44}
+              height={y1 - y0 + 16}
+              rx={3}
+              fill={
+                gateActive
+                  ? allow
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                  : "transparent"
+              }
+              stroke={gateActive ? "var(--color-accent)" : "var(--color-rule)"}
+              strokeWidth={gateActive ? 1.4 : 1}
+              strokeDasharray={gateActive ? undefined : "3 3"}
+            />
+          </motion.g>
+        );
+      })()}
+
+      {/* Messages as vertical arrows at their time-step column */}
+      {messages.map((m, idx) => {
+        const x = msgX(idx);
+        const visible = step >= m.from;
+        const isCurrent = step === m.from;
+        const past = step > m.from;
+
+        const tone =
+          m.tone === "accent"
+            ? "var(--color-accent)"
+            : m.tone === "muted"
+              ? "var(--color-text-muted)"
+              : isCurrent
+                ? "var(--color-accent)"
+                : "var(--color-text-muted)";
+        const arrowMarker =
+          m.tone === "accent" ? "url(#arrow-accent-n)" : "url(#arrow-default-n)";
+        const token = m.shortLabel ?? m.label;
+        const isSelf = m.fromCol === m.toCol;
+
+        return (
+          <motion.g
+            key={`nm-${idx}`}
+            initial={false}
+            animate={{ opacity: visible ? (isCurrent ? 1 : past ? 0.6 : 0) : 0 }}
+            transition={SPRING.smooth}
+          >
+            {isSelf ? (
+              <path
+                d={`M ${x - 2} ${rowY(m.fromCol) - 10}
+                    q -14 0 -14 10
+                    q 0 10 14 10`}
+                fill="none"
+                stroke={tone}
+                strokeWidth={isCurrent ? 1.6 : 1}
+                markerEnd={arrowMarker}
+              />
+            ) : (
+              <line
+                x1={x}
+                x2={x}
+                y1={rowY(m.fromCol)}
+                y2={rowY(m.toCol)}
+                stroke={tone}
+                strokeWidth={isCurrent ? 1.8 : 1}
+                markerEnd={arrowMarker}
+              />
+            )}
+            {/* Short token above the topmost point of the arrow */}
+            <text
+              x={x}
+              y={Math.min(rowY(m.fromCol), rowY(m.toCol)) - 6}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={9}
+              fill={isCurrent ? "var(--color-text)" : "var(--color-text-muted)"}
+            >
+              {token}
+            </text>
+          </motion.g>
+        );
+      })}
+
+      {/* Full current-message label — below the lifelines where it has room */}
+      <motion.text
+        key={`narrow-label-${step}-${allow ? "a" : "b"}`}
+        x={WIDTH / 2}
+        y={LIFELINE_BOT + 22}
+        textAnchor="middle"
+        fontFamily="var(--font-mono)"
+        fontSize={12}
+        fill="var(--color-text)"
+        initial={{ opacity: 0, y: LIFELINE_BOT + 28 }}
+        animate={{ opacity: 1, y: LIFELINE_BOT + 22 }}
+        transition={SPRING.smooth}
+      >
+        {messages[Math.min(step, messages.length - 1)]?.label ?? ""}
+      </motion.text>
+
+      {/* Compact DevTools panel */}
+      <g>
+        <rect
+          x={LEFT_PAD}
+          y={HEIGHT - DEVTOOLS_H - 4}
+          width={WIDTH - LEFT_PAD - RIGHT_PAD}
+          height={DEVTOOLS_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={LEFT_PAD + 8}
+          y={HEIGHT - DEVTOOLS_H + 12}
+          fontFamily="var(--font-mono)"
+          fontSize={10}
+          fill="var(--color-text-muted)"
+        >
+          DevTools
+        </text>
+        <motion.text
+          x={LEFT_PAD + 8}
+          y={HEIGHT - DEVTOOLS_H + 30}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text)"
+          initial={false}
+          animate={{ opacity: step >= 4 ? 1 : 0.25 }}
+          transition={SPRING.smooth}
+        >
+          Net · 200 OK · 142 B
+        </motion.text>
+        <motion.text
+          x={LEFT_PAD + 8}
+          y={HEIGHT - DEVTOOLS_H + 48}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
+          initial={false}
+          animate={{ opacity: step >= 5 ? 1 : 0.25 }}
+          transition={SPRING.smooth}
+        >
+          {allow ? "▸ Response {…}" : "✗ TypeError"}
+        </motion.text>
+      </g>
+    </svg>
   );
 }

--- a/components/viz/WidgetShell.tsx
+++ b/components/viz/WidgetShell.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { AnimatePresence, motion } from "motion/react";
 import { FullBleed } from "@/components/prose";
-import type { ReactNode } from "react";
+import { SPRING } from "@/lib/motion";
 
 type Props = {
   title: string;
@@ -12,14 +16,20 @@ type Props = {
 /**
  * WidgetShell — the canonical skeleton for every bytesize widget. DESIGN.md §7:
  * <FullBleed><Figure><Header><Canvas><Controls></Figure></FullBleed>.
- * Measurements top-right in Plex Mono tabular-nums. Controls below canvas,
- * left-aligned. Optional caption below controls, Plex Sans --text-small muted.
  *
  * The outer wrapper declares `container-type: inline-size` so nested widgets
  * can drive orientation flips via `@container` queries against the two
  * canonical breakpoints in globals.css (--flip-narrow, --flip-wide).
+ *
+ * SSR renders a single 6×6 terracotta dot centred in the canvas area. On
+ * hydration the dot fades out and the real interactive canvas fades in with
+ * SPRING.smooth — consistent brand grammar across all 13 widgets, in place
+ * of ad-hoc spinners or skeleton shimmer.
  */
 export function WidgetShell({ title, measurements, caption, controls, children }: Props) {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+
   return (
     <FullBleed>
       <div className="bs-widget-container">
@@ -45,12 +55,38 @@ export function WidgetShell({ title, measurements, caption, controls, children }
         </div>
 
         <div
-          className="rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
+          className="relative rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
           style={{
             background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
           }}
         >
-          {children}
+          <AnimatePresence initial={false} mode="wait">
+            {hydrated ? (
+              <motion.div
+                key="canvas"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.smooth}
+              >
+                {children}
+              </motion.div>
+            ) : (
+              <motion.div
+                key="dot"
+                className="flex min-h-[120px] items-center justify-center"
+                initial={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.smooth}
+                aria-hidden
+              >
+                <span
+                  className="block h-[6px] w-[6px]"
+                  style={{ background: "var(--color-accent)" }}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
 
         {controls ? <div className="pt-[var(--spacing-sm)]">{controls}</div> : null}


### PR DESCRIPTION
Stacks on top of #15. Base = \`mobile-first-phases-3-4\` so this merges into that PR first, then travels with it into \`main\`.

Covers the three items #15 explicitly flagged as deferred.

## 1. Terracotta-dot SSR loading state

\`WidgetShell\` is now a client component. SSR renders a single 6×6 terracotta square centred in the canvas container. On hydration the dot fades out and the real widget fades in with \`SPRING.smooth\` — consistent brand grammar across all 13 widgets, no spinners or skeleton shimmer.

**Why gate only the canvas, not the controls:** the shell's title, measurements, controls, and caption keep rendering on SSR, so crawlers still get meaningful copy. Only the SVG / table / interactive canvas is the signature dot.

## 2. RequestJourney orientation flip

Two SVG layouts render together; a container query against \`--flip-wide\` (640 px) hides one.

- **Wide:** conventional sequence-diagram layout, actors as columns, time flowing top-to-bottom. Unchanged from before.
- **Narrow:** horizontal lifelines — actors become rows stacked vertically, time flows left-to-right. Each message is a vertical connector at its own time-step column. Past and future messages render short-label tokens (\`fetch\`, \`GET /me\`, \`200 OK\`…) along the timeline; the full label for the current step anchors below the lifelines where it has room to breathe. Browser↔JS gate and a compact DevTools panel carry over.

Pure-CSS toggle via \`@container\`: no hydration mismatch, no ResizeObserver, no JS layout work beyond the existing step state. The narrow SVG is ~380 × ~330 units, fitting comfortably at 360 vw.

## 3. RequestClassifier stacked cards

Below \`--flip-narrow\` (560 px), each control row (\`.bs-classifier-row\`: method, Content-Type, headers) becomes a bordered card with its label as a caption on top and options flowing below. Caption styling (letterspacing + small caps) differentiates it from body text. Wide-container layout unchanged.

## Test plan
- [ ] All three post pages render without errors at 320 / 360 / 412 / 768 / 1024.
- [ ] Widget canvases briefly show the terracotta dot on first paint, then fade to their real content. No hydration-mismatch warnings in the browser console.
- [ ] Resize \`why-fetch-fails-only-in-browser\` from desktop down to phone: RequestJourney flips to horizontal-lifeline mode without layout thrash as the viewport crosses ~640 px.
- [ ] On narrow, stepping through the RequestJourney keeps the current-step label legible below the lifelines; past tokens remain visible but dimmed.
- [ ] RequestClassifier at narrow widths: each control row is a bordered card with its label on top; wide container restores side-by-side.
- [ ] \`prefers-reduced-motion: reduce\`: dot → canvas swap is instant; no fade animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)