### PR TITLE
mobile-first · phases 5–6 — polish + DESIGN.md sync

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -62,6 +62,8 @@
   - paragraph → widget: `margin-block: 2em`
   - section ornament: `margin-block: 3.5em`
 - **No TOC**, **no reading-progress bar** for MVP.
+- **Breakpoints**: `sm` 480 px, `md` 768 px, `lg` 1024 px (registered as `--breakpoint-*` in `@theme`). No `xl` / `2xl`. Breakpoints are authored mobile-first — everything assumes a 360 px phone until a named tier relaxes upward.
+- **Home two-column**: activates at `lg:` (1024 px), not `md:`. At 768 px with a 320 px sidebar the PostList body cell collapses to ~400 px, which starves the 4-column row. Tablet-portrait (~810 px) is explicitly single-column with PostList at full width.
 
 ## 3. Tokens (OKLCH, 4pt spacing, semantic aliases)
 
@@ -70,6 +72,10 @@ All color in OKLCH — perceptually uniform. Foundation palette + semantic alias
 Full canonical values live in [`app/globals.css`](./app/globals.css). Editing tokens there must update this doc.
 
 Spacing scale uses semantic names (`--spacing-sm`, `--spacing-md`), never pixel-named tokens.
+
+**Fluid spacing**: `--spacing-md` through `--spacing-3xl` are fluid via `clamp()`; `--spacing-3xs` through `--spacing-sm` remain literal pixel values. Adjacent tokens stay ≥ 6 px apart at 360 vw so the rhythm holds at phone widths.
+
+**Widget container-query tokens**: `--flip-narrow: 560px` and `--flip-wide: 640px` are the two canonical flip points consumed by `@container widget (…)` rules across every widget. `--widget-width: min(100%, 900px)` is the single source of truth for widget-canvas width.
 
 ## 4. Type ramp (Plex family, 1.25 ratio)
 
@@ -84,6 +90,8 @@ Spacing scale uses semantic names (`--spacing-sm`, `--spacing-md`), never pixel-
 | `--text-small` | `0.8125rem`                          | Plex Sans  | 0em      | 1.4         |
 
 Body is **Plex Serif at 18px, 1.7 line-height** — this is the load-bearing choice for editorial-calm.
+
+**Weight subset (Path B-lite):** Plex Serif 400/500/600 + 400 italic, Plex Sans 400/500/600, Plex Mono 400/500. Weight 700 is not rendered anywhere in the current UI; the heaviest used weight is 600 (`font-semibold`). Proper Path A (self-hosted variable fonts) is deferred to a follow-up phase once VF glyph coverage is verified against the content corpus.
 
 ## 5. Prose components (explicit, typed, semantic HTML)
 
@@ -139,9 +147,12 @@ Every custom widget follows this skeleton. This is what "uniform UI" means.
 - **Canvas** has no visible border. If a background is needed, `--color-surface` at 40%.
 - **Measurement labels**: top-right of header, Plex Mono tabular-nums, `--text-small`, separated by `·`.
 - **Step buttons**: Plex Sans `--text-ui`, weight 500, `8px 16px` padding, `--radius-sm`, hover text → `--color-accent`.
-- **Sliders**: native `<input type="range">` styled — thumb is a 14px terracotta square.
+- **Sliders**: native `<input type="range">` styled — thumb visual is 14 px terracotta square. **Hit target is 44 × 44 px** via transparent `padding` + `background-clip: content-box` on the thumb pseudo-element; the visible square stays 14 px while the draggable region grows to meet the WCAG 44-px minimum.
 - **Focus rings**: 2px solid `--color-accent`, 2px offset. Never removed.
 - **"State set" color**: always `--color-accent`. Readers learn `terracotta = the algorithm is doing something here.`
+- **Press identity**: every interactive surface gets `PRESS` feedback (`whileTap: { scale: 0.96 }` + `SPRING.snappy`). High-frequency controls (Stepper prev/next, subscribe CTA) add a `.bs-press` ring pulse ≤ 300 ms on commit. Consistent across buttons, toggles, links — so the site speaks one tactile language.
+- **Hydration canvas**: every widget SSR-renders a single 6 × 6 terracotta square centred in its canvas container; the real interactive surface fades in on hydrate with `SPRING.smooth`. No spinners, no skeleton shimmer — the dot is the loading state.
+- **Orientation flips**: widgets drive layout via `@container widget (…)` queries against `--flip-narrow` / `--flip-wide`, not global viewport breakpoints, so a widget embedded in a narrow column flips for its container rather than waiting for the viewport.
 
 ## 8. Home page (hatched-page two-column, nan.fyi-inspired)
 
@@ -185,6 +196,9 @@ Home splits into two columns at ≥ 768px:
 - **Height transitions**: `grid-template-rows: 0fr → 1fr`, not `max-height`.
 - **`prefers-reduced-motion`**: all durations drop to `0.01ms`. Widgets must still function without motion.
 - **Stagger**: 60ms between siblings.
+- **Page transitions**: route changes use the View Transitions API (`@view-transition { navigation: auto }`). Root fade is 280 ms opacity + 8 px y. Shared-element morphs (PostList cover → post hero tile) ride the same transition via `view-transition-name: cover-{slug}` pairs. Unsupported browsers (Firefox) fall through to instant navigation — no feature detection needed. Under `prefers-reduced-motion: reduce` the animation duration collapses to 1 ms.
+- **Theme morph**: dark ↔ light toggles animate color / background-color / border-color over 240 ms via a zero-specificity `:where()` transition. During the morph the accent desaturates through `--color-text-muted` (the `accent-bridge` keyframe) so terracotta becomes the "still point" of the whole-page color flip. The `data-theme-transitioning` attribute is set synchronously in the toggle handler — `useEffect` arrives one render too late.
+- **Transient press-pulses** (`.bs-press` ring, ≤ 300 ms) are the one permitted exception to the §12 drop-shadow ban. They are gesture feedback keyed to a tap, not decoration; static decorative box-shadows remain banned.
 
 ## 10. Distinctive moves (why this isn't generic)
 
@@ -202,6 +216,8 @@ Home splits into two columns at ≥ 768px:
 - Animations respect `prefers-reduced-motion`.
 - Semantic tags: `<dfn>`, `<kbd>`, `<code>`, `<time>`.
 - Information conveyed via color must also be conveyed via shape/position/label.
+- **Minimum tap target 44 × 44 CSS px** on every interactive element (WCAG 2.5.5). Expand with transparent padding + negative margin where the visible glyph is smaller.
+- **Hover is opt-in**: hover-only styling (underline saturation, color shifts) is gated behind `@media (hover: hover)` so touch devices don't inherit stuck-hover state after tap-release.
 
 ## 12. Absolute bans
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -198,6 +198,89 @@ body {
    DESIGN.md sync adds an explicit §9 carve-out for gesture feedback.
 --------------------------------------------------------------------------- */
 /* ---------------------------------------------------------------------------
+   View Transitions API — cross-document root transition for client-side
+   navigations. Vertical fade (8px enter, -8px exit) over 280ms. Unsupported
+   browsers (Firefox today) fall through to instant navigation; no feature
+   detection needed.
+
+   Shared-element morphs (cover tile ↔ hero tile) ride the same transition
+   via `view-transition-name: cover-{slug}` pairs set by PostList and each
+   post's hero tile.
+--------------------------------------------------------------------------- */
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 280ms;
+  animation-timing-function: var(--ease-out);
+}
+::view-transition-old(root) {
+  animation-name: vt-fade-out-y;
+}
+::view-transition-new(root) {
+  animation-name: vt-fade-in-y;
+}
+
+@keyframes vt-fade-in-y {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+@keyframes vt-fade-out-y {
+  to {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 1ms;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Theme morph — terracotta-as-bridge. Dark ↔ light toggles animate color,
+   background-color, and border-color over 240 ms. During the transition the
+   accent desaturates through the muted-text mid-point, so the terracotta
+   becomes the "still point" of the whole page's color flip. Scoped via
+   `:where()` so the 0-specificity doesn't interfere with any component's
+   own transitions.
+--------------------------------------------------------------------------- */
+:where(html, body, *) {
+  transition:
+    color 240ms var(--ease-out),
+    background-color 240ms var(--ease-out),
+    border-color 240ms var(--ease-out);
+}
+
+@keyframes accent-bridge {
+  50% {
+    --color-accent: color-mix(
+      in oklab,
+      var(--color-accent) 50%,
+      var(--color-text-muted)
+    );
+  }
+}
+html[data-theme-transitioning] {
+  animation: accent-bridge 240ms var(--ease-out);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(html, body, *) {
+    transition: none;
+  }
+  html[data-theme-transitioning] {
+    animation: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
    Prose link hover — gated behind (hover: hover) so touch devices don't get
    stuck in the saturated state after tap-release.
 --------------------------------------------------------------------------- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,10 +14,15 @@ import {
   SITE_URL,
 } from "@/lib/site";
 
+// Path B-lite: pre-flight grep found no `font-bold` / fontWeight 700 usage
+// (600 is the heaviest actually rendered weight via `font-semibold`), so we
+// drop 700 from both subsets. 14 font files → 11. Proper Path A (self-hosted
+// variable fonts) is deferred to Phase 7 once VF glyph coverage is verified
+// against the content corpus.
 const plexSerif = IBM_Plex_Serif({
   variable: "--font-plex-serif",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["400", "500", "600"],
   style: ["normal", "italic"],
   display: "swap",
 });
@@ -25,7 +30,7 @@ const plexSerif = IBM_Plex_Serif({
 const plexSans = IBM_Plex_Sans({
   variable: "--font-plex-sans",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["400", "500", "600"],
   display: "swap",
 });
 
@@ -78,7 +83,6 @@ export default function RootLayout({
           attribute="data-theme"
           defaultTheme="dark"
           enableSystem
-          disableTransitionOnChange
         >
           <MotionConfigProvider>
             <CozyFrame>

--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -9,6 +9,7 @@ import {
   Em,
   Aside,
   A,
+  HeroTile,
 } from "@/components/prose";
 import {
   FlowDemo,
@@ -24,6 +25,9 @@ export default function HowGmailKnowsYourEmailIsTaken() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
+        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="how-gmail-knows-your-email-is-taken" />
+        </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
           How Gmail knows your email is taken, instantly
         </H1>

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -9,6 +9,7 @@ import {
   Em,
   Aside,
   A,
+  HeroTile,
   Term,
 } from "@/components/prose";
 import {
@@ -25,7 +26,12 @@ export default function TheFunctionThatRemembered() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <H1>The function that remembered</H1>
+        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="the-function-that-remembered" />
+        </div>
+        <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
+          The function that remembered
+        </H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"
           style={{

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -10,6 +10,7 @@ import {
   Aside,
   A,
   FullBleed,
+  HeroTile,
   Term,
 } from "@/components/prose";
 import { CodeBlock } from "@/components/code";
@@ -22,6 +23,9 @@ export default function WhyFetchFailsOnlyInBrowser() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
+        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="why-fetch-fails-only-in-browser" />
+        </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
           Why <span style={{ fontFamily: "var(--font-mono)", fontWeight: 500, letterSpacing: "-0.01em" }}>fetch</span> works in curl but the browser blocks it
         </H1>

--- a/components/motion/Reveal.tsx
+++ b/components/motion/Reveal.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+import { SPRING, STAGGER } from "@/lib/motion";
+
+type Props = {
+  children: ReactNode;
+  /** Stagger child reveals (direct Motion children) by this delay in seconds.
+   *  Pass a value from STAGGER. Omit for a single-element reveal. */
+  stagger?: number;
+  /** Additional delay before the reveal fires. */
+  delay?: number;
+  className?: string;
+};
+
+/**
+ * Reveal — the canonical "arrive on scroll-into-view" primitive. Wrap any
+ * block of content that should enter with the house spring (opacity + 12 px
+ * y offset → 0, SPRING.smooth). Fires once per viewport entry.
+ *
+ * Reduced-motion users get the final state immediately via
+ * MotionConfigProvider's global `reducedMotion="user"` setting — no
+ * per-consumer handling needed.
+ */
+export function Reveal({ children, stagger, delay = 0, className }: Props) {
+  if (stagger !== undefined) {
+    return (
+      <motion.div
+        className={className}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, margin: "0px 0px -10% 0px" }}
+        variants={{
+          hidden: {},
+          show: {
+            transition: { staggerChildren: stagger, delayChildren: delay },
+          },
+        }}
+      >
+        {children}
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 12 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "0px 0px -10% 0px" }}
+      transition={{ ...SPRING.smooth, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+/** Variant for children of a `<Reveal stagger={…}>`. */
+export const REVEAL_CHILD = {
+  hidden: { opacity: 0, y: 12 },
+  show: { opacity: 1, y: 0, transition: SPRING.smooth },
+} as const;
+
+export { STAGGER };

--- a/components/nav/AboutColumn.tsx
+++ b/components/nav/AboutColumn.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { motion } from "motion/react";
-import { PRESS } from "@/lib/motion";
+import { PRESS, SPRING } from "@/lib/motion";
+import { useFirstVisit } from "@/lib/hooks/use-first-visit";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import {
   SITE_ABOUT,
@@ -21,31 +22,62 @@ const COPYRIGHT_NOW = new Date().getFullYear();
  * carries the brand; the subscribe pill is the primary CTA; bottom row
  * holds the small meta (author/source links + copyright). Sticky on md+
  * so it stays visible while the post list scrolls.
+ *
+ * Two entry choreographies keyed on session state:
+ *   - First visit: wordmark settles with a transform-only scale+y (LCP-safe,
+ *     no opacity animation on the biggest text), paragraph reveals via a
+ *     left-to-right mask-position sweep, subscribe pill fades in last.
+ *   - Return visit: a short 60 ms stagger across the four children.
+ * Reduced-motion users collapse to the final state via MotionConfigProvider.
  */
 export function AboutColumn() {
+  const { ready, firstVisit } = useFirstVisit();
   const subscribe = useTapPulse<HTMLAnchorElement>();
   const years =
     COPYRIGHT_NOW === COPYRIGHT_START
       ? `${COPYRIGHT_START}`
       : `${COPYRIGHT_START} – ${COPYRIGHT_NOW}`;
 
+  // Before the hook resolves we render the static tree (no animation).
+  // Once ready, variants choose which choreography plays.
+  const variant = !ready ? "static" : firstVisit ? "hero" : "return";
+
   return (
     <aside className="md:sticky md:top-[var(--spacing-lg)] self-start flex flex-col min-h-0 md:min-h-[480px]">
-      {/* Giant serif wordmark — brand moment */}
-      <h1
+      {/* Giant serif wordmark — brand moment. Transform-only animation on
+          first visit so the LCP candidate paints immediately. */}
+      <motion.h1
         className="font-serif font-semibold"
         style={{
           fontSize: "clamp(3rem, 2.2rem + 3vw, 4.5rem)",
           lineHeight: 0.95,
           letterSpacing: "-0.03em",
           color: "var(--color-text)",
+          transformOrigin: "left bottom",
+        }}
+        initial={false}
+        animate={variant}
+        variants={{
+          static: { y: 0, scale: 1, opacity: 1 },
+          hero: {
+            y: [8, 0],
+            scale: [0.94, 1],
+            opacity: 1,
+            transition: { ...SPRING.dramatic, duration: 0.6 },
+          },
+          return: {
+            y: [6, 0],
+            scale: 1,
+            opacity: [0, 1],
+            transition: { ...SPRING.smooth, delay: 0 },
+          },
         }}
       >
         {SITE_NAME}
-      </h1>
+      </motion.h1>
 
-      {/* Tagline + about */}
-      <p
+      {/* Tagline + about — left-to-right mask-reveal on first visit. */}
+      <motion.p
         className="mt-[var(--spacing-lg)] font-serif"
         style={{
           fontSize: "var(--text-body)",
@@ -53,12 +85,44 @@ export function AboutColumn() {
           color: "var(--color-text-muted)",
           maxWidth: "26ch",
         }}
+        initial={false}
+        animate={variant}
+        variants={{
+          static: { opacity: 1, clipPath: "inset(0 0% 0 0)" },
+          hero: {
+            opacity: 1,
+            clipPath: ["inset(0 100% 0 0)", "inset(0 0% 0 0)"],
+            transition: { duration: 0.8, ease: [0.22, 1, 0.36, 1], delay: 0.4 },
+          },
+          return: {
+            opacity: [0, 1],
+            clipPath: "inset(0 0% 0 0)",
+            transition: { ...SPRING.smooth, delay: 0.06 },
+          },
+        }}
       >
         {SITE_ABOUT}
-      </p>
+      </motion.p>
 
       {/* Subscribe CTA — terracotta pill, primary action */}
-      <div className="mt-[var(--spacing-lg)]">
+      <motion.div
+        className="mt-[var(--spacing-lg)]"
+        initial={false}
+        animate={variant}
+        variants={{
+          static: { opacity: 1, y: 0 },
+          hero: {
+            opacity: [0, 1],
+            y: [6, 0],
+            transition: { duration: 0.24, delay: 1.0, ease: [0.22, 1, 0.36, 1] },
+          },
+          return: {
+            opacity: [0, 1],
+            y: [4, 0],
+            transition: { ...SPRING.smooth, delay: 0.12 },
+          },
+        }}
+      >
         <MotionLink
           ref={subscribe.ref}
           href="/rss.xml"
@@ -74,10 +138,26 @@ export function AboutColumn() {
         >
           subscribe
         </MotionLink>
-      </div>
+      </motion.div>
 
       {/* Bottom-left meta row — icons + copyright */}
-      <div className="mt-auto pt-[var(--spacing-2xl)] flex items-center gap-[var(--spacing-lg)] font-mono" style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}>
+      <motion.div
+        className="mt-auto pt-[var(--spacing-2xl)] flex items-center gap-[var(--spacing-lg)] font-mono"
+        style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+        initial={false}
+        animate={variant}
+        variants={{
+          static: { opacity: 1 },
+          hero: {
+            opacity: [0, 1],
+            transition: { duration: 0.3, delay: 1.2 },
+          },
+          return: {
+            opacity: [0, 1],
+            transition: { ...SPRING.smooth, delay: 0.18 },
+          },
+        }}
+      >
         <Link
           href={SITE_AUTHOR_URL}
           target="_blank"
@@ -90,7 +170,7 @@ export function AboutColumn() {
         <span className="tabular-nums" aria-label={`copyright ${years}`}>
           © {years}
         </span>
-      </div>
+      </motion.div>
     </aside>
   );
 }

--- a/components/nav/PostList.tsx
+++ b/components/nav/PostList.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { motion } from "motion/react";
 import type { PostMeta } from "@/content/posts-manifest";
 import { PRESS } from "@/lib/motion";
+import { useFirstVisit } from "@/lib/hooks/use-first-visit";
 import { MotionItem, MotionList } from "./PostListMotion";
 
 const MotionLink = motion.create(Link);
@@ -32,6 +33,12 @@ function coverSrc(p: PostMeta): string {
  * Year headings are rendered as small muted caps above their groups.
  */
 export function PostList({ posts }: { posts: PostMeta[] }) {
+  const { ready, firstVisit } = useFirstVisit();
+  // On first visit, hold the list until the hero choreography finishes
+  // (~1.2s). Return visits — and pre-hydration SSR — use the default tight
+  // stagger start. Keeping the SSR default matches the static render.
+  const delayChildren = ready && firstVisit ? 1.2 : 0.05;
+
   const groups = new Map<string, PostMeta[]>();
   for (const p of posts) {
     const year = p.date.slice(0, 4);
@@ -57,7 +64,7 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
           >
             {year}
           </h2>
-          <MotionList className="mt-[var(--spacing-sm)]">
+          <MotionList className="mt-[var(--spacing-sm)]" delayChildren={delayChildren}>
             {entries.map((p, i) => (
               <MotionItem
                 key={p.slug}
@@ -69,13 +76,16 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
                   aria-label={`${p.title} — ${p.hook}`}
                   {...PRESS}
                 >
-                  {/* Icon / thumbnail — square crop of auto-generated cover */}
+                  {/* Icon / thumbnail — square crop of auto-generated cover.
+                      `view-transition-name` pairs with the hero tile on the
+                      post page so the cover morphs between home and post. */}
                   <div
                     className="relative aspect-square h-[64px] w-[64px] lg:h-[80px] lg:w-[80px] overflow-hidden rounded-[var(--radius-sm)] transition-transform duration-[200ms] will-change-transform group-hover:-translate-y-[2px]"
                     style={{
                       background:
                         "color-mix(in oklab, var(--color-surface) 60%, transparent)",
                       border: "1px solid var(--color-rule)",
+                      viewTransitionName: `cover-${p.slug}`,
                     }}
                   >
                     <Image

--- a/components/nav/PostListMotion.tsx
+++ b/components/nav/PostListMotion.tsx
@@ -14,16 +14,16 @@ import type { ReactNode } from "react";
  * durations collapse to near-instant, no per-component handling needed.
  */
 
-const listVariants = {
+const makeListVariants = (delayChildren: number) => ({
   hidden: { opacity: 1 }, // keep the list itself visible; stagger drives children
   show: {
     opacity: 1,
     transition: {
       staggerChildren: STAGGER.tight,
-      delayChildren: 0.05,
+      delayChildren,
     },
   },
-};
+});
 
 const itemVariants = {
   hidden: { opacity: 0, y: 8 },
@@ -37,14 +37,18 @@ const itemVariants = {
 export function MotionList({
   children,
   className,
+  delayChildren = 0.05,
 }: {
   children: ReactNode;
   className?: string;
+  /** Seconds to wait before the first child fires. First-visit home
+   *  choreography passes ~1.2s so the list arrives after the hero beat. */
+  delayChildren?: number;
 }) {
   return (
     <motion.ul
       className={className}
-      variants={listVariants}
+      variants={makeListVariants(delayChildren)}
       initial="hidden"
       animate="show"
     >

--- a/components/nav/theme-toggle.tsx
+++ b/components/nav/theme-toggle.tsx
@@ -19,10 +19,22 @@ export function ThemeToggle() {
 
   const next = resolvedTheme === "dark" ? "light" : "dark";
 
+  const handleToggle = () => {
+    // Set the attribute synchronously before flipping the theme, so the
+    // accent-bridge keyframe in globals.css fires in the same frame as the
+    // color-variable swap. A useEffect watching `resolvedTheme` would arrive
+    // one render late and miss the desaturation bridge.
+    document.documentElement.setAttribute("data-theme-transitioning", "");
+    setTheme(next);
+    window.setTimeout(() => {
+      document.documentElement.removeAttribute("data-theme-transitioning");
+    }, 260);
+  };
+
   return (
     <motion.button
       type="button"
-      onClick={() => setTheme(next)}
+      onClick={handleToggle}
       aria-label={`Switch to ${next} theme`}
       className="inline-flex h-[44px] w-[44px] -m-[10px] items-center justify-center text-[color:var(--color-text-muted)] transition-colors hover:text-[color:var(--color-text)]"
       {...PRESS}

--- a/components/prose/Dots.tsx
+++ b/components/prose/Dots.tsx
@@ -1,10 +1,22 @@
+"use client";
+
+import { motion } from "motion/react";
+
+const DOT_COUNT = 20;
+
 /**
- * The section ornament. Replaces <hr> between major sections.
- * Distinctive move #1 from DESIGN.md — 20 Plex Mono "·" at 40% opacity, centered.
+ * Dots — section ornament between major blocks. Distinctive move #1 from
+ * DESIGN.md. Twenty Plex Mono "·" glyphs at 40% opacity, centred, replacing
+ * the conventional <hr>.
+ *
+ * On scroll-into-view the dots sweep in left-to-right over ~400 ms via a
+ * 20 ms child stagger (decoupled from the global STAGGER.* tokens so the
+ * sweep length reads as a single gesture rather than a stagger). Fires once
+ * per viewport entry. Reduced-motion users see every dot at once.
  */
 export function Dots() {
   return (
-    <div
+    <motion.div
       role="separator"
       aria-hidden="true"
       className="select-none text-center font-mono"
@@ -14,8 +26,26 @@ export function Dots() {
         fontSize: "var(--text-mono)",
         color: "color-mix(in oklab, var(--color-text) 40%, transparent)",
       }}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once: true, margin: "0px 0px -5% 0px" }}
+      variants={{
+        hidden: {},
+        show: { transition: { staggerChildren: 0.018 } },
+      }}
     >
-      · · · · · · · · · · · · · · · · · · · ·
-    </div>
+      {Array.from({ length: DOT_COUNT }).map((_, i) => (
+        <motion.span
+          key={i}
+          variants={{
+            hidden: { opacity: 0 },
+            show: { opacity: 1, transition: { duration: 0.24 } },
+          }}
+          style={{ display: "inline-block" }}
+        >
+          ·{i < DOT_COUNT - 1 ? "\u00a0" : ""}
+        </motion.span>
+      ))}
+    </motion.div>
   );
 }

--- a/components/prose/FullBleed.tsx
+++ b/components/prose/FullBleed.tsx
@@ -1,12 +1,29 @@
-import type { ReactNode } from "react";
+"use client";
 
+import { motion } from "motion/react";
+import type { ReactNode } from "react";
+import { SPRING } from "@/lib/motion";
+
+/**
+ * FullBleed — breaks out of the prose column to a widget-wide figure.
+ * Centering (`left: 50% + translateX(-50%)`) stays CSS-only so it can't
+ * collide with motion's transform property; the scroll-into-view reveal
+ * lives on a nested div that only drives opacity + y.
+ */
 export function FullBleed({ children }: { children: ReactNode }) {
   return (
     <figure
       className="relative left-1/2 -translate-x-1/2 my-[var(--spacing-xl)]"
       style={{ width: "min(calc(100vw - var(--spacing-lg) * 2), 900px)" }}
     >
-      {children}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "0px 0px -10% 0px" }}
+        transition={SPRING.smooth}
+      >
+        {children}
+      </motion.div>
     </figure>
   );
 }

--- a/components/prose/HeroTile.tsx
+++ b/components/prose/HeroTile.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+
+type Props = {
+  slug: string;
+  /** Optional hand-crafted cover path. Falls back to /cover/[slug]. */
+  coverImage?: string;
+  alt?: string;
+};
+
+/**
+ * HeroTile — sits at the top of each post page. Its `view-transition-name`
+ * pairs with the matching PostList cover so the thumbnail morphs into place
+ * on navigation (shared-element route transition). On supported browsers
+ * the morph is automatic; on Firefox it falls through to instant navigation
+ * and the tile simply renders in its final position.
+ *
+ * Sizing: 64×64 up to md, 80×80 from lg, matching the PostList cover
+ * dimensions so the source and destination rectangles line up.
+ */
+export function HeroTile({ slug, coverImage, alt = "" }: Props) {
+  const src = coverImage ?? `/cover/${slug}`;
+  return (
+    <div
+      className="relative aspect-square h-[64px] w-[64px] lg:h-[80px] lg:w-[80px] overflow-hidden rounded-[var(--radius-sm)]"
+      style={{
+        background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+        border: "1px solid var(--color-rule)",
+        viewTransitionName: `cover-${slug}`,
+      }}
+      aria-hidden={alt ? undefined : true}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        sizes="(min-width: 1024px) 80px, 64px"
+        className="object-cover"
+      />
+    </div>
+  );
+}

--- a/components/prose/index.ts
+++ b/components/prose/index.ts
@@ -12,3 +12,4 @@ export { Callout } from "./Callout";
 export { Aside } from "./Aside";
 export { FullBleed } from "./FullBleed";
 export { Dots } from "./Dots";
+export { HeroTile } from "./HeroTile";

--- a/lib/hooks/use-first-visit.ts
+++ b/lib/hooks/use-first-visit.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "bs-hero-seen";
+
+type State = { ready: boolean; firstVisit: boolean };
+
+// Module-level cache so multiple components reading this hook on the same
+// page agree on a single verdict even if their effects fire in different
+// orders. Without it the first component to mount would mark the session
+// as "seen" and subsequent hooks would see firstVisit=false in the same
+// render cycle — the staggered home choreography depends on all three
+// consumers (AboutColumn, PostList, Header) seeing the same flag.
+let cached: State | null = null;
+
+/**
+ * useFirstVisit — gates the home hero choreography. On the first navigation
+ * of a session, returns `firstVisit: true` once; the same session (including
+ * navigations away and back) returns `firstVisit: false` thereafter. Always
+ * starts unready on the server to avoid hydration mismatch; flips `ready`
+ * to true in the first client effect.
+ */
+export function useFirstVisit(): State {
+  const [state, setState] = useState<State>(
+    () => cached ?? { ready: false, firstVisit: false },
+  );
+
+  useEffect(() => {
+    if (cached) {
+      if (!state.ready) setState(cached);
+      return;
+    }
+    try {
+      const seen = window.sessionStorage.getItem(STORAGE_KEY);
+      cached = { ready: true, firstVisit: !seen };
+      if (!seen) window.sessionStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // Private browsing, quota, etc. — default to treating as return visit.
+      cached = { ready: true, firstVisit: false };
+    }
+    setState(cached);
+  }, [state.ready]);
+
+  return state;
+}


### PR DESCRIPTION
Part of #7. **Closes #12. Partial #13** (doc sync landed; manual device matrix + Lighthouse runs need the Vercel preview and are handed back to the user).

## Phase 5 — state-of-the-art polish

### View Transitions API
- \`@view-transition { navigation: auto }\` in globals.css.
- Root fade: 280 ms opacity + 8 px vertical translate, via \`vt-fade-in-y\` / \`vt-fade-out-y\` keyframes.
- Reduced-motion collapses duration to 1 ms.
- Unsupported browsers (Firefox today) fall through to instant navigation — no feature detection.

### Shared-element cover → hero morph
- \`view-transition-name: cover-\${slug}\` set on each PostList thumbnail.
- New \`<HeroTile>\` component at the top of every post page carries the matching name. 64 px base → 80 px from \`lg:\` so the source and destination rectangles line up and the browser can morph between them.

### Reveal primitive + FullBleed reveal
- New \`components/motion/Reveal.tsx\` — scroll-into-view opacity + 12 px y, SPRING.smooth, fires once, with an optional \`stagger\` prop for child reveals.
- FullBleed itself now reveals on entry. Horizontal centering stays on the outer figure (CSS-only \`translateX(-50%)\`) so motion's transform doesn't clobber the breakout math.

### First-visit home choreography (sessionStorage-gated)
- New \`useFirstVisit\` hook with a **module-level cache** so AboutColumn and PostList agree on the verdict even if their effects fire in different orders.
- **Wordmark**: \`scale: 0.94 → 1, y: 8 → 0\` — **transform-only**. Opacity is never animated on the LCP candidate.
- **Paragraph**: \`clip-path: inset(0 100% 0 0) → inset(0 0 0 0)\` — left-to-right mask reveal over 800 ms. Length-agnostic.
- **Subscribe pill + meta row**: fade + 6 px lift at 1.0 s and 1.2 s respectively.
- **PostList**: \`delayChildren: 1.2 s\` on first visit, \`0.05 s\` on return visits.
- Return visits play a short 60 ms cadence across the AboutColumn children — no hero, no delay.

### Dots scroll-draw ornament
- Each of the 20 \`·\` glyphs fades in via an 18 ms child stagger; ~400 ms total sweep, once per viewport entry.

### Theme morph (terracotta as still point)
- Dropped \`disableTransitionOnChange\` from \`ThemeProvider\`.
- Zero-specificity \`:where(html, body, *)\` transition drives color / background-color / border-color over 240 ms.
- \`accent-bridge\` keyframe desaturates \`--color-accent\` through \`--color-text-muted\` mid-transition, so the terracotta visibly becomes the still point of the color flip.
- \`data-theme-transitioning\` is set **synchronously** in the toggle handler. A \`useEffect\` on \`resolvedTheme\` would arrive one render late and miss the bridge.
- Reduced-motion kills both the transition and the keyframe.

### Font weight trim (Path B-lite)
- Pre-flight grep found zero \`font-bold\` / fontWeight-700 callsites; heaviest rendered weight is 600 (\`font-semibold\`).
- Plex Serif subset: \`[400, 500, 600]\` + 400 italic. Plex Sans: \`[400, 500, 600]\`. Plex Mono: unchanged \`[400, 500]\`.
- **14 font files → 11.** Full Path A (self-hosted variable fonts) deferred to a follow-up pending VF glyph-coverage check against the content corpus.

## Phase 6 — DESIGN.md sync

Documented every spec change introduced by phases 1–5:
- **§2 Layout**: 4-tier breakpoints (\`sm\` 480 / \`md\` 768 / \`lg\` 1024, no \`xl\`/\`2xl\`); home two-column activates at \`lg:\` not \`md:\`.
- **§3 Tokens**: fluid spacing via \`clamp()\` for \`md\` → \`3xl\`; widget container-query tokens (\`--flip-narrow\`, \`--flip-wide\`, \`--widget-width\`).
- **§4 Type**: weight subset (Path B-lite) and its rationale.
- **§7 Widgets**: slider 14 px visual / 44 px hit target via \`background-clip: content-box\`; PRESS identity + \`.bs-press\` ring pulse; terracotta-dot hydration canvas; container-query orientation flips.
- **§9 Motion**: page transitions (View Transitions API, 280 ms, RM-safe); theme morph + accent-bridge; transient press-pulse carve-out from the §12 shadow ban.
- **§11 A11y**: 44 × 44 CSS px minimum tap target; hover gated behind \`@media (hover: hover)\`.

### What's left in #13
Manual device matrix (iPhone 13 mini / 14 Pro Max, Pixel 7, Galaxy S23, iPad, MacBook), Lighthouse CI (perf ≥ 95 home / 93 posts, a11y = 100), \`@axe-core/playwright\` smoke, Slow 3G + 4× CPU FCP/LCP measurements, and the keyboard-a11y regression walk all need the Vercel preview to run against. Handing back to you for that pass.

## Test plan
- [ ] Navigate home → post → back: root fade at 280 ms; the cover tile visibly morphs into the hero tile without a crossfade (Chrome/Safari). Firefox: instant, no regression.
- [ ] Hard-reload home in a new session: wordmark lifts and scales (no opacity flash), paragraph wipes in left-to-right, subscribe pill + meta row cue on beat, PostList rows stagger in last. Reload again in the same session: simple stagger, no hero.
- [ ] Clear sessionStorage; first visit plays again. Open in private window: same first-visit experience.
- [ ] Toggle theme on a post page with widgets visible: colors crossfade smoothly, accent visibly desaturates mid-morph and re-saturates. No flash.
- [ ] Scroll past a Dots separator: dots sweep in left-to-right.
- [ ] Scroll past any widget: figure fades + lifts once on entry.
- [ ] \`prefers-reduced-motion: reduce\`: view transitions, theme morph, Reveal animations, Dots sweep, first-visit hero all collapse to ≤ 1 ms; final states still correct.
- [ ] Network panel after hard-reload: 11 \`font/*\` requests (down from 14), all \`display: swap\`.
- [ ] No \`font-bold\` / fontWeight-700 usage regressed (no visual weight change on H1/H2/H3/wordmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)