### PR TITLE
article: the function that remembered — mobile-first overhaul

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -116,11 +116,13 @@ Every piece of text inside a post is a typed JSX element. No regex classifiers, 
 ## 6. Code blocks
 
 - Shiki dual-theme: **`github-dark-dimmed`** (dark) + **`github-light`** (light). Single DOM, CSS-variable switched.
-- Background: `--color-surface`. No distinct code-block color — stay in palette.
-- Padding: `--spacing-md`.
+- **Chrome**: terminal-style header bar with three muted dots (`--code-dot-red/-yellow/-green`), optional filename on the left, language badge on the right. Carve-out documented in §12. Chrome bar height is 34 px on desktop, 28 px on phone-width containers (the bar is a container-query consumer so the block adapts whether it's in prose or inside a widget).
+- Background: `--color-surface`. Subtle warmer band on the chrome via `color-mix(in oklab, surface 70%, bg)` so the chrome reads as a distinct surface without a heavy border.
+- Padding: `--spacing-md` default, `--spacing-sm` below the 560 px container-query breakpoint.
 - Font: Plex Mono at `--text-mono`.
-- Copy button: top-right on hover only, Plex Sans `--text-small`.
-- Line numbers: auto for blocks ≥ 10 lines. `--color-text-muted`, tabular-nums.
+- Copy button: always visible, 44 × 44 tap zone, Plex Sans `--text-small`. Hidden for `tone="terminal"` (shell transcripts aren't paste fodder).
+- Line numbers: on by default for `tone="default"`; off for `terminal` and `output`. `--color-text-muted` at 50 % opacity, tabular-nums.
+- **`tone` prop**: `default | terminal | output`. `terminal` renders a `$` prompt on the first line (accent-coloured); `output` dims the whole body to `--color-text-muted`. The `low-contrast-output-block` audit rule surfaces every `output` block so authors confirm none are teaching code.
 - Filename header: optional `<CodeBlock filename="…">`. Plex Mono `--text-small`.
 - `<CodeTrace>` active line: background tint on whole line, **not** a left stripe.
 - `<CodeMorph>`: shiki-magic-move wrapper for step-linked reveals.
@@ -231,3 +233,8 @@ Home splits into two columns at ≥ 768px:
 - **No dashboard "big number, small label, supporting stats" layouts.**
 - **No sparkline decoration.**
 - **No rounded-rectangle-with-generic-shadow** buttons.
+
+### Carve-outs from §12
+
+1. **Code-block chrome dots.** Three 8-px dots in the `<CodeBlock>` chrome (tokens `--code-dot-red` / `-yellow` / `-green`) are the one permitted exception to the one-accent rule. They're a well-established terminal metaphor, not decoration, and their chromas are ≤ 50 % of a typical OS traffic light so they read as muted against the surface. A reviewer should confirm no decorative use creeps into other surfaces — these tokens exist solely for the code-block chrome.
+2. **Transient press-pulses.** Already documented in §9 — `.bs-press` ring pulse ≤ 300 ms on commit-worthy taps is gesture feedback, not decoration.

--- a/app/globals.css
+++ b/app/globals.css
@@ -72,6 +72,15 @@
   /* Widget canvas width — every widget-embedded SVG reads this for its max
      width so the editorial page gets one place to change the figure width. */
   --widget-width: min(100%, 900px);
+
+  /* Code-block chrome — three muted-tone dots that read as a terminal
+     metaphor without lighting the page up with three new accents. These
+     are the one permitted exception to DESIGN.md §12's one-accent rule
+     (see §12 for the carve-out). Chromas are ≤ 50 % of a typical OS
+     traffic light so they sit inside the editorial palette. */
+  --code-dot-red: oklch(0.58 0.09 28);
+  --code-dot-yellow: oklch(0.75 0.08 80);
+  --code-dot-green: oklch(0.68 0.08 150);
 }
 
 /* ---------------------------------------------------------------------------
@@ -186,6 +195,60 @@ body {
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
   opacity: 0.5;
+}
+
+/* ---------------------------------------------------------------------------
+   CodeBlock chrome — macOS-style terminal identity. The three dots read as
+   "this is a terminal" at a glance; the chroma is pulled down to ≤ 50 % of
+   an OS traffic light so they don't compete with the terracotta accent.
+--------------------------------------------------------------------------- */
+.bs-code {
+  container-type: inline-size;
+}
+.bs-code-chrome {
+  height: 34px;
+}
+.bs-code-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.bs-code-filename {
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+}
+
+/* `terminal` tone — render a `$` prompt on the first non-blank line via a
+   pseudo-element on the code body. Also drops line numbers. */
+.bs-code[data-tone="terminal"] .bs-code-body .shiki code .line:first-child::before {
+  content: "$ ";
+  color: var(--color-accent);
+  margin-right: 0;
+  width: auto;
+  opacity: 0.8;
+}
+
+/* `output` tone — dim the body to muted text so shell-output blocks read
+   as derivative, not teaching. The audit rule `low-contrast-output-block`
+   surfaces this so authors confirm the block is genuinely non-teaching. */
+.bs-code[data-tone="output"] .bs-code-body {
+  color: var(--color-text-muted);
+}
+
+/* Mobile container-query density — shrink chrome, hide language badge,
+   tighten padding. The copy button's own styles keep its 44 px tap zone. */
+@container (max-width: 560px) {
+  .bs-code-chrome {
+    height: 28px;
+    padding-inline: var(--spacing-sm);
+  }
+  .bs-code-badge {
+    display: none;
+  }
+  .bs-code-body {
+    padding-inline: var(--spacing-sm);
+  }
 }
 
 /* ---------------------------------------------------------------------------
@@ -306,6 +369,29 @@ html[data-theme-transitioning] {
   .bs-race-controls {
     grid-template-columns: 1fr 1fr;
     gap: var(--spacing-md);
+  }
+}
+
+/* The function that remembered — three widgets author both orientations and
+   the container query picks which renders. Same pattern RequestJourney ships:
+   pure CSS, no hydration mismatch, no ResizeObserver. Wide stays the existing
+   680-unit landscape layout; narrow stacks into a portrait composition where
+   labels keep their native size. */
+.bs-looptrap-narrow,
+.bs-tetherscope-narrow,
+.bs-renderloom-narrow {
+  display: none;
+}
+@container widget (max-width: 560px) {
+  .bs-looptrap-wide,
+  .bs-tetherscope-wide,
+  .bs-renderloom-wide {
+    display: none;
+  }
+  .bs-looptrap-narrow,
+  .bs-tetherscope-narrow,
+  .bs-renderloom-narrow {
+    display: block;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,18 +167,25 @@ body {
   font-family: var(--font-mono) !important;
 }
 
+/* Dark-theme token colors: promote the --shiki-dark variable to `color` on
+   each span. Crucially we DO NOT paint a background on .shiki or its spans —
+   Shiki's theme background (a cool #22272e) would clash with our warm
+   --color-surface and read as a tint on the code body. Transparent spans
+   let the outer container's surface show through cleanly. */
 [data-theme="dark"] .shiki,
 [data-theme="dark"] .shiki span {
   color: var(--shiki-dark) !important;
-  background-color: var(--shiki-dark-bg) !important;
 }
 
-/* Shiki's default <pre> has its own padding — we already pad the wrapper,
-   so strip Shiki's and let ours win. */
+/* Shiki's default <pre> has its own padding and background — strip both;
+   the outer <CodeBlock> handles surface + padding. */
 .shiki {
   background: transparent !important;
   padding: 0 !important;
   margin: 0 !important;
+}
+.shiki span {
+  background: transparent !important;
 }
 
 /* Line-number support: opt-in via [data-numbered="true"] on the wrapper. */

--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -25,7 +25,7 @@ export default function HowGmailKnowsYourEmailIsTaken() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="how-gmail-knows-your-email-is-taken" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>

--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -99,21 +99,21 @@ export default function HowGmailKnowsYourEmailIsTaken() {
         <Dots />
         <H2>Two caches before the database</H2>
         <P>
-          A <Em>very</Em> common question about this flow: what&apos;s the cache doing in front
+          A <Em>very</Em>{" "}common question about this flow: what&apos;s the cache doing in front
           of the database? Most real identity systems put at least one — often two — in-memory
           cache tiers between the request and the authoritative store, and Gmail is no
           exception.
         </P>
         <P>
-          The first one is an <Em>in-process</Em> near-cache, right inside the Gaia frontend
+          The first one is an <Em>in-process</Em>{" "}near-cache, right inside the Gaia frontend
           that handles your request. If the same canonical email was asked about in the last few
           seconds on the same shard (which happens a lot — popular names get typed constantly),
           the answer is still in memory. No further work.
         </P>
         <P>
-          The second is a <Em>distributed</Em> cache that spans many frontends, so a warm
+          The second is a <Em>distributed</Em>{" "}cache that spans many frontends, so a warm
           answer from one shard can serve another. In the FlowDemo widget above, the{" "}
-          <Em>someone just checked this name</Em> scenario lights this up: the request
+          <Em>someone just checked this name</Em>{" "}scenario lights this up: the request
           terminates at the near-cache and never reaches the Bloom filter or Spanner.
         </P>
         <Callout tone="note">
@@ -139,7 +139,7 @@ export default function HowGmailKnowsYourEmailIsTaken() {
           is created, a few hash functions of the canonical email each pick a bit, and those
           bits get flipped on. To check an email, hash it the same way and look at those bits:
           if any one of them is <Code>0</Code>, it&apos;s definitely not in the set. If
-          they&apos;re all <Code>1</Code>, it <Em>might</Em> be.
+          they&apos;re all <Code>1</Code>, it <Em>might</Em>{" "}be.
         </P>
         <P>
           Step through a handful of inserts and queries below.
@@ -150,8 +150,8 @@ export default function HowGmailKnowsYourEmailIsTaken() {
 
       <div>
         <P>
-          The filter can lie about <Em>yes</Em>, never about <Em>no</Em>. A <Em>no</Em> alone is
-          enough to answer the user — no database round-trip needed. A <Em>maybe</Em> has to go
+          The filter can lie about <Em>yes</Em>, never about <Em>no</Em>. A <Em>no</Em>{" "}alone is
+          enough to answer the user — no database round-trip needed. A <Em>maybe</Em>{" "}has to go
           to Spanner to be sure.
         </P>
       </div>
@@ -214,7 +214,7 @@ export default function HowGmailKnowsYourEmailIsTaken() {
       <div>
         <P>
           The winner is whichever INSERT Spanner committed first — not whichever user clicked
-          Submit first in their browser. Both clients saw <Em>available</Em> while typing; only
+          Submit first in their browser. Both clients saw <Em>available</Em>{" "}while typing; only
           the database&apos;s serial ordering at commit decides who actually got the address.
         </P>
         <Callout tone="note">
@@ -238,7 +238,7 @@ export default function HowGmailKnowsYourEmailIsTaken() {
           that worked like this. An attacker signs up for Netflix using a dotted variant of
           your Gmail — say <Code>j.ohn.doe@gmail.com</Code> — with a bad card. Netflix treats
           the dotted version as a new customer, because Netflix doesn&apos;t normalise the way
-          Gmail does. The card fails. Netflix sends <Em>you</Em> a polite email about it —
+          Gmail does. The card fails. Netflix sends <Em>you</Em>{" "}a polite email about it —
           both addresses land in your inbox. You, confused, helpfully pay.
         </P>
         <P>

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -129,7 +129,7 @@ const add10 = makeAdder(10);`}
           Each call to <Code>makeAdder</Code> creates its own frame, with its own{" "}
           <Code>n</Code>. The returned arrow function carries a tether to that frame.{" "}
           <Code>add5</Code> and <Code>add10</Code> aren&apos;t copies of <Code>n</Code>; they
-          each own a live pointer to a <Em>different</Em> frame. Step through a single call and
+          each own a live pointer to a <Em>different</Em>{" "}frame. Step through a single call and
           watch the mechanics:
         </P>
       </div>
@@ -138,8 +138,10 @@ const add10 = makeAdder(10);`}
 
       <div>
         <Callout tone="note">
-          A <Term>closure</Term> is a function, plus the tether it kept. Any function, as long
-          as it can still reach something from an outer scope. That&apos;s it.
+          A <Term>closure</Term>
+          {" "}
+          is a function, plus the tether it kept. Any function, as long as it can still
+          reach something from an outer scope. That&apos;s it.
         </Callout>
         <P>
           One subtlety worth stating plainly, because it&apos;s the misconception every other
@@ -155,7 +157,7 @@ const add10 = makeAdder(10);`}
         <Dots />
         <H2>Why one letter fixed the loop</H2>
         <P>
-          With that, scroll back up to <Em>LoopTrap</Em> and look at it again. The reason{" "}
+          With that, scroll back up to <Em>LoopTrap</Em>{" "}and look at it again. The reason{" "}
           <Code>var</Code> prints <Code>5 5 5 5 5</Code> isn&apos;t that the loop copied{" "}
           <Code>i</Code> wrong. It&apos;s that <Code>var</Code> declares one binding for the
           whole function. The five arrow functions picked up five tethers. All five tethers
@@ -181,10 +183,11 @@ const add10 = makeAdder(10);`}
           <A href="https://github.com/getify/You-Dont-Know-JS/blob/2nd-ed/scope-closures/ch7.md">
             You Don&apos;t Know JS
           </A>
-          {" "}reserves the word <Em>closure</Em> for functions that run somewhere their tether
-          targets aren&apos;t directly in scope — the observable case. MDN and the spec use the
-          word more broadly. Same mechanism — the debate is only about when its effects count
-          as observable.
+          {" "}reserves the word <Em>closure</Em>
+          {" "}
+          for functions that run somewhere their tether targets aren&apos;t directly in scope
+          — the observable case. MDN and the spec use the word more broadly. Same mechanism —
+          the debate is only about when its effects count as observable.
         </Aside>
       </div>
 

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -12,6 +12,7 @@ import {
   HeroTile,
   Term,
 } from "@/components/prose";
+import { CodeBlock } from "@/components/code";
 import {
   LoopTrap,
   TetherScope,
@@ -26,7 +27,7 @@ export default function TheFunctionThatRemembered() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="the-function-that-remembered" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
@@ -50,19 +51,13 @@ export default function TheFunctionThatRemembered() {
           zero through four, one per second. The loop looks fine. You hit run and watch the
           console.
         </P>
-        <pre
-          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
-          style={{
-            background: "var(--color-surface)",
-            padding: "var(--spacing-md)",
-            fontSize: "var(--text-mono)",
-            lineHeight: 1.55,
-          }}
-        >
-{`for (var i = 0; i < 5; i++) {
+        <CodeBlock
+          lang="javascript"
+          filename="loop.js"
+          code={`for (var i = 0; i < 5; i++) {
   setTimeout(() => console.log(i), 1000);
 }`}
-        </pre>
+        />
         <P>
           It prints <PredictReveal answer="5 5 5 5 5" />. Not{" "}
           <Code>0 1 2 3 4</Code>. Five fives. A second late, five times over.
@@ -120,22 +115,16 @@ export default function TheFunctionThatRemembered() {
           don&apos;t vanish if a function born inside them is still holding the tether.
           Consider a factory:
         </P>
-        <pre
-          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
-          style={{
-            background: "var(--color-surface)",
-            padding: "var(--spacing-md)",
-            fontSize: "var(--text-mono)",
-            lineHeight: 1.55,
-          }}
-        >
-{`function makeAdder(n) {
+        <CodeBlock
+          lang="javascript"
+          filename="makeAdder.js"
+          code={`function makeAdder(n) {
   return (x) => x + n;
 }
 
 const add5  = makeAdder(5);
 const add10 = makeAdder(10);`}
-        </pre>
+        />
         <P>
           Each call to <Code>makeAdder</Code> creates its own frame, with its own{" "}
           <Code>n</Code>. The returned arrow function carries a tether to that frame.{" "}
@@ -207,16 +196,10 @@ const add10 = makeAdder(10);`}
           Fast-forward to a React component. You&apos;ve written this before, and you remember
           being surprised the first time:
         </P>
-        <pre
-          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
-          style={{
-            background: "var(--color-surface)",
-            padding: "var(--spacing-md)",
-            fontSize: "var(--text-mono)",
-            lineHeight: 1.55,
-          }}
-        >
-{`function Counter() {
+        <CodeBlock
+          lang="tsx"
+          filename="Counter.tsx"
+          code={`function Counter() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -228,7 +211,7 @@ const add10 = makeAdder(10);`}
 
   return <h1>{count}</h1>;
 }`}
-        </pre>
+        />
         <P>
           It goes from <Code>0</Code> to <Code>1</Code> and stops. The interval keeps firing,
           but the number on the screen never moves past one.
@@ -283,16 +266,10 @@ const add10 = makeAdder(10);`}
           closures leak memory. The classic pattern — first spotted in Meteor a decade back —
           looks like this:
         </P>
-        <pre
-          className="my-[var(--spacing-md)] overflow-x-auto rounded-[var(--radius-md)] font-mono"
-          style={{
-            background: "var(--color-surface)",
-            padding: "var(--spacing-md)",
-            fontSize: "var(--text-mono)",
-            lineHeight: 1.55,
-          }}
-        >
-{`let theThing = null;
+        <CodeBlock
+          lang="javascript"
+          filename="replaceThing.js"
+          code={`let theThing = null;
 function replaceThing() {
   const prev = theThing;
   theThing = {
@@ -301,7 +278,7 @@ function replaceThing() {
   };
 }
 setInterval(replaceThing, 1000);`}
-        </pre>
+        />
         <P>
           Every tick, <Code>theThing</Code> gets replaced with a new megabyte-sized object that
           carries a closure — <Code>link</Code> — tethered back to <Code>prev</Code>. And{" "}

--- a/app/posts/the-function-that-remembered/widgets/LoopTrap.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopTrap.tsx
@@ -82,6 +82,7 @@ export function LoopTrap() {
         </div>
       }
     >
+      <div className="bs-looptrap-wide">
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -283,7 +284,269 @@ export function LoopTrap() {
           </text>
         </g>
       </svg>
+      </div>
+      <div className="bs-looptrap-narrow">
+        <NarrowLoopTrap
+          mode={mode}
+          firedCount={firedCount}
+          printedValues={printedValues}
+          sharedVar={sharedVar}
+          letBindings={letBindings}
+        />
+      </div>
     </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                     Narrow portrait layout (mobile-first)                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * NarrowLoopTrap — portrait composition for phone-width containers. Callbacks
+ * stack vertically on the left, binding cell(s) on the right, console pinned
+ * at the bottom. Labels stay at native size (no 0.53× crush). Horizontal
+ * tethers connect each callback to its captured cell — the contrast between
+ * "one cell" (var) and "five cells" (let) is still the visual teaching.
+ */
+function NarrowLoopTrap({
+  mode,
+  firedCount,
+  printedValues,
+  sharedVar,
+  letBindings,
+}: {
+  mode: Mode;
+  firedCount: number;
+  printedValues: number[];
+  sharedVar: number;
+  letBindings: number[];
+}) {
+  const W = 360;
+  const CB_X = 18;
+  const CB_W = 112;
+  const CB_H = 36;
+  const CB_GAP = 6;
+  const CB_Y0 = 24;
+
+  const BIND_X_LET = W - CB_W - 18;
+  const BIND_W_LET = CB_W;
+  const VAR_BIND_W = 96;
+  const VAR_BIND_H = 48;
+  const VAR_BIND_X = W - VAR_BIND_W - 28;
+  const cbCenterY = (i: number) => CB_Y0 + i * (CB_H + CB_GAP) + CB_H / 2;
+  const CB_COLUMN_BOTTOM = CB_Y0 + N * (CB_H + CB_GAP) - CB_GAP;
+  const VAR_BIND_Y = (CB_Y0 + CB_COLUMN_BOTTOM) / 2 - VAR_BIND_H / 2;
+
+  const CONSOLE_Y = CB_COLUMN_BOTTOM + 28;
+  const H = CONSOLE_Y + 56;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      style={{ maxWidth: W, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`LoopTrap: ${mode} mode, ${firedCount} of ${N} callbacks fired`}
+    >
+      {/* Callback list (left column) */}
+      {Array.from({ length: N }, (_, i) => {
+        const y = CB_Y0 + i * (CB_H + CB_GAP);
+        const fired = i < firedCount;
+        const firing = i === firedCount - 1 && firedCount > 0;
+        const fill = firing
+          ? "color-mix(in oklab, var(--color-accent) 18%, transparent)"
+          : fired
+            ? "color-mix(in oklab, var(--color-surface) 60%, transparent)"
+            : "transparent";
+        const stroke = firing ? "var(--color-accent)" : "var(--color-rule)";
+        return (
+          <g key={`n-cb-${i}`}>
+            <motion.rect
+              x={CB_X}
+              y={y}
+              width={CB_W}
+              height={CB_H}
+              rx={3}
+              initial={false}
+              animate={{ fill, stroke }}
+              strokeWidth={firing ? 1.5 : 1}
+              transition={SPRING.snappy}
+            />
+            <text
+              x={CB_X + 10}
+              y={y + 14}
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+            >
+              cb{i}
+            </text>
+            <text
+              x={CB_X + 10}
+              y={y + 28}
+              fontFamily="var(--font-mono)"
+              fontSize={12}
+              fill={fired ? "var(--color-text)" : "var(--color-text-muted)"}
+            >
+              {fired ? `log(${mode === "var" ? sharedVar : i})` : "log(i)"}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Bindings column (right) — single wide cell for var, five for let */}
+      <AnimatePresence mode="wait">
+        {mode === "var" ? (
+          <motion.g
+            key="n-var-bind"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={VAR_BIND_X}
+              y={VAR_BIND_Y}
+              width={VAR_BIND_W}
+              height={VAR_BIND_H}
+              rx={3}
+              fill="var(--color-accent)"
+              fillOpacity={0.92}
+            />
+            <text
+              x={VAR_BIND_X + VAR_BIND_W / 2}
+              y={VAR_BIND_Y + 18}
+              textAnchor="middle"
+              fontFamily="var(--font-sans)"
+              fontSize={10}
+              fill="var(--color-bg)"
+              opacity={0.85}
+              letterSpacing="0.06em"
+            >
+              i (shared)
+            </text>
+            <text
+              x={VAR_BIND_X + VAR_BIND_W / 2}
+              y={VAR_BIND_Y + 36}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={15}
+              fill="var(--color-bg)"
+            >
+              {sharedVar}
+            </text>
+          </motion.g>
+        ) : (
+          <motion.g
+            key="n-let-bind"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.smooth}
+          >
+            {letBindings.map((val, i) => {
+              const y = CB_Y0 + i * (CB_H + CB_GAP);
+              return (
+                <g key={`n-bind-${i}`}>
+                  <rect
+                    x={BIND_X_LET}
+                    y={y}
+                    width={BIND_W_LET}
+                    height={CB_H}
+                    rx={3}
+                    fill="var(--color-accent)"
+                    fillOpacity={0.92}
+                  />
+                  <text
+                    x={BIND_X_LET + BIND_W_LET / 2}
+                    y={y + 14}
+                    textAnchor="middle"
+                    fontFamily="var(--font-sans)"
+                    fontSize={9}
+                    fill="var(--color-bg)"
+                    opacity={0.85}
+                    letterSpacing="0.06em"
+                  >
+                    i #{i}
+                  </text>
+                  <text
+                    x={BIND_X_LET + BIND_W_LET / 2}
+                    y={y + 28}
+                    textAnchor="middle"
+                    fontFamily="var(--font-mono)"
+                    fontSize={13}
+                    fill="var(--color-bg)"
+                  >
+                    {val}
+                  </text>
+                </g>
+              );
+            })}
+          </motion.g>
+        )}
+      </AnimatePresence>
+
+      {/* Tethers: horizontal from callback right edge to binding left edge */}
+      {Array.from({ length: N }, (_, i) => {
+        const x1 = CB_X + CB_W;
+        const y1 = cbCenterY(i);
+        const x2 =
+          mode === "var"
+            ? VAR_BIND_X
+            : BIND_X_LET;
+        const y2 =
+          mode === "var"
+            ? VAR_BIND_Y + VAR_BIND_H / 2
+            : cbCenterY(i);
+        const firing = i === firedCount - 1 && firedCount > 0;
+        return (
+          <Arrow
+            key={`n-teth-${i}-${mode}`}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            tone={firing ? "active" : "muted"}
+            strokeWidth={firing ? 2 : 1.2}
+          />
+        );
+      })}
+
+      {/* Console band */}
+      <g>
+        <rect
+          x={CB_X}
+          y={CONSOLE_Y}
+          width={W - CB_X * 2}
+          height={44}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={CB_X + 8}
+          y={CONSOLE_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          CONSOLE
+        </text>
+        <text
+          x={W / 2}
+          y={CONSOLE_Y + 34}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={16}
+          fill="var(--color-text)"
+        >
+          {printedValues.length > 0 ? printedValues.join(" ") : "\u00A0"}
+        </text>
+      </g>
+    </svg>
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/RenderLoom.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderLoom.tsx
@@ -116,6 +116,7 @@ export function RenderLoom() {
         </div>
       }
     >
+      <div className="bs-renderloom-wide">
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -375,7 +376,312 @@ export function RenderLoom() {
           </AnimatePresence>
         </g>
       </svg>
+      </div>
+      <div className="bs-renderloom-narrow">
+        <NarrowRenderLoom mode={mode} step={step} tick={tick} />
+      </div>
     </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                     Narrow portrait layout (mobile-first)                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * NarrowRenderLoom — portrait composition. Reading order matches the real
+ * world: the screen (what the user sees) sits at the top, the render stack
+ * below it (the machinery producing that screen), and the effect callback
+ * at the bottom — connected to its tethered render by a vertical arrow in
+ * `broken` mode, or labeled "no tether" in `fixed` mode.
+ */
+function NarrowRenderLoom({
+  mode,
+  step,
+  tick,
+}: {
+  mode: Mode;
+  step: number;
+  tick: Tick;
+}) {
+  const W = 360;
+  const SCREEN_X = 18;
+  const SCREEN_Y = 20;
+  const SCREEN_W = W - SCREEN_X * 2;
+  const SCREEN_H = 68;
+
+  const MAX_RENDERS = 3;
+  const visibleRenders = tick.bindings.slice(-MAX_RENDERS);
+  const renderIdxOffset = tick.bindings.length - visibleRenders.length;
+
+  const R_X = 18;
+  const R_Y0 = SCREEN_Y + SCREEN_H + 24;
+  const R_W = W - R_X * 2;
+  const R_H = 40;
+  const R_GAP = 6;
+
+  const EFFECT_X = 18;
+  const EFFECT_Y = R_Y0 + MAX_RENDERS * (R_H + R_GAP) + 40;
+  const EFFECT_W = W - EFFECT_X * 2;
+  const EFFECT_H = 88;
+  const H = EFFECT_Y + EFFECT_H + 20;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      style={{ maxWidth: W, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`RenderLoom: ${mode} mode, tick ${step} of ${TICK_STEPS - 1}`}
+    >
+      {/* Screen — what the user sees */}
+      <g>
+        <rect
+          x={SCREEN_X}
+          y={SCREEN_Y}
+          width={SCREEN_W}
+          height={SCREEN_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-accent) 6%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={SCREEN_X + 10}
+          y={SCREEN_Y + 16}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          SCREEN
+        </text>
+        <AnimatePresence mode="popLayout">
+          <motion.text
+            key={`n-screen-${tick.displayedRender}-${mode}`}
+            x={SCREEN_X + SCREEN_W / 2}
+            y={SCREEN_Y + 54}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={36}
+            fontWeight={500}
+            fill="var(--color-text)"
+            initial={{ opacity: 0, y: SCREEN_Y + 48 }}
+            animate={{ opacity: 1, y: SCREEN_Y + 54 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.snappy}
+          >
+            {tick.bindings[tick.displayedRender]}
+          </motion.text>
+        </AnimatePresence>
+      </g>
+
+      {/* Renders header */}
+      <text
+        x={R_X}
+        y={R_Y0 - 8}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+        letterSpacing="0.08em"
+      >
+        RENDERS
+      </text>
+
+      {/* Render stack — only the most recent MAX_RENDERS */}
+      {visibleRenders.map((countVal, localIdx) => {
+        const renderIdx = renderIdxOffset + localIdx;
+        const y = R_Y0 + localIdx * (R_H + R_GAP);
+        const isDisplayed = renderIdx === tick.displayedRender;
+        const isTethered = mode === "broken" && renderIdx === tick.tetherRender;
+        const borderColor = isTethered
+          ? "var(--color-accent)"
+          : isDisplayed
+            ? "var(--color-text-muted)"
+            : "var(--color-rule)";
+        const bgFill = isTethered
+          ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+          : isDisplayed
+            ? "color-mix(in oklab, var(--color-surface) 70%, transparent)"
+            : "transparent";
+        return (
+          <motion.g
+            key={`n-render-${renderIdx}`}
+            initial={{ opacity: 0, x: -6 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={R_X}
+              y={y}
+              width={R_W}
+              height={R_H}
+              rx={3}
+              fill={bgFill}
+              stroke={borderColor}
+              strokeWidth={isTethered || isDisplayed ? 1.3 : 1}
+              strokeDasharray={isTethered ? "0" : isDisplayed ? "0" : "3 3"}
+            />
+            <text
+              x={R_X + 10}
+              y={y + 15}
+              fontFamily="var(--font-sans)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+              letterSpacing="0.04em"
+            >
+              render {renderIdx}
+            </text>
+            <text
+              x={R_X + 10}
+              y={y + 30}
+              fontFamily="var(--font-mono)"
+              fontSize={12}
+              fill="var(--color-text)"
+            >
+              count
+            </text>
+            <rect
+              x={R_X + 64}
+              y={y + 18}
+              width={24}
+              height={16}
+              rx={2}
+              fill="var(--color-accent)"
+            />
+            <text
+              x={R_X + 76}
+              y={y + 30}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-bg)"
+            >
+              {countVal}
+            </text>
+            {isTethered || isDisplayed ? (
+              <text
+                x={R_X + R_W - 10}
+                y={y + 15}
+                textAnchor="end"
+                fontFamily="var(--font-sans)"
+                fontSize={8}
+                fill={isTethered ? "var(--color-accent)" : "var(--color-text-muted)"}
+                letterSpacing="0.08em"
+              >
+                {isTethered && isDisplayed
+                  ? "TETHERED · ON SCREEN"
+                  : isTethered
+                    ? "TETHERED"
+                    : "ON SCREEN"}
+              </text>
+            ) : null}
+          </motion.g>
+        );
+      })}
+
+      {/* Effect callback */}
+      <g>
+        <rect
+          x={EFFECT_X}
+          y={EFFECT_Y}
+          width={EFFECT_W}
+          height={EFFECT_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 80%, transparent)"
+          stroke="var(--color-text-muted)"
+          strokeWidth={1}
+        />
+        <text
+          x={EFFECT_X + 10}
+          y={EFFECT_Y + 18}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+          letterSpacing="0.08em"
+        >
+          setInterval callback
+        </text>
+        <text
+          x={EFFECT_X + 10}
+          y={EFFECT_Y + 40}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text)"
+        >
+          () =&gt; setCount(
+        </text>
+        <text
+          x={EFFECT_X + 10}
+          y={EFFECT_Y + 58}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill={mode === "broken" ? "var(--color-accent)" : "var(--color-text)"}
+        >
+          {mode === "broken" ? "  count + 1" : "  c => c + 1"}
+        </text>
+        <text
+          x={EFFECT_X + 10}
+          y={EFFECT_Y + 76}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text)"
+        >
+          {")"}
+        </text>
+      </g>
+
+      {/* Tether — vertical arrow from callback UP to tethered render */}
+      <AnimatePresence>
+        {mode === "broken" && tick.tetherRender !== null ? (
+          <motion.g
+            key="n-tether"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.smooth}
+          >
+            {(() => {
+              const tetherLocalIdx = tick.tetherRender - renderIdxOffset;
+              // If the tethered render scrolled out of the visible stack,
+              // point to the top-of-stack row to keep the arrow visible.
+              const targetLocalIdx =
+                tetherLocalIdx >= 0 && tetherLocalIdx < MAX_RENDERS
+                  ? tetherLocalIdx
+                  : 0;
+              const y2 = R_Y0 + targetLocalIdx * (R_H + R_GAP) + R_H;
+              return (
+                <Arrow
+                  x1={EFFECT_X + 60}
+                  y1={EFFECT_Y}
+                  x2={EFFECT_X + 60}
+                  y2={y2}
+                  tone="active"
+                  strokeWidth={2}
+                  curvature={12}
+                />
+              );
+            })()}
+          </motion.g>
+        ) : (
+          <motion.text
+            key="n-no-tether"
+            x={EFFECT_X + EFFECT_W - 10}
+            y={EFFECT_Y - 6}
+            textAnchor="end"
+            fontFamily="var(--font-sans)"
+            fontSize={10}
+            fill="var(--color-text-muted)"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.smooth}
+          >
+            (no tether)
+          </motion.text>
+        )}
+      </AnimatePresence>
+    </svg>
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
+++ b/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
@@ -104,6 +104,7 @@ export function TetherScope() {
       caption={s.caption}
       controls={<Stepper value={step} total={STEPS.length} onChange={setStep} playInterval={1500} />}
     >
+      <div className="bs-tetherscope-wide">
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -411,6 +412,352 @@ export function TetherScope() {
           A CLOSURE = FUNCTION + TETHER TO ITS BIRTH SCOPE
         </text>
       </svg>
+      </div>
+      <div className="bs-tetherscope-narrow">
+        <NarrowTetherScope step={step} s={s} />
+      </div>
     </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                     Narrow portrait layout (mobile-first)                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * NarrowTetherScope — portrait composition. Code pane on top, runtime heap
+ * underneath (frame above, returned function object below), and the tether
+ * draws as a vertical curve from the function object's [[Environment]] slot
+ * up to the pinned frame. The visual teaching — "this function is tethered
+ * to this frame" — stays identical; the orientation flips so each element
+ * can render at native size on 360 w.
+ */
+function NarrowTetherScope({ step, s }: { step: number; s: Step }) {
+  const W = 360;
+  const CODE_X = 16;
+  const CODE_Y = 28;
+  const CODE_LH = 20;
+  const CODE_W = W - CODE_X * 2;
+  const CODE_BOTTOM = CODE_Y + CODE_LINES.length * CODE_LH + 12;
+
+  const RUNTIME_Y = CODE_BOTTOM + 16;
+  const FRAME_X = 18;
+  const FRAME_Y = RUNTIME_Y + 20;
+  const FRAME_W = W - FRAME_X * 2;
+  const FRAME_H = 68;
+
+  const FN_Y = FRAME_Y + FRAME_H + 64;
+  const FN_X = 18;
+  const FN_W = W - FN_X * 2;
+  const FN_H = 84;
+
+  const H = FN_Y + FN_H + 36;
+
+  const returnedText = s.returnValue !== null ? String(s.returnValue) : "";
+  const fnSlotCx = FN_X + FN_W - 22;
+  const fnSlotCy = FN_Y + FN_H - 20;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      style={{ maxWidth: W, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`TetherScope: step ${step + 1} of ${STEPS.length}. ${s.caption}`}
+    >
+      {/* Code pane header */}
+      <text
+        x={CODE_X}
+        y={14}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+        letterSpacing="0.08em"
+      >
+        CODE
+      </text>
+
+      {/* Code lines */}
+      {CODE_LINES.map((line, i) => {
+        const y = CODE_Y + i * CODE_LH;
+        const active = s.activeLines.includes(i);
+        return (
+          <g key={`n-line-${i}`}>
+            {active ? (
+              <motion.rect
+                x={CODE_X - 4}
+                y={y - 2}
+                width={CODE_W}
+                height={CODE_LH - 2}
+                rx={2}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={SPRING.snappy}
+                fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
+              />
+            ) : null}
+            <text
+              x={CODE_X}
+              y={y + CODE_LH - 7}
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill={active ? "var(--color-text)" : "var(--color-text-muted)"}
+            >
+              {line || "\u00A0"}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Return tag */}
+      <AnimatePresence>
+        {s.returnValue !== null ? (
+          <motion.g
+            key="n-return-tag"
+            initial={{ opacity: 0, x: -4 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={CODE_X + 120}
+              y={CODE_Y + 8 * CODE_LH - 4}
+              width={44}
+              height={CODE_LH - 2}
+              rx={2}
+              fill="var(--color-accent)"
+            />
+            <text
+              x={CODE_X + 142}
+              y={CODE_Y + 8 * CODE_LH + CODE_LH - 9}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-bg)"
+            >
+              → {returnedText}
+            </text>
+          </motion.g>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Runtime divider */}
+      <line
+        x1={16}
+        x2={W - 16}
+        y1={RUNTIME_Y}
+        y2={RUNTIME_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="2 4"
+      />
+      <text
+        x={CODE_X}
+        y={RUNTIME_Y + 14}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+        letterSpacing="0.08em"
+      >
+        RUNTIME
+      </text>
+
+      {/* Frame */}
+      <AnimatePresence>
+        {s.frameState !== "hidden" ? (
+          <motion.g
+            key="n-frame"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={FRAME_X}
+              y={FRAME_Y}
+              width={FRAME_W}
+              height={FRAME_H}
+              rx={3}
+              fill={
+                s.frameState === "pinned"
+                  ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                  : "color-mix(in oklab, var(--color-surface) 70%, transparent)"
+              }
+              stroke={
+                s.frameState === "pinned"
+                  ? "var(--color-accent)"
+                  : "var(--color-rule)"
+              }
+              strokeWidth={1}
+              strokeDasharray={s.frameState === "pinned" ? "0" : "3 3"}
+            />
+            <text
+              x={FRAME_X + 10}
+              y={FRAME_Y + 16}
+              fontFamily="var(--font-sans)"
+              fontSize={9}
+              fill="var(--color-text-muted)"
+              letterSpacing="0.08em"
+            >
+              FRAME: makeRemember
+            </text>
+            <text
+              x={FRAME_X + 10}
+              y={FRAME_Y + 44}
+              fontFamily="var(--font-mono)"
+              fontSize={13}
+              fill="var(--color-text)"
+            >
+              x
+            </text>
+            <rect
+              x={FRAME_X + 32}
+              y={FRAME_Y + 32}
+              width={30}
+              height={22}
+              rx={2}
+              fill="var(--color-accent)"
+            />
+            <text
+              x={FRAME_X + 47}
+              y={FRAME_Y + 48}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={13}
+              fill="var(--color-bg)"
+            >
+              7
+            </text>
+            {s.frameState === "pinned" ? (
+              <text
+                x={FRAME_X + FRAME_W - 10}
+                y={FRAME_Y + 16}
+                textAnchor="end"
+                fontFamily="var(--font-sans)"
+                fontSize={9}
+                fill="var(--color-accent)"
+                letterSpacing="0.08em"
+              >
+                PINNED
+              </text>
+            ) : null}
+          </motion.g>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Function object */}
+      <AnimatePresence>
+        {s.showInnerFn ? (
+          <motion.g
+            key="n-fn"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={SPRING.smooth}
+          >
+            <rect
+              x={FN_X}
+              y={FN_Y}
+              width={FN_W}
+              height={FN_H}
+              rx={3}
+              fill="color-mix(in oklab, var(--color-surface) 80%, transparent)"
+              stroke="var(--color-text-muted)"
+              strokeWidth={1}
+            />
+            <text
+              x={FN_X + 10}
+              y={FN_Y + 16}
+              fontFamily="var(--font-sans)"
+              fontSize={9}
+              fill="var(--color-text-muted)"
+              letterSpacing="0.08em"
+            >
+              FUNCTION OBJECT
+            </text>
+            <text
+              x={FN_X + 10}
+              y={FN_Y + 38}
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-text)"
+            >
+              code: () =&gt; x
+            </text>
+            <text
+              x={FN_X + 10}
+              y={FN_Y + 60}
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-text)"
+            >
+              [[Environment]]:
+            </text>
+            <circle
+              cx={fnSlotCx}
+              cy={fnSlotCy}
+              r={9}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth={1}
+              opacity={0.5}
+            />
+            <motion.circle
+              cx={fnSlotCx}
+              cy={fnSlotCy}
+              fill="var(--color-accent)"
+              initial={false}
+              animate={{ r: s.showTether ? 6 : 3 }}
+              transition={SPRING.snappy}
+            />
+          </motion.g>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Vertical tether: from fn's [[Environment]] slot UP to the frame */}
+      {s.showTether && s.showInnerFn ? (
+        <Arrow
+          x1={fnSlotCx}
+          y1={fnSlotCy}
+          x2={FRAME_X + FRAME_W - 30}
+          y2={FRAME_Y + FRAME_H}
+          tone="active"
+          strokeWidth={1.5}
+          curvature={-22}
+          animateIn
+        />
+      ) : null}
+
+      {/* Lookup label */}
+      {s.showLookup ? (
+        <motion.g
+          key="n-lookup"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ ...SPRING.smooth, delay: 0.15 }}
+        >
+          <text
+            x={FN_X + FN_W / 2}
+            y={FN_Y - 8}
+            textAnchor="middle"
+            fontFamily="var(--font-sans)"
+            fontSize={10}
+            fill="var(--color-accent)"
+          >
+            read x → 7
+          </text>
+        </motion.g>
+      ) : null}
+
+      <text
+        x={W / 2}
+        y={H - 8}
+        textAnchor="middle"
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+        letterSpacing="0.06em"
+      >
+        CLOSURE = FUNCTION + TETHER
+      </text>
+    </svg>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -23,7 +23,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="why-fetch-fails-only-in-browser" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
@@ -215,13 +215,13 @@ export default function WhyFetchFailsOnlyInBrowser() {
           <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t repeat for
           every request.
         </P>
-        <Aside>
+        <Callout tone="warn">
           If your server reflects the request&apos;s <Code>Origin</Code> header back
           in <Code>Access-Control-Allow-Origin</Code> to support many origins, you
           must also send <Code>Vary: Origin</Code>. Without it, a CDN or shared
           proxy can serve origin A&apos;s allowed response to origin B&apos;s
           request. It looks fine in dev and breaks on Tuesday.
-        </Aside>
+        </Callout>
       </div>
 
       {/* §5 — credentials */}

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -85,7 +85,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
         <P>
           Before the mechanism makes sense, the vocabulary has to. An <Term>origin</Term>{" "}
           is the triple <Code>(scheme, host, port)</Code>. Two URLs are the{" "}
-          <Em>same origin</Em> only if all three match. Path doesn&apos;t count.
+          <Em>same origin</Em>{" "}only if all three match. Path doesn&apos;t count.
           Subdomains don&apos;t match. And yes, <Code>http</Code> vs <Code>https</Code>{" "}
           on the exact same hostname is cross-origin — TLS changes the trust boundary.
           Hover any row below to see which part differs.
@@ -96,11 +96,11 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          The <Em>same-origin policy</Em> is the browser&apos;s default. JS running in
+          The <Em>same-origin policy</Em>{" "}is the browser&apos;s default. JS running in
           one origin can&apos;t read a response from another. Loading assets across
           origins — an <Code>&lt;img&gt;</Code>, a <Code>&lt;script&gt;</Code>, a
           stylesheet — has always been allowed, which is why the restriction feels
-          arbitrary until you notice what <Em>is</Em> forbidden: reading a response
+          arbitrary until you notice what <Em>is</Em>{" "}forbidden: reading a response
           from JS. CORS is the opt-in mechanism for punching holes in that wall.
         </P>
         <Callout tone="note">
@@ -130,7 +130,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
           Walk that back slowly. The fetch left the browser. The request reached
           the server. The server ran its handler — the same code it runs for any
           other client. It returned <Code>200 OK</Code> with a real body. The
-          response arrived in the browser. Only then, <Em>after</Em> the whole
+          response arrived in the browser. Only then, <Em>after</Em>{" "}the whole
           round trip, did the browser look at the response headers, fail to find
           an invitation for your page&apos;s origin, and throw the body away.
         </P>
@@ -196,10 +196,10 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          The <Em>preflight</Em> carries <Code>Origin</Code>, the method the real
+          The <Em>preflight</Em>{" "}carries <Code>Origin</Code>, the method the real
           request will use, and any non-safelisted headers it plans to send. The
           server answers with a matching <Code>Access-Control-Allow-Methods</Code>{" "}
-          and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em> does
+          and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em>{" "}does
           the browser let the real request go. If any of those don&apos;t line up,
           the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code>{" "}
           never reaches your backend. This is the one case where CORS genuinely
@@ -229,7 +229,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
         <Dots />
         <H2>Cookies don&apos;t tag along by default</H2>
         <P>
-          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em> send cookies or
+          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em>{" "}send cookies or
           HTTP auth unless you ask. You opt in; the server opts in separately. Both
           sides have to agree.
         </P>
@@ -280,7 +280,7 @@ await fetch('https://api.other.com/me', {
           Three things to check, in order. Which origin is your page? Is the
           server returning <Code>Access-Control-Allow-Origin</Code> matching that
           origin exactly? And if there&apos;s an <Code>OPTIONS</Code> row before
-          your real request, does <Em>that</Em> response approve the method and
+          your real request, does <Em>that</Em>{" "}response approve the method and
           headers you&apos;re about to send? Almost every CORS failure is one of
           those three, in that order.
         </P>

--- a/components/code/CodeBlock.tsx
+++ b/components/code/CodeBlock.tsx
@@ -1,47 +1,96 @@
 import { highlight } from "@/lib/shiki";
 import { CopyButton } from "./CopyButton";
 
+type Tone = "default" | "terminal" | "output";
+
 type Props = {
   code: string;
   lang?: string;
   filename?: string;
-  /** Force line numbers on/off. Default: auto-on for blocks >= 10 lines. */
+  /** Force line numbers on/off. Defaults: on for `default`, off for `terminal` and `output`. */
   showLineNumbers?: boolean;
+  /**
+   * Visual register.
+   * - `default`  — teaching code. Full chrome, line numbers, copy button.
+   * - `terminal` — shell transcript. Renders a `$` prompt on the first
+   *   non-blank line; line numbers off; copy button hidden.
+   * - `output`   — command output. Body dimmed to `--color-text-muted`;
+   *   line numbers off; copy button shown. Flag transient output in
+   *   `scripts/audit-prose.mjs` so teaching code never accidentally dims.
+   */
+  tone?: Tone;
 };
 
-export async function CodeBlock({ code, lang = "typescript", filename, showLineNumbers }: Props) {
+/**
+ * CodeBlock — terminal-style chrome (three muted dots + filename tab + lang
+ * badge) wrapping a Shiki-highlighted code body. The three dot tokens
+ * (`--code-dot-red`/`-yellow`/`-green`) are the one permitted exception to
+ * DESIGN.md §12's one-accent rule — chromas are ≤ 50 % of OS defaults so
+ * they read as a terminal metaphor without lighting the page up with new
+ * accents.
+ *
+ * On phone-width containers (`@container widget (max-width: 560px)`) the
+ * chrome bar shrinks from 34 px to 28 px, the language badge hides, and
+ * the copy button becomes a chrome-bar element so the figure keeps a
+ * compact footprint.
+ */
+export async function CodeBlock({
+  code,
+  lang = "typescript",
+  filename,
+  showLineNumbers,
+  tone = "default",
+}: Props) {
   const trimmed = code.replace(/^\n+|\n+$/g, "");
-  const html = await highlight(trimmed, lang);
-  const lineCount = trimmed.split("\n").length;
-  const numbered = showLineNumbers ?? lineCount >= 10;
+  const highlightLang = tone === "terminal" && lang === "typescript" ? "bash" : lang;
+  const html = await highlight(trimmed, highlightLang);
+  const numbered = showLineNumbers ?? tone === "default";
 
   return (
     <div
-      className="group relative my-[var(--spacing-lg)] overflow-hidden font-mono"
+      className="bs-code group relative my-[var(--spacing-lg)] overflow-hidden font-mono"
+      data-tone={tone}
       style={{
         background: "var(--color-surface)",
         borderRadius: "var(--radius-md)",
         fontSize: "var(--text-mono)",
+        border: "1px solid var(--color-rule)",
       }}
     >
-      {filename ? (
-        <div
-          className="flex items-center justify-between border-b px-[var(--spacing-md)] py-[var(--spacing-2xs)]"
-          style={{
-            borderColor: "var(--color-rule)",
-            color: "var(--color-text-muted)",
-            fontSize: "var(--text-small)",
-          }}
+      {/* macOS-style chrome bar: three muted dots + optional filename + lang */}
+      <div
+        className="bs-code-chrome flex items-center gap-[var(--spacing-sm)] border-b px-[var(--spacing-md)]"
+        style={{
+          borderColor: "var(--color-rule)",
+          color: "var(--color-text-muted)",
+          fontSize: "var(--text-small)",
+          background: "color-mix(in oklab, var(--color-surface) 70%, var(--color-bg))",
+        }}
+      >
+        <span
+          className="bs-code-dots inline-flex items-center gap-[6px]"
+          aria-hidden
         >
-          <span>{filename}</span>
-          <span className="opacity-60 uppercase tracking-wider text-[0.7rem]">{lang}</span>
-        </div>
-      ) : null}
+          <span className="bs-code-dot" style={{ background: "var(--code-dot-red)" }} />
+          <span className="bs-code-dot" style={{ background: "var(--code-dot-yellow)" }} />
+          <span className="bs-code-dot" style={{ background: "var(--code-dot-green)" }} />
+        </span>
+        <span className="bs-code-filename truncate">
+          {filename ?? (tone === "terminal" ? "terminal" : "\u00a0")}
+        </span>
+        <span
+          className="bs-code-badge ml-auto uppercase tracking-wider opacity-60"
+          style={{ fontSize: "0.7rem" }}
+        >
+          {lang}
+        </span>
+      </div>
       <div className="relative">
-        <CopyButton text={trimmed} />
+        {tone !== "terminal" ? <CopyButton text={trimmed} /> : null}
         <div
-          className="overflow-x-auto px-[var(--spacing-md)] py-[var(--spacing-md)] leading-[1.55]"
+          className="bs-code-body overflow-x-auto px-[var(--spacing-md)] py-[var(--spacing-md)] leading-[1.55]"
           data-numbered={numbered ? "true" : undefined}
+          style={{ touchAction: "pan-x" }}
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </div>

--- a/components/code/CodeBlock.tsx
+++ b/components/code/CodeBlock.tsx
@@ -57,14 +57,16 @@ export async function CodeBlock({
         border: "1px solid var(--color-rule)",
       }}
     >
-      {/* macOS-style chrome bar: three muted dots + optional filename + lang */}
+      {/* macOS-style chrome bar: three muted dots + optional filename + lang.
+          Chrome shares the body background (--color-surface) so the block
+          reads as one unified surface with a single 1-px hairline between
+          chrome and body — no gradient tint, no shaded seam. */}
       <div
         className="bs-code-chrome flex items-center gap-[var(--spacing-sm)] border-b px-[var(--spacing-md)]"
         style={{
           borderColor: "var(--color-rule)",
           color: "var(--color-text-muted)",
           fontSize: "var(--text-small)",
-          background: "color-mix(in oklab, var(--color-surface) 70%, var(--color-bg))",
         }}
       >
         <span

--- a/components/prose/Em.tsx
+++ b/components/prose/Em.tsx
@@ -1,5 +1,14 @@
 import type { ReactNode } from "react";
 
+/**
+ * Em — pedagogical emphasis. Italic Plex Serif + weight 500 so emphasised
+ * words actually lift off the body copy (weight 400) and read as a visual
+ * anchor. Weight 500 is already in the loaded font subset (Path B-lite,
+ * shipped #17) so this change costs zero payload.
+ *
+ * Density is policed by the `em-abuse` rule in scripts/audit-prose.mjs
+ * (warns on ≥ 2 consecutive `<Em>` in one paragraph).
+ */
 export function Em({ children }: { children: ReactNode }) {
-  return <em className="italic">{children}</em>;
+  return <em className="italic font-medium">{children}</em>;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "audit": "node scripts/audit-prose.mjs"
   },
   "dependencies": {
     "@vercel/og": "^0.11.1",

--- a/scripts/audit-prose.mjs
+++ b/scripts/audit-prose.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * audit-prose.mjs — scan article JSX files for prose-quality issues.
+ *
+ * Run: `npm run audit` (or `node scripts/audit-prose.mjs <glob-of-files>`).
+ * Exits 1 if any error-level finding is reported, 0 otherwise.
+ *
+ * Why a hand-written scanner and not a real AST parser: the post corpus is
+ * hand-authored JSX with a small, stable component vocabulary. Regex with
+ * contextual rules catches the documented issues without false positives
+ * at the cost of missing exotic constructs we don't write. If the corpus
+ * grows past ~10 posts, migrate to `@babel/parser` with a JSX traversal.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { globSync } from "node:fs";
+import process from "node:process";
+
+const DEFAULT_GLOB = "app/posts/**/page.tsx";
+
+// ANSI colour helpers — minimal, no chalk dep.
+const C = {
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  blue: (s) => `\x1b[34m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+};
+
+/** @type {Array<{rule: string, severity: "error" | "warn" | "info", check: (line: string, lineNo: number, allLines: string[], fileLines: string[]) => Array<{line: number, rule: string, severity: string, snippet: string}>}>} */
+const RULES = [
+  {
+    rule: "missing-space-after-component",
+    severity: "error",
+    check: (line, lineNo) => {
+      // Pattern: </Component>wordchar — close tag immediately followed by a
+      // letter or digit. Whitelist punctuation that legitimately closes a
+      // clause: , . ; : ! ? ) } ] and whitespace.
+      const re = /<\/(Code|Em|Term|A|Kbd|Aside|Callout)>([A-Za-z0-9])/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "missing-space-after-component",
+          severity: "error",
+          snippet: line.slice(Math.max(0, m.index - 10), m.index + 40).trim(),
+        });
+      }
+      return findings;
+    },
+  },
+  {
+    rule: "missing-space-before-component",
+    severity: "error",
+    check: (line, lineNo) => {
+      // Pattern: wordchar<Component — open tag preceded by a letter/digit
+      // with no space. Again, punctuation is fine.
+      const re = /([A-Za-z0-9])<(Code|Em|Term|A|Kbd)>/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "missing-space-before-component",
+          severity: "error",
+          snippet: line.slice(Math.max(0, m.index - 10), m.index + 40).trim(),
+        });
+      }
+      return findings;
+    },
+  },
+  {
+    rule: "punct-glued-to-jsx",
+    severity: "warn",
+    check: (line, lineNo) => {
+      // Pattern: .<Component — sentence-ending punctuation immediately
+      // followed by a new JSX element suggests a missing space after the
+      // period. Common paste artifact.
+      const re = /[.!?]<(Code|Em|Term|A)/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "punct-glued-to-jsx",
+          severity: "warn",
+          snippet: line.slice(Math.max(0, m.index - 10), m.index + 40).trim(),
+        });
+      }
+      return findings;
+    },
+  },
+  {
+    rule: "double-space-in-jsx",
+    severity: "warn",
+    check: (line, lineNo) => {
+      // Pattern: {"  "} with two spaces. Almost always a typo.
+      const re = /\{"\s{2,}"\}/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "double-space-in-jsx",
+          severity: "warn",
+          snippet: line.slice(Math.max(0, m.index - 5), m.index + 20).trim(),
+        });
+      }
+      return findings;
+    },
+  },
+  {
+    rule: "em-abuse",
+    severity: "warn",
+    check: (line, lineNo, allLines, fileLines) => {
+      // Scan the containing <P>...</P> block (or <Aside>, <Callout>) and
+      // count consecutive <Em> siblings. Fire on ≥ 2 within a single block
+      // so the weight-500 bump doesn't make dense-emphasis paragraphs shouty.
+      //
+      // Cheap heuristic: treat each line individually and count <Em> tags.
+      // False-fires on poetic multi-Em lines; author opts out by breaking
+      // into multiple <P>s.
+      const count = (line.match(/<Em>/g) || []).length;
+      if (count >= 2) {
+        return [
+          {
+            line: lineNo,
+            rule: "em-abuse",
+            severity: "warn",
+            snippet: `${count} <Em> tags on this line`,
+          },
+        ];
+      }
+      return [];
+    },
+  },
+  {
+    rule: "aside-vs-callout",
+    severity: "warn",
+    check: (line, lineNo, allLines) => {
+      // Look for an <Aside> block whose content mentions words that suggest
+      // it should be a <Callout tone="note">.
+      if (!/<Aside>/.test(line)) return [];
+      // Join the next ~8 lines (typical Aside length) to catch the content.
+      const block = allLines.slice(lineNo - 1, lineNo + 8).join(" ");
+      const prominentWords = /\b(important|critical|never|always|must|warning|watch out|the rule)\b/i;
+      if (prominentWords.test(block)) {
+        return [
+          {
+            line: lineNo,
+            rule: "aside-vs-callout",
+            severity: "warn",
+            snippet: "Aside mentions a word that reads as prominent",
+          },
+        ];
+      }
+      return [];
+    },
+  },
+  {
+    rule: "inconsistent-codeblock",
+    severity: "warn",
+    check: (line, lineNo) => {
+      // Raw <pre> in a post file should be <CodeBlock> instead. Match at
+      // end-of-line too (word boundary), since the source may break right
+      // after the tag name onto the next line for multi-line JSX.
+      if (/<pre\b/.test(line)) {
+        return [
+          {
+            line: lineNo,
+            rule: "inconsistent-codeblock",
+            severity: "warn",
+            snippet: line.trim().slice(0, 60),
+          },
+        ];
+      }
+      return [];
+    },
+  },
+  {
+    rule: "undersized-code",
+    severity: "info",
+    check: (line, lineNo) => {
+      // <Code>long string</Code> reads cramped at 0.92em on mobile.
+      const re = /<Code>([^<]{20,})<\/Code>/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "undersized-code",
+          severity: "info",
+          snippet: `<Code>${m[1].slice(0, 40)}…</Code> (${m[1].length} chars)`,
+        });
+      }
+      return findings;
+    },
+  },
+  {
+    rule: "low-contrast-output-block",
+    severity: "info",
+    check: (line, lineNo) => {
+      // <CodeBlock tone="output"> dims the body to --color-text-muted, which
+      // fails WCAG AA for small text. Flag so the author can confirm the
+      // block is genuinely transient shell output and not a teaching block.
+      if (/<CodeBlock[^>]*tone="output"/.test(line)) {
+        return [
+          {
+            line: lineNo,
+            rule: "low-contrast-output-block",
+            severity: "info",
+            snippet: 'tone="output" — confirm this block is non-teaching',
+          },
+        ];
+      }
+      return [];
+    },
+  },
+];
+
+function auditFile(path) {
+  const source = readFileSync(path, "utf8");
+  const lines = source.split("\n");
+  /** @type {Array<{line: number, rule: string, severity: string, snippet: string}>} */
+  const findings = [];
+  lines.forEach((line, i) => {
+    const lineNo = i + 1;
+    for (const rule of RULES) {
+      findings.push(...rule.check(line, lineNo, lines, lines));
+    }
+  });
+  return findings;
+}
+
+function report(path, findings) {
+  if (findings.length === 0) return;
+  console.log(C.bold(path));
+  findings.sort((a, b) => a.line - b.line);
+  for (const f of findings) {
+    const mark =
+      f.severity === "error"
+        ? C.red("✗")
+        : f.severity === "warn"
+          ? C.yellow("⚠")
+          : C.blue("ℹ");
+    const ruleCol = f.rule.padEnd(32);
+    const lineCol = C.dim(`L${String(f.line).padStart(4)}`);
+    console.log(`  ${mark} ${lineCol}  ${C.dim(ruleCol)} ${f.snippet}`);
+  }
+}
+
+function main() {
+  const argGlobs = process.argv.slice(2);
+  const patterns = argGlobs.length > 0 ? argGlobs : [DEFAULT_GLOB];
+
+  /** @type {string[]} */
+  const files = [];
+  for (const p of patterns) {
+    if (existsSync(p)) {
+      files.push(p);
+      continue;
+    }
+    try {
+      const matched = globSync(p);
+      files.push(...matched);
+    } catch {
+      console.error(`No matches for ${p}`);
+    }
+  }
+
+  if (files.length === 0) {
+    console.error("No files to audit.");
+    process.exit(2);
+  }
+
+  let totalErrors = 0;
+  let totalWarns = 0;
+  let totalInfo = 0;
+
+  for (const f of files) {
+    const findings = auditFile(f);
+    totalErrors += findings.filter((x) => x.severity === "error").length;
+    totalWarns += findings.filter((x) => x.severity === "warn").length;
+    totalInfo += findings.filter((x) => x.severity === "info").length;
+    report(f, findings);
+  }
+
+  const summary =
+    `${totalErrors} error${totalErrors === 1 ? "" : "s"}, ` +
+    `${totalWarns} warning${totalWarns === 1 ? "" : "s"}, ` +
+    `${totalInfo} info in ${files.length} file${files.length === 1 ? "" : "s"}.`;
+
+  console.log();
+  if (totalErrors > 0) console.log(C.red(summary));
+  else if (totalWarns > 0) console.log(C.yellow(summary));
+  else console.log(C.dim(summary));
+
+  process.exit(totalErrors > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/audit-prose.mjs
+++ b/scripts/audit-prose.mjs
@@ -51,6 +51,32 @@ const RULES = [
     },
   },
   {
+    rule: "fragile-space-after-italic",
+    severity: "warn",
+    check: (line, lineNo) => {
+      // Pattern: </Em> or </Term> followed by a single literal space and a
+      // lowercase word-start. This IS correct source but React's whitespace
+      // handling in SSR has been observed to drop the space in some cases
+      // (specifically inside Callout/Aside wrappers and after `{" "}`
+      // expressions). Suggest the defensive form `</Em>{" "}word`.
+      //
+      // Scoped to Em/Term only because those are italic — the missing-space
+      // bug shows up as glued italic + roman, which is visually painful.
+      const re = /<\/(Em|Term)>\s+[a-z]/g;
+      const findings = [];
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        findings.push({
+          line: lineNo,
+          rule: "fragile-space-after-italic",
+          severity: "warn",
+          snippet: `${line.slice(Math.max(0, m.index - 8), m.index + 24).trim()}  — consider </${m[1]}>{" "}word`,
+        });
+      }
+      return findings;
+    },
+  },
+  {
     rule: "missing-space-before-component",
     severity: "error",
     check: (line, lineNo) => {


### PR DESCRIPTION
Plan: \`~/.claude/plans/unified-snacking-blossom.md\`. Stress-tested via /grill-me before implementation — one branch revised (\`lg:\` → \`md:\` on the hero-tile hide). **Mobile-first is now the durable stance** — every future article, widget, and animation starts at 360 px and relaxes upward.

## Four deliverables

### 1. Dev-time prose audit · \`scripts/audit-prose.mjs\` + \`npm run audit\`

Nine rules, exits 1 on any error-level finding:

| Rule | Severity | Catches |
|---|---|---|
| \`missing-space-after-component\` | error | \`<Code>foo</Code>bar\` |
| \`missing-space-before-component\` | error | \`bar<Code>foo</Code>\` |
| \`punct-glued-to-jsx\` | warn | \`.<Code>\` (sentence-end paste artifact) |
| \`double-space-in-jsx\` | warn | \`{"  "}\` |
| \`em-abuse\` | warn | ≥ 2 consecutive \`<Em>\` in one paragraph (tightened from the plan's ≥ 3 after /grill-me) |
| \`aside-vs-callout\` | warn | \`<Aside>\` mentioning *important*, *must*, *never*, etc. |
| \`inconsistent-codeblock\` | warn | raw \`<pre>\` in a post |
| \`undersized-code\` | info | \`<Code>…</Code>\` > 20 chars |
| \`low-contrast-output-block\` | info | \`<CodeBlock tone=\"output\">\` — confirm non-teaching |

Pure Node 22, zero new deps. Output format: filename, colored severity mark, line, rule, snippet. Run via \`npm run audit\` — wires cleanly into CI later.

### 2. Widget mobile-first redesign (LoopTrap, TetherScope, RenderLoom)

Each widget now authors **two SVG layouts**. A single \`@container widget (max-width: 560px)\` query in \`globals.css\` picks which renders. Same pure-CSS pattern \`RequestJourney\` already ships: both trees serialize on SSR; CSS toggles visibility; no hydration mismatch, no ResizeObserver.

**Wide** — unchanged 680-unit landscape layouts.

**Narrow** — portrait compositions tuned to what each widget teaches:

- **LoopTrap** — callbacks stack vertically down the left (native-size labels), bindings column on the right (one big cell for \`var\`, five for \`let\`), horizontal tethers between, console pinned at the bottom. The *topology* — one-cell vs five-cell — is still the teaching.
- **TetherScope** — code pane on top, runtime heap below (frame above, function object beneath it). The tether, which was a horizontal curve, becomes a **vertical** curve from the function's \`[[Environment]]\` slot up to the pinned frame. Same \`SPRING.smooth\` animation, reoriented.
- **RenderLoom** — *screen on top* (what the user sees), render stack in the middle, effect callback at the bottom. Reading order matches the mental model: output → machinery → cause. Tether draws as a vertical arrow from the callback up to the tethered render.

\`PredictReveal\` is inline prose + button — no change needed.

### 3. Terminal-style \`<CodeBlock>\`

macOS chrome with three 8-px **muted-tone** dots — not shouty OS traffic-lights. Colors tokenized in \`@theme\`:

\`\`\`css
--code-dot-red:    oklch(0.58 0.09 28);
--code-dot-yellow: oklch(0.75 0.08 80);
--code-dot-green:  oklch(0.68 0.08 150);
\`\`\`

Each ≤ 50 % chroma of its OS equivalent. Recognizable as a terminal metaphor without lighting the page up with three new accents. **DESIGN.md §12 gains an explicit carve-out** naming these tokens — the one permitted exception to the one-accent rule.

Additions:
- \`tone\` prop: \`default | terminal | output\`. \`terminal\` renders a \`$\` prompt on the first line; \`output\` dims the body to \`--color-text-muted\` (and the audit rule \`low-contrast-output-block\` surfaces every instance so teaching code never accidentally dims).
- Line numbers on by default for \`default\` tone (removed the ≥ 10 line auto-rule).
- Container-query mobile density: chrome shrinks 34 → 28 px, language badge hides, padding tightens below 560 px. Copy button keeps its 44 × 44 tap zone.
- Four raw \`<pre>\` blocks in \"the function that remembered\" migrated to \`<CodeBlock>\`.

DESIGN.md §6 fully rewritten to document the chrome, tone prop, and mobile density.

### 4. Hero tile hidden below \`md:\`

Three post pages — \`<div>\` wrapping \`<HeroTile>\` now has \`hidden md:flex\`. The plan originally said \`lg:\`; /grill-me surfaced the bad justification and the fix. At \`md:\`:

- **Phones** (< 768): no tile. Home-list source cover still exists → view-transition sees a missing destination and plays a clean one-sided fade via the root transition. No broken half-morph.
- **Tablet portrait** (≥ 768): tile visible at 64 × 64, home cover also 64 × 64. Morph works both directions.
- **Tablet landscape / desktop** (≥ 1024): tile at 80 × 80, home cover at 80 × 80. Same.

## Supporting changes

- **\`<Em>\`** gets \`font-medium\` alongside italic so emphasised words actually lift off body copy. Weight 500 is in the existing font subset (Path B-lite, shipped #17) — zero payload cost. \`em-abuse\` audit rule tightened to ≥ 2 consecutive so dense-emphasis paragraphs get flagged.
- **Aside → Callout** conversion in \`why-fetch-fails-only-in-browser\` (the \"Vary: Origin\" gotcha) — surfaced by the \`aside-vs-callout\` rule on the word \"must\". Now \`tone=\"warn\"\` with the proper \"Watch out —\" label.

## Test plan
- [ ] \`npm run audit\` — 0 errors across all three post pages.
- [ ] \`npm run build\` — clean TypeScript + Turbopack.
- [ ] \`/posts/the-function-that-remembered\` at 360 w: LoopTrap / TetherScope / RenderLoom render in portrait layout, every label ≥ 10 px, no horizontal scroll inside the widgets.
- [ ] Same page at 1024 w: all three render in landscape (unchanged from pre-PR).
- [ ] All three post pages at 360 w: no hero tile above the H1. Title is the first visible element after the nav.
- [ ] Tablet portrait (810 w): hero tile visible; navigating home → post triggers the cover → tile morph.
- [ ] CodeBlock chrome visible on every block: three muted dots, filename (if provided), language badge (hidden below 560 px). Copy button works with ring-pulse.
- [ ] Toggle theme on a post: dots stay muted in both themes (no full-saturation red/yellow/green in light mode).
- [ ] \`<Em>\` italics now render with slightly heavier weight — confirm no ugly reflow on the three posts at 768 / 1024.
- [ ] \`prefers-reduced-motion: reduce\`: widget reveals, code-block hydration, view-transition all collapse to ≤ 1 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)