### PR TITLE
article: the browser stopped asking

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -461,6 +461,54 @@ html[data-theme-transitioning] {
   }
 }
 
+/* PipeCompare (the-browser-stopped-asking §3) — mobile-first. The default
+   layout stacks one row per protocol vertically with the label + stats
+   ABOVE its timeline, so phone widths never compress a 9-pt legend into
+   illegibility. At --flip-wide the three rows sit in a single canvas with
+   stats in a left gutter, giving the reader the side-by-side comparison
+   that carries the §3 pedagogy. Same JS state drives both. */
+.bs-pc-wide {
+  display: none;
+}
+@container widget (min-width: 640px) {
+  .bs-pc-narrow {
+    display: none;
+  }
+  .bs-pc-wide {
+    display: block;
+  }
+}
+
+/* UpgradeHandshake (§4) — mobile-first. Default is vertical: browser on
+   top, vertical pipe, server on the bottom. At --flip-wide the classic
+   horizontal sequence-diagram layout (browser ← pipe → server) returns. */
+.bs-uh-wide {
+  display: none;
+}
+@container widget (min-width: 640px) {
+  .bs-uh-narrow {
+    display: none;
+  }
+  .bs-uh-wide {
+    display: block;
+  }
+}
+
+/* ReconnectGap (§5) — mobile-first. Default labels each timeline row ABOVE
+   the lifeline; wide variant moves labels into a left gutter so the
+   timelines align vertically. */
+.bs-rg-wide {
+  display: none;
+}
+@container widget (min-width: 560px) {
+  .bs-rg-narrow {
+    display: none;
+  }
+  .bs-rg-wide {
+    display: block;
+  }
+}
+
 @keyframes ring-pulse {
   0% {
     box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-accent) 35%, transparent);

--- a/app/posts/the-browser-stopped-asking/metadata.ts
+++ b/app/posts/the-browser-stopped-asking/metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "the-browser-stopped-asking";
+const TITLE = "The browser stopped asking";
+const HOOK =
+  "HTTP is request-response by design. Real-time apps break that rule by keeping one request alive forever — and the server starts talking first.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: HOOK,
+  openGraph: {
+    title: TITLE,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/the-browser-stopped-asking/page.tsx
+++ b/app/posts/the-browser-stopped-asking/page.tsx
@@ -507,28 +507,6 @@ const socket = io("https://…", {
           The title lied slightly: the browser didn&apos;t stop asking. It stopped
           ending the question.
         </p>
-
-        <div style={{ marginBlockStart: "var(--spacing-xl)" }}>
-          <p
-            className="font-sans font-semibold uppercase tracking-wider"
-            style={{
-              fontSize: "0.7rem",
-              letterSpacing: "0.08em",
-              color: "var(--color-accent)",
-              marginBlockEnd: "var(--spacing-2xs)",
-            }}
-          >
-            next —
-          </p>
-          <P>
-            We&apos;ve seen the pipe. We haven&apos;t seen what flows through it.
-            When Jordan types <Code>B → BC</Code>{" "}at the same moment you type{" "}
-            <Code>B → AB</Code>, why doesn&apos;t the document collapse into{" "}
-            <Code>ABC</Code>{" "}on one screen and <Code>BC</Code>{" "}on the other?
-            That answer isn&apos;t about the pipe — it&apos;s about the merge
-            algorithm running on top of it (the CRDT / OT family). Post two.
-          </P>
-        </div>
       </div>
     </Prose>
   );

--- a/app/posts/the-browser-stopped-asking/page.tsx
+++ b/app/posts/the-browser-stopped-asking/page.tsx
@@ -1,0 +1,535 @@
+import {
+  Prose,
+  H1,
+  H2,
+  H3,
+  P,
+  Code,
+  Callout,
+  Dots,
+  Em,
+  A,
+  FullBleed,
+  HeroTile,
+  Term,
+} from "@/components/prose";
+import { CodeBlock } from "@/components/code";
+import { PipeCompare, UpgradeHandshake, ReconnectGap } from "./widgets";
+import { metadata } from "./metadata";
+
+export { metadata };
+
+export default function TheBrowserStoppedAsking() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="the-browser-stopped-asking" />
+        </div>
+        <H1>The browser stopped asking</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-20">apr 20, 2026</time>
+          <span className="mx-2">·</span>
+          <span>9 min read</span>
+        </p>
+
+        {/* §0 — the scene */}
+        <P>
+          You open a Google Doc link a teammate sent you. In the top-right a tinted
+          avatar appears — Jordan is in. A colored cursor labeled <Em>Jordan</Em>{" "}shows
+          up inside the document. Jordan starts typing. The characters appear on your
+          screen as they&apos;re typed — not on refresh, not after a click, not when
+          you tab back in. They&apos;re just there.
+        </P>
+        <P>
+          The moment is so mundane we forget that the web wasn&apos;t born able to do
+          this. Rewind: <Em>what had to change about the web for Jordan&apos;s cursor
+          to appear on your screen?</Em>
+        </P>
+      </div>
+
+      {/* §1 — HTTP's only move */}
+      <div>
+        <Dots />
+        <H2>HTTP&apos;s only move is request-and-reply</H2>
+        <P>
+          The web&apos;s original protocol has one shape: the browser asks, the server
+          answers, the connection closes. That&apos;s it. A <Term>request</Term>{" "}
+          leaves your machine, a <Term>response</Term>{" "}comes back, and whatever
+          socket they travelled on is recycled or discarded. There is no protocol
+          room for the server to say anything the browser didn&apos;t ask for.
+        </P>
+        <P>
+          This isn&apos;t a style choice; it&apos;s baked in. HTTP/1.1{" "}
+          <A href="https://www.rfc-editor.org/rfc/rfc9112#section-9.2">
+            (RFC 9112 §9.2)
+          </A>
+          {" "}doesn&apos;t carry a request ID on the wire. Responses are matched to
+          requests <Em>by arrival order</Em>. If the server ever spoke out of turn,
+          the browser would have no way to know which request — if any — it was
+          replying to.
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="http"
+          filename="the shape everything else lives inside"
+          tone="terminal"
+          code={`GET /doc/42 HTTP/1.1
+Host: docs.example
+Accept: text/html
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Length: 1432
+
+<!doctype html>…`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          The web&apos;s cell wall is that the client always speaks first. Everything
+          that follows — every mechanism that makes Jordan&apos;s cursor appear on
+          your screen — is a way to <Em>live inside that wall</Em>. None of them let
+          the server initiate. They all turn the browser into something else: a
+          listener, not an asker.
+        </P>
+      </div>
+
+      {/* §2 — polling */}
+      <div>
+        <Dots />
+        <H2>First workaround: just keep asking</H2>
+        <P>
+          The most obvious answer is also the crudest. Fire a request every second
+          and see if anything&apos;s new.
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="javascript"
+          filename="polling.js"
+          code={`setInterval(async () => {
+  const res = await fetch('/doc/42/updates?since=' + lastSeen);
+  const updates = await res.json();
+  if (updates.length) applyUpdates(updates);
+}, 1000);
+
+// 60 requests / minute. Each carries ~500–2000 B of HTTP headers.
+// At 1s intervals, that's ~120 KB / minute just to say: "anything new?"
+// Most of the time the answer is: no.`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          This <Term>polling</Term>{" "}loop honors HTTP&apos;s rule to the letter. It
+          also pays for it. A full request-response round-trip isn&apos;t free:
+          RFC 6202 notes that <Em>&ldquo;every long poll request and long poll
+          response is a complete HTTP message and thus contains a full set of HTTP
+          headers&rdquo;</Em> — the same is obviously true of short polling, where
+          the headers show up 60 times a minute whether or not there&apos;s anything
+          to say{" "}
+          <A href="https://datatracker.ietf.org/doc/html/rfc6202#section-2.2">
+            (RFC 6202 §2.2)
+          </A>.
+        </P>
+        <P>
+          Worse, your typing latency is bounded below by your polling interval.
+          Jordan hits a key; you don&apos;t see it until your next tick. Make the
+          interval shorter? You burn more bytes per minute. Make it longer? You watch
+          letters arrive in clumps.
+        </P>
+        <Callout tone="note">
+          Polling isn&apos;t dead. When updates are rare and tolerable latency is in
+          seconds (build statuses, queue positions), it&apos;s genuinely the right
+          shape. The trouble is what happens when you try to scale it to{" "}
+          <Em>every cursor in every open document</Em>.
+        </Callout>
+      </div>
+
+      {/* §3 — long polling + PipeCompare */}
+      <div>
+        <Dots />
+        <H2>What if you asked once, and the server waited?</H2>
+        <P>
+          Here&apos;s the clever move. The client still asks. But the server
+          doesn&apos;t reply until it has news. The request goes out, the TCP socket
+          stays open, and the response just… sits there, a promise dangling on both
+          sides of the wire. When something happens — Jordan types a letter — the
+          server finally writes the response and closes. The client reads it and
+          immediately opens another request, and the cycle repeats.
+        </P>
+        <P>
+          Ably calls this shape <A href="https://ably.com/topic/long-polling">&ldquo;bending HTTP slightly out of shape&rdquo;</A>.
+          The request-response format is preserved — it&apos;s still one ask, one
+          answer. What changed is the client&apos;s tolerance for waiting. A polling
+          client fires and forgets; a <Term>long-polling</Term>{" "}client fires and
+          listens, sometimes for tens of seconds, before the single reply arrives.
+        </P>
+        <P>
+          Alex Russell coined <Em>Comet</Em>{" "}for this family{" "}
+          <A href="https://infrequently.org/2006/03/comet-low-latency-data-for-the-browser/">
+            in March 2006
+          </A>, and it was the secret sauce behind the first generation of
+          &ldquo;live&rdquo; web apps. <strong>Google Docs shipped on long polling
+          for years.</strong> Look inside Google&apos;s Closure Library and
+          you&apos;ll still find <Code>goog.net.BrowserChannel</Code> — long polling
+          over XHR, with forever-iframe streaming as a fallback. Attribution comes
+          from ex-Googlers and{" "}
+          <A href="https://github.com/josephg/node-browserchannel">
+            Joseph Gentle&apos;s node re-implementation
+          </A>; Google itself doesn&apos;t publish it as an API, which is its own
+          kind of tell.
+        </P>
+      </div>
+
+      <PipeCompare />
+
+      <div>
+        <P>
+          Press play and watch the first two rows together. Polling racks up
+          roundtrips — most empty. Long polling only sends a byte when it matters.
+          The third row is a different kind of thing. The rest of this post is about
+          how it gets there.
+        </P>
+        <P>
+          What&apos;s happening in the long-polling row is the move the whole
+          genre is built on. The client <Em>still asked.</Em> It just{" "}
+          <Em>stopped hanging up</Em>{" "}when the server had nothing to say. That one
+          change — the browser refusing to finish the question — is what every
+          later protocol inherits.
+        </P>
+        <P>
+          Long polling is the first trick that actually felt live. It&apos;s also a
+          hack: every reply still pays one full HTTP round-trip of overhead —
+          headers, TLS re-validation, a TCP handshake if the connection didn&apos;t
+          stay warm. Someone was going to want to skip that.
+        </P>
+      </div>
+
+      {/* §4 — WebSockets + UpgradeHandshake */}
+      <div>
+        <Dots />
+        <H2>The line that ends HTTP mid-socket</H2>
+        <P>
+          WebSocket&apos;s move is to get HTTP to politely step aside. The client
+          opens a regular HTTP request with three special headers that ask it to{" "}
+          <Em>stop being HTTP</Em>. The server replies with a status code that
+          was, until WebSocket came along, vanishingly rare —{" "}
+          <Code>101 Switching Protocols</Code>{" "}— plus one header that proves it
+          understood.
+        </P>
+      </div>
+
+      <FullBleed>
+        <div className="grid gap-[var(--spacing-md)] md:grid-cols-[1fr_1fr]">
+          <CodeBlock
+            lang="http"
+            filename="client · opening request"
+            code={`GET /chat HTTP/1.1
+Host: docs.example
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Sec-WebSocket-Version: 13`}
+          />
+          <CodeBlock
+            lang="http"
+            filename="server · the 101 reply"
+            code={`HTTP/1.1 101 Switching Protocols
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`}
+          />
+        </div>
+      </FullBleed>
+
+      <div>
+        <P>
+          The proof header is a hash. The client sent a random key in the request;
+          the server has to send one specific derivation of it back. The next widget
+          runs that derivation <Em>in your browser</Em>{" "}against a fresh random key
+          every time you press the button.
+        </P>
+      </div>
+
+      <UpgradeHandshake />
+
+      <div>
+        <P>
+          What you just watched was a SHA-1 over your random key with one very
+          strange suffix glued on. That suffix is a literal string, written into
+          the spec itself, identical for every server on earth:
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="text"
+          filename="RFC 6455 §1.3 — the string, verbatim"
+          code={`258EAFA5-E914-47DA-95CA-C5AB0DC85B11`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          The whole algorithm fits on one line:
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="text"
+          tone="output"
+          code={`Sec-WebSocket-Accept = base64( sha1( Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" ) )`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          The GUID is there so an unaware server can&apos;t accidentally reply{" "}
+          <Em>&ldquo;yes, we&apos;re speaking WebSocket&rdquo;</Em>{" "}without having
+          read the spec — the only way to produce the right accept header is to
+          know exactly what string to glue on{" "}
+          <A href="https://www.rfc-editor.org/rfc/rfc6455#section-1.3">
+            (RFC 6455 §1.3)
+          </A>. The widget runs the computation through your browser&apos;s Web
+          Crypto API, so the <Code>Sec-WebSocket-Accept</Code>{" "}you see is the
+          real SHA-1 your machine just computed. Nothing in the reveal is faked.
+        </P>
+        <P>
+          After that reply is written and read, the same TCP socket is{" "}
+          <Em>no longer speaking HTTP.</Em>{" "}It speaks WebSocket frames — 2 bytes
+          of header for most messages, up to 14 at the far end. Either side can
+          send, anytime, as long as both ends want the connection open. The client
+          spoke first, exactly once, and then the conversation became something
+          else.
+        </P>
+        <Callout tone="note">
+          Frame opcodes are a four-bit field{" "}
+          <A href="https://www.rfc-editor.org/rfc/rfc6455#section-5.2">
+            (§5.2)
+          </A>:{" "}<Code>0x1</Code> text, <Code>0x2</Code> binary,{" "}
+          <Code>0x8</Code> close, <Code>0x9</Code> ping, <Code>0xA</Code> pong. The
+          last two are load-bearing in production — NAT middleboxes silently drop
+          idle TCP flows, so WebSocket servers send pings at a cadence shorter than
+          the shortest NAT timeout on the path. Your socket looks healthy right up
+          until the next write fails.
+        </Callout>
+      </div>
+
+      {/* §5 — SSE + ReconnectGap */}
+      <div>
+        <Dots />
+        <H2>One direction, with a safety net</H2>
+        <P>
+          WebSocket isn&apos;t the only way out. <Term>Server-Sent Events</Term>{" "}
+          (SSE) are the one-way cousin: a regular HTTP response with{" "}
+          <Code>Content-Type: text/event-stream</Code> that the server never closes.
+          The browser hands each <Code>data: …\n\n</Code> chunk to{" "}
+          <Code>onmessage</Code> as it arrives. An SSE handler can be eight lines
+          of Node.
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="javascript"
+          filename="server.js · the entire SSE handler"
+          code={`app.get('/stream', (req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.flushHeaders();
+
+  const send = (ev) => res.write(\`id: \${ev.id}\\ndata: \${JSON.stringify(ev)}\\n\\n\`);
+  const off = bus.on('update', send);
+  req.on('close', off);
+});`}
+        />
+      </FullBleed>
+
+      <div>
+        <P>
+          If WebSocket is &ldquo;HTTP steps aside,&rdquo; SSE is &ldquo;HTTP just
+          never stops.&rdquo; No Upgrade, no magic GUID, no frame opcodes. Just one
+          very patient HTTP response that keeps writing.
+        </P>
+        <P>
+          Then why not use WebSocket for everything? Because SSE ships the one
+          feature WebSocket doesn&apos;t:{" "}
+          <strong>automatic reconnect, with state recovery.</strong> The browser
+          remembers the last event&apos;s <Code>id:</Code>{" "}field, and when the
+          stream drops, it reopens the connection with a{" "}
+          <Code>Last-Event-ID</Code>{" "}header so the server can resume from that
+          cursor{" "}
+          <A href="https://html.spec.whatwg.org/multipage/server-sent-events.html#processing-model">
+            (WHATWG HTML §9.2.3)
+          </A>. WebSocket has none of this in the spec. The socket closes, you start
+          over — from whatever <Code>ws://</Code>{" "}URL, with whatever auth, and
+          whatever resume protocol you decided to build.
+        </P>
+      </div>
+
+      <ReconnectGap />
+
+      <div>
+        <P>
+          Drag the dropout in the widget. Both rows experience the same outage; only
+          one of them quietly heals. This is why SSE is not a weaker WebSocket —
+          it&apos;s a different trade. For one-way flows (notifications, logs,
+          progress streams, a live leaderboard), SSE gives you resilience for free.
+          For real two-way exchanges — say, sending Jordan&apos;s keystrokes back to
+          Google&apos;s ack path — you need <Term>full-duplex</Term>, both ends
+          talking at once instead of in turns. SSE can&apos;t give you that.
+        </P>
+      </div>
+
+      {/* §6 — the catch */}
+      <div>
+        <Dots />
+        <H2>The cost moved. It didn&apos;t vanish.</H2>
+        <P>
+          Three places the cost reappears — one for each mechanism. None of them
+          are in the tutorials.
+        </P>
+
+        <H3>&ldquo;Just use WebSockets&rdquo; still opens with long polling</H3>
+        <P>
+          Open the docs for the most widely deployed real-time library in the JS
+          world and read carefully.{" "}
+          <A href="https://socket.io/docs/v4/how-it-works/">Socket.IO v4</A>{" "}
+          <Em>still starts every connection with HTTP long polling</Em>, and only
+          upgrades to WebSocket once the handshake clears. Corporate proxies,
+          older transparent caches, and some antivirus software silently mis-handle
+          the <Code>Upgrade</Code>{" "}header. The fallback isn&apos;t legacy — it&apos;s
+          2026 insurance.
+        </P>
+      </div>
+
+      <FullBleed>
+        <CodeBlock
+          lang="javascript"
+          filename="socket.io-client · the default nobody reads"
+          code={`import { io } from "socket.io-client";
+
+const socket = io("https://…", {
+  transports: ["polling", "websocket"],  // ← polling first. on purpose.
+});`}
+        />
+      </FullBleed>
+
+      <div>
+        <H3>A gateway restarts, and every client knocks at once</H3>
+        <P>
+          Discord learned this at five million concurrent sessions. One gateway
+          blipped and the stampede of reconnects hit a ring-lookup process that{" "}
+          <A href="https://discord.com/blog/how-discord-scaled-elixir-to-5-000-000-concurrent-users">
+            took 17.5 seconds just to answer the queries
+          </A>{" "}
+          until they cached the results. Slack&apos;s{" "}
+          <A href="https://slack.engineering/flannel-an-application-level-edge-cache-to-make-slack-scale/">
+            Flannel
+          </A>{" "}was motivated by the same shape: one office loses network, and the
+          retry wave costs more than the outage that caused it. The tutorial writes{" "}
+          <Code>ws.onclose = () =&gt; reconnect()</Code>{" "}and moves on; production
+          writes randomized backoff, per-tenant semaphores, and lazy payloads so the
+          next herd can&apos;t trample the server that just recovered.
+        </P>
+
+        <H3>Fanout is the real ceiling</H3>
+        <P>
+          Phoenix held two million idle WebSocket connections on one box. So that
+          part isn&apos;t the problem. The problem is writing to all of them at the
+          same moment — Discord&apos;s publish to a single 30,000-member guild took{" "}
+          <strong>900 ms – 2.1 s</strong>{" "}before they parallelized fanout with
+          Manifold. The reader&apos;s mental model flips: the hard part of
+          real-time isn&apos;t holding the connection. It&apos;s the{" "}
+          <Code>O(N)</Code>{" "}write on every event.
+        </P>
+
+        <P>
+          None of this kills the idea. It just means <Em>real-time is a system,
+          not a primitive.</Em> The socket is the easy part.
+        </P>
+      </div>
+
+      {/* §7 — back to the scene */}
+      <div>
+        <Dots />
+        <H2>So when Jordan&apos;s cursor shows up on your screen…</H2>
+        <P>
+          …which of these is actually doing the work? Probably a WebSocket today.
+          Was long polling, via BrowserChannel, for most of the last decade. Google
+          doesn&apos;t publish which, and the honest answer is that most production
+          systems have <Em>some layer of every mechanism in this post</Em>{" "}somewhere
+          — polling for a heartbeat, long polling as a Socket.IO fallback, a
+          WebSocket for the hot path, SSE for the log tail, a cache in front of it
+          all so a reconnect storm doesn&apos;t take the site down.
+        </P>
+        <P>
+          What they share is the move at the center of every one of them. The
+          server never learned to speak first. The browser just stopped hanging up.
+          A request goes out; it doesn&apos;t come back until it has something to
+          say; it opens another the moment it does; or the socket simply never
+          closes.
+        </P>
+        <p
+          style={{
+            fontSize: "1.125em",
+            marginBlockStart: "1.5em",
+            marginBlockEnd: "0.2em",
+            lineHeight: 1.55,
+          }}
+        >
+          <Em>
+            Every &ldquo;real-time&rdquo; web app on your laptop right now is
+            variations on a browser that refuses to finish its sentence.
+          </Em>
+        </p>
+        <p
+          className="font-sans"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+            marginBlockStart: "0.5em",
+          }}
+        >
+          The title lied slightly: the browser didn&apos;t stop asking. It stopped
+          ending the question.
+        </p>
+
+        <div style={{ marginBlockStart: "var(--spacing-xl)" }}>
+          <p
+            className="font-sans font-semibold uppercase tracking-wider"
+            style={{
+              fontSize: "0.7rem",
+              letterSpacing: "0.08em",
+              color: "var(--color-accent)",
+              marginBlockEnd: "var(--spacing-2xs)",
+            }}
+          >
+            next —
+          </p>
+          <P>
+            We&apos;ve seen the pipe. We haven&apos;t seen what flows through it.
+            When Jordan types <Code>B → BC</Code>{" "}at the same moment you type{" "}
+            <Code>B → AB</Code>, why doesn&apos;t the document collapse into{" "}
+            <Code>ABC</Code>{" "}on one screen and <Code>BC</Code>{" "}on the other?
+            That answer isn&apos;t about the pipe — it&apos;s about the merge
+            algorithm running on top of it (the CRDT / OT family). Post two.
+          </P>
+        </div>
+      </div>
+    </Prose>
+  );
+}

--- a/app/posts/the-browser-stopped-asking/widgets/PipeCompare.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/PipeCompare.tsx
@@ -1,0 +1,825 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { PRESS, SPRING } from "@/lib/motion";
+import { Scrubber } from "@/components/viz/Scrubber";
+import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
+import { WidgetShell } from "./WidgetShell";
+
+const DURATION_MS = 10_000;
+
+// Polling knobs
+const POLL_INTERVAL_MS = 1000;
+const POLL_LATENCY_MS = 120;
+const POLL_REQ_BYTES = 520;
+const POLL_EMPTY_RES_BYTES = 140;
+const POLL_DATA_RES_BYTES = 260;
+
+// Long-polling knobs
+const LP_LATENCY_MS = 60;
+const LP_REQ_BYTES = 520;
+const LP_RES_BYTES = 260;
+
+// WebSocket knobs
+const WS_HANDSHAKE_MS = 140;
+const WS_HANDSHAKE_BYTES = 520;
+const WS_FRAME_BYTES = 14;
+const WS_DELIVERY_MS = 10;
+
+// "News" on the server — three events across the 10s window.
+const EVENTS_MS = [1600, 4700, 8200] as const;
+
+/* -------------------------------------------------------------------------- */
+/*                              Simulation pure-fns                           */
+/* -------------------------------------------------------------------------- */
+
+type Stats = {
+  reqs: number;
+  bytesSent: number;
+  eventsDelivered: number;
+  worstLatencyMs: number;
+};
+
+type Msg = {
+  /** t of when the message appears on the wire (start). */
+  tStart: number;
+  /** t of when it arrives (end). For instantaneous pulses, tEnd === tStart. */
+  tEnd: number;
+  /** Direction. */
+  dir: "down" | "up"; // down = browser→server, up = server→browser
+  kind: "req" | "emptyRes" | "dataRes" | "frameUp" | "frameDown" | "handshakeReq" | "handshakeRes";
+  /** An optional "span" payload (for long-poll's held request). */
+  held?: boolean;
+};
+
+type Sim = {
+  stats: Stats;
+  messages: Msg[];
+  /** For long-poll, the *currently-held* request span, if any. */
+  heldSpan?: { from: number; to: number };
+};
+
+function simPolling(nowMs: number): Sim {
+  const messages: Msg[] = [];
+  let bytesSent = 0;
+  let reqs = 0;
+  let eventsDelivered = 0;
+  let worst = 0;
+
+  for (let start = 0; start <= nowMs; start += POLL_INTERVAL_MS) {
+    // Request fires
+    messages.push({ tStart: start, tEnd: start, dir: "down", kind: "req" });
+    bytesSent += POLL_REQ_BYTES;
+    reqs += 1;
+
+    const resT = start + POLL_LATENCY_MS;
+    if (resT > nowMs) break;
+
+    // Did any event land in the window strictly after the previous poll and
+    // at-or-before this one? Those get batched into this poll's reply.
+    const inWin = EVENTS_MS.filter(
+      (e) => e > start - POLL_INTERVAL_MS && e <= start,
+    );
+    if (inWin.length > 0) {
+      messages.push({ tStart: resT, tEnd: resT, dir: "up", kind: "dataRes" });
+      bytesSent += POLL_DATA_RES_BYTES;
+      eventsDelivered += inWin.length;
+      for (const e of inWin) worst = Math.max(worst, resT - e);
+    } else {
+      messages.push({ tStart: resT, tEnd: resT, dir: "up", kind: "emptyRes" });
+      bytesSent += POLL_EMPTY_RES_BYTES;
+    }
+  }
+
+  return {
+    stats: { reqs, bytesSent, eventsDelivered, worstLatencyMs: worst },
+    messages,
+  };
+}
+
+function simLongPoll(nowMs: number): Sim {
+  const messages: Msg[] = [];
+  let bytesSent = 0;
+  let reqs = 0;
+  let eventsDelivered = 0;
+  let worst = 0;
+  let openedAt = 0;
+  let heldSpan: Sim["heldSpan"];
+
+  for (let i = 0; i < 40 && openedAt <= nowMs; i++) {
+    // Client fires a fresh long-poll request
+    messages.push({ tStart: openedAt, tEnd: openedAt, dir: "down", kind: "req" });
+    bytesSent += LP_REQ_BYTES;
+    reqs += 1;
+
+    const nextEvt = EVENTS_MS.find((e) => e >= openedAt);
+    if (nextEvt == null) {
+      heldSpan = { from: openedAt, to: nowMs };
+      break;
+    }
+
+    if (nextEvt > nowMs) {
+      heldSpan = { from: openedAt, to: nowMs };
+      break;
+    }
+
+    const replyT = nextEvt + LP_LATENCY_MS;
+    messages.push({
+      tStart: openedAt,
+      tEnd: Math.min(replyT, nowMs),
+      dir: "down",
+      kind: "req",
+      held: true,
+    });
+
+    if (replyT <= nowMs) {
+      messages.push({ tStart: replyT, tEnd: replyT, dir: "up", kind: "dataRes" });
+      bytesSent += LP_RES_BYTES;
+      eventsDelivered += 1;
+      worst = Math.max(worst, replyT - nextEvt);
+      openedAt = replyT + 2;
+    } else {
+      heldSpan = { from: openedAt, to: nowMs };
+      break;
+    }
+  }
+
+  return {
+    stats: { reqs, bytesSent, eventsDelivered, worstLatencyMs: worst },
+    messages,
+    heldSpan,
+  };
+}
+
+function simWebSocket(nowMs: number): Sim {
+  const messages: Msg[] = [];
+  let bytesSent = 0;
+  let reqs = 0;
+  let eventsDelivered = 0;
+  let worst = 0;
+
+  if (nowMs >= 0) {
+    messages.push({ tStart: 0, tEnd: 0, dir: "down", kind: "handshakeReq" });
+    reqs += 1;
+    bytesSent += WS_HANDSHAKE_BYTES;
+  }
+  if (nowMs >= WS_HANDSHAKE_MS) {
+    messages.push({
+      tStart: WS_HANDSHAKE_MS,
+      tEnd: WS_HANDSHAKE_MS,
+      dir: "up",
+      kind: "handshakeRes",
+    });
+  }
+  for (const e of EVENTS_MS) {
+    const deliverT = e + WS_DELIVERY_MS;
+    if (deliverT <= nowMs) {
+      messages.push({ tStart: e, tEnd: deliverT, dir: "up", kind: "frameUp" });
+      bytesSent += WS_FRAME_BYTES;
+      eventsDelivered += 1;
+      worst = Math.max(worst, deliverT - e);
+    }
+  }
+
+  return {
+    stats: { reqs, bytesSent, eventsDelivered, worstLatencyMs: worst },
+    messages,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Component                                 */
+/* -------------------------------------------------------------------------- */
+
+export function PipeCompare() {
+  const [nowMs, setNowMs] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const startedAtRef = useRef<number | null>(null);
+  const baseMsRef = useRef(0);
+  const rafRef = useRef<number | null>(null);
+
+  const stepTo = useCallback((ms: number) => {
+    const clamped = Math.max(0, Math.min(DURATION_MS, ms));
+    setNowMs(clamped);
+    baseMsRef.current = clamped;
+    startedAtRef.current = null;
+  }, []);
+
+  const setFromScrub = useCallback((n: number) => {
+    setPlaying(false);
+    stepTo(n);
+  }, [stepTo]);
+
+  useEffect(() => {
+    if (!playing) {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      return;
+    }
+    let cancelled = false;
+    const tick = (tNow: number) => {
+      if (cancelled) return;
+      if (startedAtRef.current == null) startedAtRef.current = tNow;
+      const elapsed = tNow - startedAtRef.current;
+      const next = baseMsRef.current + elapsed;
+      if (next >= DURATION_MS) {
+        setNowMs(DURATION_MS);
+        setPlaying(false);
+        return;
+      }
+      setNowMs(next);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [playing]);
+
+  const polling = simPolling(nowMs);
+  const longpoll = simLongPoll(nowMs);
+  const websocket = simWebSocket(nowMs);
+
+  const play = useTapPulse<HTMLButtonElement>();
+  const togglePlay = () => {
+    play.pulse();
+    if (nowMs >= DURATION_MS) {
+      stepTo(0);
+      setPlaying(true);
+      return;
+    }
+    setPlaying((p) => !p);
+  };
+
+  return (
+    <WidgetShell
+      title="three protocols · one 10-second window"
+      measurements={`t = ${(nowMs / 1000).toFixed(1)}s of ${DURATION_MS / 1000}s`}
+      caption={
+        <>
+          Three server events fire during this window (the terracotta stars on each row).
+          Polling wastes most of its roundtrips. Long polling keeps one request open
+          until news arrives. WebSocket only pays the cost once, at the handshake.
+        </>
+      }
+      controls={
+        <div className="flex flex-wrap items-center gap-[var(--spacing-md)]">
+          <motion.button
+            ref={play.ref}
+            type="button"
+            onClick={togglePlay}
+            aria-label={playing ? "Pause playback" : "Play playback"}
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] min-h-[44px] inline-flex items-center font-sans transition-colors"
+            style={{
+              fontSize: "var(--text-ui)",
+              color: playing ? "var(--color-accent)" : "var(--color-text)",
+              border: "1px solid var(--color-rule)",
+            }}
+            {...PRESS}
+          >
+            {playing ? "pause" : nowMs >= DURATION_MS ? "replay ▸" : "play ▸"}
+          </motion.button>
+          <div className="flex-1 min-w-[200px]">
+            <Scrubber
+              label="t"
+              value={Math.round(nowMs)}
+              min={0}
+              max={DURATION_MS}
+              step={50}
+              onChange={setFromScrub}
+              format={(v) => `${(v / 1000).toFixed(1)}s`}
+            />
+          </div>
+        </div>
+      }
+    >
+      <PipeCanvas
+        nowMs={nowMs}
+        polling={polling}
+        longpoll={longpoll}
+        websocket={websocket}
+      />
+    </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                    Canvas                                  */
+/* -------------------------------------------------------------------------- */
+
+type RowConfig = {
+  label: string;
+  sublabel: string;
+  sim: Sim;
+  protocol: "polling" | "longpoll" | "websocket";
+};
+
+function PipeCanvas({
+  nowMs,
+  polling,
+  longpoll,
+  websocket,
+}: {
+  nowMs: number;
+  polling: Sim;
+  longpoll: Sim;
+  websocket: Sim;
+}) {
+  const WIDTH = 800;
+  const ROW_H = 110;
+  const ROW_GAP = 14;
+  const HEIGHT = ROW_H * 3 + ROW_GAP * 2 + 42;
+  const LEFT = 112;
+  const RIGHT = 16;
+  const TRACK_W = WIDTH - LEFT - RIGHT;
+  const x = (t: number) => LEFT + Math.max(0, Math.min(DURATION_MS, t)) / DURATION_MS * TRACK_W;
+
+  const rows: RowConfig[] = [
+    { label: "polling", sublabel: `ask every ${POLL_INTERVAL_MS / 1000}s`, sim: polling, protocol: "polling" },
+    { label: "long polling", sublabel: "ask once · reply when there's news", sim: longpoll, protocol: "longpoll" },
+    { label: "WebSocket", sublabel: "upgrade once · socket stays open", sim: websocket, protocol: "websocket" },
+  ];
+
+  // Keep the SVG at its intrinsic size so 9-10pt labels stay readable at every
+  // width. Below ~800 CSS px the outer overflow-x scroll lets the reader drag
+  // the canvas horizontally — preferred over proportionally shrinking text
+  // into illegibility. DESIGN.md §7 note: canvas > label chrome.
+  return (
+    <div
+      style={{
+        overflowX: "auto",
+        overflowY: "hidden",
+        maxWidth: "100%",
+      }}
+    >
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width={WIDTH}
+      height={HEIGHT}
+      style={{ maxWidth: "100%", minWidth: 560, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`Three protocols compared at t = ${(nowMs / 1000).toFixed(1)}s`}
+    >
+      {rows.map((row, i) => {
+        const y = i * (ROW_H + ROW_GAP) + 10;
+        return (
+          <ProtocolRow
+            key={row.protocol}
+            row={row}
+            x0={LEFT}
+            w={TRACK_W}
+            y={y}
+            h={ROW_H}
+            nowMs={nowMs}
+            xOfT={x}
+          />
+        );
+      })}
+
+      {/* Shared time axis at the bottom */}
+      <g transform={`translate(0, ${HEIGHT - 24})`}>
+        {[0, 2, 4, 6, 8, 10].map((sec) => {
+          const px = x(sec * 1000);
+          return (
+            <g key={sec}>
+              <line
+                x1={px}
+                x2={px}
+                y1={-4}
+                y2={0}
+                stroke="var(--color-rule)"
+                strokeWidth={1}
+              />
+              <text
+                x={px}
+                y={12}
+                textAnchor="middle"
+                fontFamily="var(--font-mono)"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+              >
+                {sec}s
+              </text>
+            </g>
+          );
+        })}
+      </g>
+
+      {/* Global playhead across all rows. No transition — the rAF loop already
+          updates nowMs 60×/s, so interpolation adds lag instead of smoothness. */}
+      <line
+        x1={x(nowMs)}
+        x2={x(nowMs)}
+        y1={8}
+        y2={HEIGHT - 28}
+        stroke="var(--color-accent)"
+        strokeWidth={1.2}
+        strokeDasharray="4 3"
+        opacity={0.5}
+      />
+    </svg>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  One row                                   */
+/* -------------------------------------------------------------------------- */
+
+function ProtocolRow({
+  row,
+  x0,
+  w,
+  y,
+  h,
+  nowMs,
+  xOfT,
+}: {
+  row: RowConfig;
+  x0: number;
+  w: number;
+  y: number;
+  h: number;
+  nowMs: number;
+  xOfT: (t: number) => number;
+}) {
+  const BROWSER_Y = y + 24;
+  const SERVER_Y = y + 88;
+
+  return (
+    <g>
+      {/* Row backdrop */}
+      <rect
+        x={0}
+        y={y}
+        width={x0 + w + 20}
+        height={h}
+        rx={4}
+        fill="transparent"
+      />
+
+      {/* Label + stats */}
+      <text
+        x={8}
+        y={y + 20}
+        fontFamily="var(--font-sans)"
+        fontSize={13}
+        fontWeight={500}
+        fill="var(--color-text)"
+      >
+        {row.label}
+      </text>
+      <text
+        x={8}
+        y={y + 36}
+        fontFamily="var(--font-mono)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+      >
+        {row.sublabel}
+      </text>
+
+      <StatsBlock x={8} y={y + 58} stats={row.sim.stats} protocol={row.protocol} nowMs={nowMs} />
+
+      {/* Two lifelines */}
+      <text
+        x={x0 - 8}
+        y={BROWSER_Y + 3}
+        textAnchor="end"
+        fontFamily="var(--font-mono)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+      >
+        browser
+      </text>
+      <text
+        x={x0 - 8}
+        y={SERVER_Y + 3}
+        textAnchor="end"
+        fontFamily="var(--font-mono)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+      >
+        server
+      </text>
+      <line
+        x1={x0}
+        x2={x0 + w}
+        y1={BROWSER_Y}
+        y2={BROWSER_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+      <line
+        x1={x0}
+        x2={x0 + w}
+        y1={SERVER_Y}
+        y2={SERVER_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+
+      {/* Events: stars on the server lifeline (only those that have fired) */}
+      {EVENTS_MS.filter((e) => e <= nowMs).map((e) => (
+        <g key={`evt-${row.protocol}-${e}`} transform={`translate(${xOfT(e)}, ${SERVER_Y})`}>
+          <circle
+            r={3.2}
+            cx={0}
+            cy={0}
+            fill="var(--color-accent)"
+          />
+          <circle
+            r={6}
+            cx={0}
+            cy={0}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth={0.8}
+            opacity={0.35}
+          />
+        </g>
+      ))}
+
+      {/* Held-request span (long-poll only) */}
+      {row.sim.heldSpan ? (
+        <HeldSpan
+          x1={xOfT(row.sim.heldSpan.from)}
+          x2={xOfT(row.sim.heldSpan.to)}
+          y1={BROWSER_Y}
+          y2={SERVER_Y}
+        />
+      ) : null}
+
+      {/* For long-poll: the past held spans (between req and dataRes pairs) */}
+      {row.protocol === "longpoll" &&
+        row.sim.messages
+          .filter((m) => m.held)
+          .map((m, i) => (
+            <HeldSpan
+              key={`held-${i}`}
+              x1={xOfT(m.tStart)}
+              x2={xOfT(m.tEnd)}
+              y1={BROWSER_Y}
+              y2={SERVER_Y}
+              faded
+            />
+          ))}
+
+      {/* WebSocket: thick persistent pipe after handshake */}
+      {row.protocol === "websocket" && nowMs >= WS_HANDSHAKE_MS ? (
+        <line
+          x1={xOfT(WS_HANDSHAKE_MS)}
+          x2={xOfT(nowMs)}
+          y1={(BROWSER_Y + SERVER_Y) / 2}
+          y2={(BROWSER_Y + SERVER_Y) / 2}
+          stroke="var(--color-accent)"
+          strokeWidth={3}
+          opacity={0.75}
+        />
+      ) : null}
+
+      {/* Messages — key by protocol + tStart + kind so each message has a
+          stable identity across re-renders, and new messages mount fresh so
+          the scale-from-0.6 entry animation fires exactly when they appear. */}
+      {row.sim.messages.map((m) =>
+        m.held ? null : (
+          <MessageArrow
+            key={`m-${row.protocol}-${m.kind}-${m.tStart}-${m.tEnd}`}
+            m={m}
+            xOfT={xOfT}
+            browserY={BROWSER_Y}
+            serverY={SERVER_Y}
+            nowMs={nowMs}
+          />
+        ),
+      )}
+    </g>
+  );
+}
+
+function HeldSpan({
+  x1,
+  x2,
+  y1,
+  y2,
+  faded = false,
+}: {
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+  faded?: boolean;
+}) {
+  return (
+    <rect
+      x={x1}
+      y={y1 + 2}
+      width={Math.max(1, x2 - x1)}
+      height={y2 - y1 - 4}
+      fill={faded
+        ? "color-mix(in oklab, var(--color-text-muted) 8%, transparent)"
+        : "color-mix(in oklab, var(--color-accent) 10%, transparent)"}
+      stroke={faded ? "var(--color-text-muted)" : "var(--color-accent)"}
+      strokeWidth={0.8}
+      strokeDasharray={faded ? "3 3" : undefined}
+      opacity={faded ? 0.55 : 0.8}
+    />
+  );
+}
+
+function MessageArrow({
+  m,
+  xOfT,
+  browserY,
+  serverY,
+  nowMs,
+}: {
+  m: Msg;
+  xOfT: (t: number) => number;
+  browserY: number;
+  serverY: number;
+  nowMs: number;
+}) {
+  const isRecent = Math.abs(nowMs - m.tEnd) < 350;
+  const baseColor =
+    m.kind === "emptyRes"
+      ? "var(--color-text-muted)"
+      : m.kind === "handshakeReq" || m.kind === "handshakeRes"
+        ? "var(--color-text-muted)"
+        : "var(--color-accent)";
+  const opacity =
+    m.kind === "emptyRes" ? 0.55 : isRecent ? 1 : 0.78;
+  const strokeWidth = isRecent ? 1.8 : 1.1;
+
+  const x1 = xOfT(m.tStart);
+  const x2 = xOfT(m.tEnd);
+  const y1 = m.dir === "down" ? browserY : serverY;
+  const y2 = m.dir === "down" ? serverY : browserY;
+
+  // Each message is keyed by its protocol + time so new messages mount when
+  // the playhead crosses tEnd; React treats them as fresh and motion/react
+  // runs the `initial → animate` transition. That pop — from opacity 0 and a
+  // slight scale-from-0.6 — is the teaching signal: "this byte appeared on
+  // the wire now, it wasn't here 40 ms ago." Prior: static `initial={false}`.
+  const originX = (x1 + x2) / 2;
+  const originY = (y1 + y2) / 2;
+
+  // For instantaneous pulses, draw a vertical arrow at x1=x2
+  if (Math.abs(m.tStart - m.tEnd) < 4) {
+    return (
+      <motion.g
+        initial={{ opacity: 0, scale: 0.6 }}
+        animate={{ opacity, scale: 1 }}
+        transition={SPRING.snappy}
+        style={{ transformOrigin: `${originX}px ${originY}px`, transformBox: "view-box" }}
+      >
+        <line
+          x1={x1}
+          x2={x2}
+          y1={y1}
+          y2={y2}
+          stroke={baseColor}
+          strokeWidth={strokeWidth}
+        />
+        {/* Arrow head */}
+        <path
+          d={arrowHeadPath(x2, y2, m.dir === "down" ? "down" : "up")}
+          fill={baseColor}
+        />
+        {/* Labels only for recent messages */}
+        {isRecent ? (
+          <text
+            x={x1 + 4}
+            y={(y1 + y2) / 2}
+            fontFamily="var(--font-mono)"
+            fontSize={8}
+            fill={baseColor}
+          >
+            {labelFor(m.kind)}
+          </text>
+        ) : null}
+      </motion.g>
+    );
+  }
+
+  // Slanted line for timed messages
+  return (
+    <motion.g
+      initial={{ opacity: 0, scale: 0.6 }}
+      animate={{ opacity, scale: 1 }}
+      transition={SPRING.snappy}
+      style={{ transformOrigin: `${originX}px ${originY}px`, transformBox: "view-box" }}
+    >
+      <line
+        x1={x1}
+        x2={x2}
+        y1={y1}
+        y2={y2}
+        stroke={baseColor}
+        strokeWidth={strokeWidth}
+      />
+      <path d={arrowHeadPath(x2, y2, m.dir === "down" ? "down" : "up")} fill={baseColor} />
+    </motion.g>
+  );
+}
+
+function labelFor(kind: Msg["kind"]): string {
+  switch (kind) {
+    case "req":
+      return "GET";
+    case "emptyRes":
+      return "200 []";
+    case "dataRes":
+      return "200";
+    case "frameUp":
+      return "0x1";
+    case "frameDown":
+      return "0x1";
+    case "handshakeReq":
+      return "Upgrade";
+    case "handshakeRes":
+      return "101";
+    default:
+      return "";
+  }
+}
+
+function arrowHeadPath(x: number, y: number, dir: "up" | "down"): string {
+  const h = 5;
+  if (dir === "down") {
+    return `M ${x - h} ${y - h} L ${x + h} ${y - h} L ${x} ${y} Z`;
+  }
+  return `M ${x - h} ${y + h} L ${x + h} ${y + h} L ${x} ${y} Z`;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Stats block                               */
+/* -------------------------------------------------------------------------- */
+
+function StatsBlock({
+  x,
+  y,
+  stats,
+  protocol,
+  nowMs,
+}: {
+  x: number;
+  y: number;
+  stats: Stats;
+  protocol: RowConfig["protocol"];
+  nowMs: number;
+}) {
+  const bytes =
+    stats.bytesSent >= 1000
+      ? `${(stats.bytesSent / 1000).toFixed(1)} KB`
+      : `${stats.bytesSent} B`;
+  const maxDelta =
+    stats.worstLatencyMs > 0 ? `${stats.worstLatencyMs}ms` : "—";
+  const eventsLabel =
+    protocol === "polling"
+      ? `polls: ${stats.reqs}`
+      : protocol === "longpoll"
+        ? `cycles: ${stats.reqs}`
+        : `frames: ${stats.eventsDelivered}`;
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <text
+        x={0}
+        y={0}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        {eventsLabel}
+      </text>
+      <text
+        x={0}
+        y={14}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text)"
+      >
+        bytes: {bytes}
+      </text>
+      <text
+        x={0}
+        y={28}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill={stats.worstLatencyMs > 500 ? "var(--color-accent)" : "var(--color-text-muted)"}
+      >
+        max Δ: {maxDelta}
+      </text>
+      {/* Touch nowMs so this re-renders on each frame. */}
+      <rect x={0} y={0} width={1} height={1} fill="transparent" opacity={0} pointerEvents="none">
+        <title>{`t=${nowMs}`}</title>
+      </rect>
+    </g>
+  );
+}

--- a/app/posts/the-browser-stopped-asking/widgets/PipeCompare.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/PipeCompare.tsx
@@ -297,12 +297,23 @@ export function PipeCompare() {
         </div>
       }
     >
-      <PipeCanvas
-        nowMs={nowMs}
-        polling={polling}
-        longpoll={longpoll}
-        websocket={websocket}
-      />
+      {/* Both layouts render; CSS container query picks which is visible. */}
+      <div className="bs-pc-narrow">
+        <PipeCanvasNarrow
+          nowMs={nowMs}
+          polling={polling}
+          longpoll={longpoll}
+          websocket={websocket}
+        />
+      </div>
+      <div className="bs-pc-wide">
+        <PipeCanvas
+          nowMs={nowMs}
+          polling={polling}
+          longpoll={longpoll}
+          websocket={websocket}
+        />
+      </div>
     </WidgetShell>
   );
 }
@@ -344,23 +355,14 @@ function PipeCanvas({
     { label: "WebSocket", sublabel: "upgrade once · socket stays open", sim: websocket, protocol: "websocket" },
   ];
 
-  // Keep the SVG at its intrinsic size so 9-10pt labels stay readable at every
-  // width. Below ~800 CSS px the outer overflow-x scroll lets the reader drag
-  // the canvas horizontally — preferred over proportionally shrinking text
-  // into illegibility. DESIGN.md §7 note: canvas > label chrome.
+  // Wide variant — side-by-side comparison in one canvas with stats in a
+  // left gutter. Used at container widths ≥ --flip-wide (640px). Below that
+  // the narrow variant (stacked per-protocol cards) is shown instead.
   return (
-    <div
-      style={{
-        overflowX: "auto",
-        overflowY: "hidden",
-        maxWidth: "100%",
-      }}
-    >
     <svg
       viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width={WIDTH}
-      height={HEIGHT}
-      style={{ maxWidth: "100%", minWidth: 560, height: "auto", display: "block" }}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
       role="img"
       aria-label={`Three protocols compared at t = ${(nowMs / 1000).toFixed(1)}s`}
     >
@@ -422,7 +424,307 @@ function PipeCanvas({
         opacity={0.5}
       />
     </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                             Narrow canvas (mobile)                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * PipeCanvasNarrow — mobile-first layout. Each protocol becomes a standalone
+ * stack: label + stats + timeline, rendered in its own compact SVG and
+ * stacked vertically. Labels never compete with the canvas for horizontal
+ * real estate — they sit above. The side-by-side comparison beat (wide
+ * variant) is a pleasure the reader loses on a phone; in return the
+ * messages become actually readable.
+ */
+function PipeCanvasNarrow({
+  nowMs,
+  polling,
+  longpoll,
+  websocket,
+}: {
+  nowMs: number;
+  polling: Sim;
+  longpoll: Sim;
+  websocket: Sim;
+}) {
+  const rows: RowConfig[] = [
+    { label: "polling", sublabel: `ask every ${POLL_INTERVAL_MS / 1000}s`, sim: polling, protocol: "polling" },
+    { label: "long polling", sublabel: "ask once · reply when there's news", sim: longpoll, protocol: "longpoll" },
+    { label: "WebSocket", sublabel: "upgrade once · socket stays open", sim: websocket, protocol: "websocket" },
+  ];
+  return (
+    <div className="flex flex-col gap-[var(--spacing-md)]">
+      {rows.map((row, i) => (
+        <ProtocolCardNarrow
+          key={row.protocol}
+          row={row}
+          nowMs={nowMs}
+          enterIndex={i}
+        />
+      ))}
     </div>
+  );
+}
+
+function ProtocolCardNarrow({
+  row,
+  nowMs,
+  enterIndex,
+}: {
+  row: RowConfig;
+  nowMs: number;
+  enterIndex: number;
+}) {
+  const WIDTH = 380;
+  const HEIGHT = 132;
+  const LEFT = 10;
+  const RIGHT = 10;
+  const TRACK_W = WIDTH - LEFT - RIGHT;
+  const BROWSER_Y = 48;
+  const SERVER_Y = 104;
+  const x = (t: number) =>
+    LEFT + Math.max(0, Math.min(DURATION_MS, t)) / DURATION_MS * TRACK_W;
+
+  // Stagger the three protocol cards on first mount so the reader's eye
+  // moves top-to-bottom in the teaching order: polling → long polling →
+  // WebSocket. 60 ms between cards, SPRING.smooth reveal. Reduced-motion
+  // users see an instant snap via MotionConfigProvider. Teaching signal:
+  // "read these in order, not as a flat list."
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ ...SPRING.smooth, delay: enterIndex * 0.06 }}
+    >
+      {/* HTML header lets the label + stats use actual prose typography, not
+          shrunken SVG text. Stats stay on the right so the reader's eye lands
+          on the protocol name first, the cost second. */}
+      <div
+        className="flex items-baseline justify-between gap-[var(--spacing-sm)] pb-[var(--spacing-2xs)]"
+        style={{ fontSize: "var(--text-ui)" }}
+      >
+        <div>
+          <span className="font-sans font-medium" style={{ color: "var(--color-text)" }}>
+            {row.label}
+          </span>
+          <span
+            className="ml-[var(--spacing-sm)] font-mono"
+            style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          >
+            {row.sublabel}
+          </span>
+        </div>
+        <NarrowStats stats={row.sim.stats} protocol={row.protocol} />
+      </div>
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+        role="img"
+        aria-label={`${row.label} at t = ${(nowMs / 1000).toFixed(1)}s`}
+      >
+        {/* Browser + server lifelines */}
+        <text
+          x={LEFT}
+          y={BROWSER_Y - 6}
+          fontFamily="var(--font-mono)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+        >
+          browser
+        </text>
+        <line
+          x1={LEFT}
+          x2={LEFT + TRACK_W}
+          y1={BROWSER_Y}
+          y2={BROWSER_Y}
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+          strokeDasharray="3 4"
+        />
+        <line
+          x1={LEFT}
+          x2={LEFT + TRACK_W}
+          y1={SERVER_Y}
+          y2={SERVER_Y}
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+          strokeDasharray="3 4"
+        />
+        <text
+          x={LEFT}
+          y={SERVER_Y + 14}
+          fontFamily="var(--font-mono)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+        >
+          server
+        </text>
+
+        {/* Server events (stars) — same scale-in + ring-ripple as the wide
+            variant so the first appearance of each event teaches instead of
+            pops. Remounts once per crossing of nowMs ≥ e. */}
+        {EVENTS_MS.filter((e) => e <= nowMs).map((e) => (
+          <g key={`evt-n-${row.protocol}-${e}`} transform={`translate(${x(e)}, ${SERVER_Y})`}>
+            <motion.circle
+              r={3}
+              cx={0}
+              cy={0}
+              fill="var(--color-accent)"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={SPRING.snappy}
+              style={{ transformOrigin: "0 0" }}
+            />
+            <motion.circle
+              cx={0}
+              cy={0}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth={0.8}
+              initial={{ r: 3, opacity: 0.9 }}
+              animate={{ r: 11, opacity: 0 }}
+              transition={{ duration: 0.42, ease: [0.22, 1, 0.36, 1] }}
+            />
+            <circle
+              r={6}
+              cx={0}
+              cy={0}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth={0.8}
+              opacity={0.35}
+            />
+          </g>
+        ))}
+
+        {/* Long-poll held span */}
+        {row.sim.heldSpan ? (
+          <rect
+            x={x(row.sim.heldSpan.from)}
+            y={BROWSER_Y + 2}
+            width={Math.max(1, x(row.sim.heldSpan.to) - x(row.sim.heldSpan.from))}
+            height={SERVER_Y - BROWSER_Y - 4}
+            fill="color-mix(in oklab, var(--color-accent) 10%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={0.8}
+            opacity={0.8}
+          />
+        ) : null}
+        {row.protocol === "longpoll"
+          ? row.sim.messages
+              .filter((m) => m.held)
+              .map((m, i) => (
+                <rect
+                  key={`held-n-${i}`}
+                  x={x(m.tStart)}
+                  y={BROWSER_Y + 2}
+                  width={Math.max(1, x(m.tEnd) - x(m.tStart))}
+                  height={SERVER_Y - BROWSER_Y - 4}
+                  fill="color-mix(in oklab, var(--color-text-muted) 8%, transparent)"
+                  stroke="var(--color-text-muted)"
+                  strokeWidth={0.8}
+                  strokeDasharray="3 3"
+                  opacity={0.55}
+                />
+              ))
+          : null}
+
+        {/* WebSocket persistent pipe */}
+        {row.protocol === "websocket" && nowMs >= WS_HANDSHAKE_MS ? (
+          <line
+            x1={x(WS_HANDSHAKE_MS)}
+            x2={x(nowMs)}
+            y1={(BROWSER_Y + SERVER_Y) / 2}
+            y2={(BROWSER_Y + SERVER_Y) / 2}
+            stroke="var(--color-accent)"
+            strokeWidth={3}
+            opacity={0.75}
+          />
+        ) : null}
+
+        {/* Messages */}
+        {row.sim.messages.map((m) =>
+          m.held ? null : (
+            <MessageArrow
+              key={`mn-${row.protocol}-${m.kind}-${m.tStart}-${m.tEnd}`}
+              m={m}
+              xOfT={x}
+              browserY={BROWSER_Y}
+              serverY={SERVER_Y}
+              nowMs={nowMs}
+            />
+          ),
+        )}
+
+        {/* Playhead at current time */}
+        <line
+          x1={x(nowMs)}
+          x2={x(nowMs)}
+          y1={BROWSER_Y - 14}
+          y2={SERVER_Y + 16}
+          stroke="var(--color-accent)"
+          strokeWidth={1.2}
+          strokeDasharray="4 3"
+          opacity={0.45}
+        />
+
+        {/* Mini time axis below */}
+        <text
+          x={LEFT}
+          y={HEIGHT - 4}
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-text-muted)"
+        >
+          0s
+        </text>
+        <text
+          x={LEFT + TRACK_W}
+          y={HEIGHT - 4}
+          textAnchor="end"
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-text-muted)"
+        >
+          {DURATION_MS / 1000}s
+        </text>
+      </svg>
+    </motion.div>
+  );
+}
+
+function NarrowStats({
+  stats,
+  protocol,
+}: {
+  stats: Stats;
+  protocol: RowConfig["protocol"];
+}) {
+  const bytes =
+    stats.bytesSent >= 1000
+      ? `${(stats.bytesSent / 1000).toFixed(1)} KB`
+      : `${stats.bytesSent} B`;
+  const countLabel =
+    protocol === "polling"
+      ? `${stats.reqs} polls`
+      : protocol === "longpoll"
+        ? `${stats.reqs} cycles`
+        : `${stats.eventsDelivered} frames`;
+  return (
+    <span
+      className="font-mono tabular-nums"
+      style={{
+        fontSize: "var(--text-small)",
+        color: "var(--color-text-muted)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {countLabel} · {bytes}
+    </span>
   );
 }
 
@@ -525,14 +827,32 @@ function ProtocolRow({
         strokeDasharray="3 4"
       />
 
-      {/* Events: stars on the server lifeline (only those that have fired) */}
+      {/* Events: stars on the server lifeline, only those that have fired.
+          Each star mounts the moment nowMs crosses EVENTS_MS[i] — the key
+          excludes time-variant values so React remounts exactly once per
+          event, which fires the scale-in + ring-ripple below. Delight that
+          teaches: "something happened on the server at this moment." */}
       {EVENTS_MS.filter((e) => e <= nowMs).map((e) => (
         <g key={`evt-${row.protocol}-${e}`} transform={`translate(${xOfT(e)}, ${SERVER_Y})`}>
-          <circle
+          <motion.circle
             r={3.2}
             cx={0}
             cy={0}
             fill="var(--color-accent)"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={SPRING.snappy}
+            style={{ transformOrigin: "0 0" }}
+          />
+          <motion.circle
+            cx={0}
+            cy={0}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth={0.8}
+            initial={{ r: 3, opacity: 0.9 }}
+            animate={{ r: 12, opacity: 0 }}
+            transition={{ duration: 0.42, ease: [0.22, 1, 0.36, 1] }}
           />
           <circle
             r={6}

--- a/app/posts/the-browser-stopped-asking/widgets/ReconnectGap.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/ReconnectGap.tsx
@@ -14,6 +14,13 @@ type EventFate =
   | { kind: "replayed"; at: number }
   | { kind: "lost" };
 
+type ClassifiedEvent = {
+  id: number;
+  t: number;
+  ws: EventFate;
+  sse: EventFate;
+};
+
 function classify(t: number, dropAt: number, dropEnd: number): {
   ws: EventFate;
   sse: EventFate;
@@ -37,7 +44,7 @@ export function ReconnectGap() {
   const [dropMs, setDropMs] = useState(2200);
   const dropEnd = Math.min(dropAt + dropMs, DURATION_MS);
 
-  const classified = EVENT_TIMES_MS.map((t, idx) => ({
+  const classified: ClassifiedEvent[] = EVENT_TIMES_MS.map((t, idx) => ({
     id: idx + 1,
     t,
     ...classify(t, dropAt, dropEnd),
@@ -84,32 +91,38 @@ export function ReconnectGap() {
         </div>
       }
     >
-      <ReconnectCanvas
-        classified={classified}
-        dropAt={dropAt}
-        dropEnd={dropEnd}
-        lastSseId={lastSseId}
-      />
+      {/* Both SVGs render; CSS container query picks which is visible. */}
+      <div className="bs-rg-narrow">
+        <NarrowCanvas
+          classified={classified}
+          dropAt={dropAt}
+          dropEnd={dropEnd}
+          lastSseId={lastSseId}
+        />
+      </div>
+      <div className="bs-rg-wide">
+        <WideCanvas
+          classified={classified}
+          dropAt={dropAt}
+          dropEnd={dropEnd}
+          lastSseId={lastSseId}
+        />
+      </div>
     </WidgetShell>
   );
 }
 
 /* -------------------------------------------------------------------------- */
+/*                               Wide (desktop)                               */
+/* -------------------------------------------------------------------------- */
 
-type Event = {
-  id: number;
-  t: number;
-  ws: EventFate;
-  sse: EventFate;
-};
-
-function ReconnectCanvas({
+function WideCanvas({
   classified,
   dropAt,
   dropEnd,
   lastSseId,
 }: {
-  classified: Event[];
+  classified: ClassifiedEvent[];
   dropAt: number;
   dropEnd: number;
   lastSseId: number;
@@ -124,168 +137,37 @@ function ReconnectCanvas({
   const x = (t: number) => LEFT + (t / DURATION_MS) * TRACK_W;
 
   return (
-    <div style={{ overflowX: "auto", overflowY: "hidden", maxWidth: "100%" }}>
     <svg
       viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width={WIDTH}
-      height={HEIGHT}
-      style={{ maxWidth: "100%", minWidth: 520, height: "auto", display: "block" }}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
       role="img"
       aria-label="Dropout recovery: WebSocket row vs SSE row"
     >
-      {/* Row labels */}
-      <text
-        x={8}
-        y={WS_Y - 18}
-        fontFamily="var(--font-sans)"
-        fontSize={13}
-        fontWeight={500}
-        fill="var(--color-text-muted)"
-      >
-        WebSocket
-      </text>
-      <text
-        x={8}
-        y={WS_Y + 2}
-        fontFamily="var(--font-mono)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
-      >
-        no reconnect
-      </text>
+      <RowLabel x={8} y={WS_Y - 18} title="WebSocket" sub="no reconnect" />
+      <RowLabel x={8} y={SSE_Y - 18} title="SSE" sub="Last-Event-ID" />
 
-      <text
-        x={8}
-        y={SSE_Y - 18}
-        fontFamily="var(--font-sans)"
-        fontSize={13}
-        fontWeight={500}
-        fill="var(--color-text-muted)"
-      >
-        SSE
-      </text>
-      <text
-        x={8}
-        y={SSE_Y + 2}
-        fontFamily="var(--font-mono)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
-      >
-        Last-Event-ID
-      </text>
+      <Timeline x0={LEFT} x1={LEFT + TRACK_W} y={WS_Y} />
+      <Timeline x0={LEFT} x1={LEFT + TRACK_W} y={SSE_Y} />
 
-      {/* Timelines */}
-      <line
-        x1={LEFT}
-        x2={LEFT + TRACK_W}
-        y1={WS_Y}
-        y2={WS_Y}
-        stroke="var(--color-rule)"
-        strokeWidth={1}
-        strokeDasharray="3 4"
-      />
-      <line
-        x1={LEFT}
-        x2={LEFT + TRACK_W}
-        y1={SSE_Y}
-        y2={SSE_Y}
-        stroke="var(--color-rule)"
-        strokeWidth={1}
-        strokeDasharray="3 4"
+      <TimeAxis xStart={LEFT} xEnd={LEFT + TRACK_W} y={HEIGHT - 8} />
+
+      <DropoutBand
+        xOfT={x}
+        dropAt={dropAt}
+        dropEnd={dropEnd}
+        yTop={WS_Y - 22}
+        bandHeight={SSE_Y - WS_Y + 44}
       />
 
-      {/* Time axis */}
-      <text
-        x={LEFT}
-        y={HEIGHT - 8}
-        fontFamily="var(--font-sans)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
-      >
-        0s
-      </text>
-      <text
-        x={LEFT + TRACK_W}
-        y={HEIGHT - 8}
-        textAnchor="end"
-        fontFamily="var(--font-sans)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
-      >
-        {DURATION_MS / 1000}s
-      </text>
+      <ReconnectLabel
+        xOfT={x}
+        dropEnd={dropEnd}
+        yBase={SSE_Y}
+        lastSseId={lastSseId}
+        variant="wide"
+      />
 
-      {/* Dropout band spanning both rows. Uses translateX + scaleX (transforms
-          only) instead of animating width — DESIGN.md §9 bans non-transform
-          animation. The base rect is 100px wide at x=0; scaleX stretches it to
-          the real dropout duration, translateX places it. */}
-      <motion.g
-        initial={false}
-        animate={{
-          x: x(dropAt),
-          scaleX: (x(dropEnd) - x(dropAt)) / 100,
-        }}
-        transition={SPRING.snappy}
-        style={{ transformOrigin: "0 0", transformBox: "fill-box" }}
-      >
-        <rect
-          x={0}
-          y={WS_Y - 22}
-          width={100}
-          height={SSE_Y - WS_Y + 44}
-          fill="color-mix(in oklab, var(--color-text-muted) 7%, transparent)"
-          stroke="var(--color-text-muted)"
-          strokeWidth={1}
-          strokeDasharray="3 3"
-          vectorEffect="non-scaling-stroke"
-        />
-      </motion.g>
-      <motion.text
-        initial={false}
-        animate={{ x: x(dropAt) + 6 }}
-        transition={SPRING.snappy}
-        y={WS_Y - 26}
-        fontFamily="var(--font-mono)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
-      >
-        network dropout
-      </motion.text>
-
-      {/* SSE reconnect marker at dropEnd */}
-      <motion.g
-        initial={false}
-        animate={{ x: x(dropEnd), opacity: dropEnd < DURATION_MS ? 1 : 0 }}
-        transition={SPRING.smooth}
-      >
-        <line
-          y1={SSE_Y - 16}
-          y2={SSE_Y + 18}
-          stroke="var(--color-accent)"
-          strokeWidth={1.4}
-          strokeDasharray="3 2"
-        />
-        <text
-          x={6}
-          y={SSE_Y + 34}
-          fontFamily="var(--font-mono)"
-          fontSize={10}
-          fill="var(--color-accent)"
-        >
-          GET /stream
-        </text>
-        <text
-          x={6}
-          y={SSE_Y + 48}
-          fontFamily="var(--font-mono)"
-          fontSize={10}
-          fill="var(--color-accent)"
-        >
-          Last-Event-ID: evt-{lastSseId}
-        </text>
-      </motion.g>
-
-      {/* Events */}
       {classified.map((e) => (
         <EventMark
           key={e.id}
@@ -297,7 +179,301 @@ function ReconnectCanvas({
         />
       ))}
     </svg>
-    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Narrow (mobile)                               */
+/* -------------------------------------------------------------------------- */
+
+function NarrowCanvas({
+  classified,
+  dropAt,
+  dropEnd,
+  lastSseId,
+}: {
+  classified: ClassifiedEvent[];
+  dropAt: number;
+  dropEnd: number;
+  lastSseId: number;
+}) {
+  const WIDTH = 380;
+  const HEIGHT = 320;
+  const LEFT = 16;
+  const RIGHT = 16;
+  const TRACK_W = WIDTH - LEFT - RIGHT;
+  // Labels sit ABOVE each timeline at narrow widths instead of in a left gutter.
+  const WS_LABEL_Y = 22;
+  const WS_Y = 72;
+  const SSE_LABEL_Y = 154;
+  const SSE_Y = 204;
+  const x = (t: number) => LEFT + (t / DURATION_MS) * TRACK_W;
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+      role="img"
+      aria-label="Dropout recovery (compact): WebSocket row vs SSE row"
+    >
+      <RowLabelInline x={LEFT} y={WS_LABEL_Y} title="WebSocket" sub="no reconnect" />
+      <RowLabelInline x={LEFT} y={SSE_LABEL_Y} title="SSE" sub="Last-Event-ID" />
+
+      <Timeline x0={LEFT} x1={LEFT + TRACK_W} y={WS_Y} />
+      <Timeline x0={LEFT} x1={LEFT + TRACK_W} y={SSE_Y} />
+
+      <TimeAxis xStart={LEFT} xEnd={LEFT + TRACK_W} y={HEIGHT - 8} />
+
+      <DropoutBand
+        xOfT={x}
+        dropAt={dropAt}
+        dropEnd={dropEnd}
+        yTop={WS_Y - 22}
+        bandHeight={SSE_Y - WS_Y + 44}
+      />
+
+      <ReconnectLabel
+        xOfT={x}
+        dropEnd={dropEnd}
+        yBase={SSE_Y}
+        lastSseId={lastSseId}
+        variant="narrow"
+      />
+
+      {classified.map((e) => (
+        <EventMark
+          key={e.id}
+          event={e}
+          x={x(e.t)}
+          xReplay={e.sse.kind === "replayed" ? x(e.sse.at) : undefined}
+          wsY={WS_Y}
+          sseY={SSE_Y}
+        />
+      ))}
+    </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                          Shared canvas primitives                          */
+/* -------------------------------------------------------------------------- */
+
+function RowLabel({
+  x,
+  y,
+  title,
+  sub,
+}: {
+  x: number;
+  y: number;
+  title: string;
+  sub: string;
+}) {
+  return (
+    <>
+      <text
+        x={x}
+        y={y}
+        fontFamily="var(--font-sans)"
+        fontSize={13}
+        fontWeight={500}
+        fill="var(--color-text-muted)"
+      >
+        {title}
+      </text>
+      <text
+        x={x}
+        y={y + 20}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        {sub}
+      </text>
+    </>
+  );
+}
+
+function RowLabelInline({
+  x,
+  y,
+  title,
+  sub,
+}: {
+  x: number;
+  y: number;
+  title: string;
+  sub: string;
+}) {
+  return (
+    <g>
+      <text
+        x={x}
+        y={y}
+        fontFamily="var(--font-sans)"
+        fontSize={13}
+        fontWeight={500}
+        fill="var(--color-text)"
+      >
+        {title}
+      </text>
+      <text
+        x={x}
+        y={y + 16}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        {sub}
+      </text>
+    </g>
+  );
+}
+
+function Timeline({ x0, x1, y }: { x0: number; x1: number; y: number }) {
+  return (
+    <line
+      x1={x0}
+      x2={x1}
+      y1={y}
+      y2={y}
+      stroke="var(--color-rule)"
+      strokeWidth={1}
+      strokeDasharray="3 4"
+    />
+  );
+}
+
+function TimeAxis({ xStart, xEnd, y }: { xStart: number; xEnd: number; y: number }) {
+  return (
+    <>
+      <text
+        x={xStart}
+        y={y}
+        fontFamily="var(--font-sans)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        0s
+      </text>
+      <text
+        x={xEnd}
+        y={y}
+        textAnchor="end"
+        fontFamily="var(--font-sans)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        {DURATION_MS / 1000}s
+      </text>
+    </>
+  );
+}
+
+function DropoutBand({
+  xOfT,
+  dropAt,
+  dropEnd,
+  yTop,
+  bandHeight,
+}: {
+  xOfT: (t: number) => number;
+  dropAt: number;
+  dropEnd: number;
+  yTop: number;
+  bandHeight: number;
+}) {
+  return (
+    <>
+      <motion.g
+        initial={false}
+        animate={{
+          x: xOfT(dropAt),
+          scaleX: (xOfT(dropEnd) - xOfT(dropAt)) / 100,
+        }}
+        transition={SPRING.snappy}
+        style={{ transformOrigin: "0 0", transformBox: "fill-box" }}
+      >
+        <rect
+          x={0}
+          y={yTop}
+          width={100}
+          height={bandHeight}
+          fill="color-mix(in oklab, var(--color-text-muted) 7%, transparent)"
+          stroke="var(--color-text-muted)"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+          vectorEffect="non-scaling-stroke"
+        />
+      </motion.g>
+      <motion.text
+        initial={false}
+        animate={{ x: xOfT(dropAt) + 6 }}
+        transition={SPRING.snappy}
+        y={yTop - 4}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        network dropout
+      </motion.text>
+    </>
+  );
+}
+
+function ReconnectLabel({
+  xOfT,
+  dropEnd,
+  yBase,
+  lastSseId,
+  variant,
+}: {
+  xOfT: (t: number) => number;
+  dropEnd: number;
+  yBase: number;
+  lastSseId: number;
+  variant: "wide" | "narrow";
+}) {
+  const visible = dropEnd < DURATION_MS;
+  const xPos = xOfT(dropEnd);
+  // Narrow places labels right of the reconnect line, below the SSE row.
+  // Wide places them below-left of the row.
+  const labelX = variant === "narrow" ? Math.min(xPos + 6, 240) : 6;
+  return (
+    <motion.g
+      initial={false}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={SPRING.smooth}
+    >
+      <line
+        x1={xPos}
+        x2={xPos}
+        y1={yBase - 16}
+        y2={yBase + 18}
+        stroke="var(--color-accent)"
+        strokeWidth={1.4}
+        strokeDasharray="3 2"
+      />
+      <text
+        x={variant === "narrow" ? labelX : xPos + 6}
+        y={yBase + 34}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-accent)"
+      >
+        GET /stream
+      </text>
+      <text
+        x={variant === "narrow" ? labelX : xPos + 6}
+        y={yBase + 48}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-accent)"
+      >
+        Last-Event-ID: evt-{lastSseId}
+      </text>
+    </motion.g>
   );
 }
 
@@ -308,36 +484,53 @@ function EventMark({
   wsY,
   sseY,
 }: {
-  event: Event;
+  event: ClassifiedEvent;
   x: number;
   xReplay?: number;
   wsY: number;
   sseY: number;
 }) {
   const label = `evt-${event.id}`;
+  const wsDelivered = event.ws.kind === "delivered";
   return (
     <g>
-      {/* WS: filled if delivered, hollow if lost */}
-      <circle
+      {/* WS row — the ring transitions smoothly when the dropout swallows or
+          releases this event. motion.circle interpolates radius and fill-
+          opacity, so the "delivered → lost" swap plays as a micro-moment of
+          loss instead of a silent attribute swap. The dashed stroke + X
+          mark cross-fade via AnimatePresence siblings. */}
+      <motion.circle
         cx={x}
         cy={wsY}
-        r={event.ws.kind === "delivered" ? 5 : 4}
-        fill={event.ws.kind === "delivered" ? "var(--color-accent)" : "transparent"}
-        stroke={
-          event.ws.kind === "delivered" ? "var(--color-accent)" : "var(--color-text-muted)"
-        }
+        initial={false}
+        animate={{
+          r: wsDelivered ? 5 : 4,
+          fillOpacity: wsDelivered ? 1 : 0,
+          strokeDashoffset: wsDelivered ? 0 : 0.001, // nudge to retrigger dash
+        }}
+        transition={SPRING.snappy}
+        fill="var(--color-accent)"
+        stroke={wsDelivered ? "var(--color-accent)" : "var(--color-text-muted)"}
         strokeWidth={1.4}
-        strokeDasharray={event.ws.kind === "lost" ? "2 2" : undefined}
+        strokeDasharray={wsDelivered ? "0 0" : "2 2"}
       />
-      {event.ws.kind === "lost" ? (
-        <line
-          x1={x - 3.5}
-          x2={x + 3.5}
-          y1={wsY - 3.5}
-          y2={wsY + 3.5}
-          stroke="var(--color-text-muted)"
-          strokeWidth={1.1}
-        />
+      {!wsDelivered ? (
+        <motion.g
+          key={`x-${event.id}`}
+          initial={{ opacity: 0, scale: 0.6 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={SPRING.snappy}
+          style={{ transformOrigin: `${x}px ${wsY}px` }}
+        >
+          <line
+            x1={x - 3.5}
+            x2={x + 3.5}
+            y1={wsY - 3.5}
+            y2={wsY + 3.5}
+            stroke="var(--color-text-muted)"
+            strokeWidth={1.1}
+          />
+        </motion.g>
       ) : null}
       <text
         x={x}
@@ -350,10 +543,9 @@ function EventMark({
         {label}
       </text>
 
-      {/* SSE: filled when delivered or replayed */}
+      {/* SSE row */}
       {event.sse.kind === "replayed" && xReplay !== undefined ? (
         <g key={`replay-${event.id}-${xReplay.toFixed(0)}`}>
-          {/* ghost at original time */}
           <circle
             cx={x}
             cy={sseY}
@@ -363,10 +555,6 @@ function EventMark({
             strokeWidth={1}
             strokeDasharray="2 2"
           />
-          {/* replay arc — strokes itself from origin to destination. The animation
-              is the teaching signal: "server replayed this missed event after
-              reconnect." Stagger by event.id so a multi-event dropout draws as a
-              sequence, not a burst. */}
           <motion.path
             d={`M ${x + 3} ${sseY} Q ${(x + xReplay) / 2} ${sseY - 14} ${xReplay - 3} ${sseY}`}
             fill="none"
@@ -379,7 +567,6 @@ function EventMark({
               delay: 0.1 + event.id * 0.06,
             }}
           />
-          {/* delivered dot — pops in at the tail after the arc draws */}
           <motion.circle
             cx={xReplay}
             cy={sseY}

--- a/app/posts/the-browser-stopped-asking/widgets/ReconnectGap.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/ReconnectGap.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "motion/react";
+import { SPRING } from "@/lib/motion";
+import { Scrubber } from "@/components/viz/Scrubber";
+import { WidgetShell } from "./WidgetShell";
+
+const DURATION_MS = 10_000;
+const EVENT_TIMES_MS = [800, 2200, 4700, 6200, 8400] as const;
+
+type EventFate =
+  | { kind: "delivered"; at: number }
+  | { kind: "replayed"; at: number }
+  | { kind: "lost" };
+
+function classify(t: number, dropAt: number, dropEnd: number): {
+  ws: EventFate;
+  sse: EventFate;
+} {
+  const beforeDrop = t < dropAt;
+  const duringDrop = t >= dropAt && t < dropEnd;
+  if (beforeDrop) {
+    return { ws: { kind: "delivered", at: t }, sse: { kind: "delivered", at: t } };
+  }
+  if (duringDrop) {
+    return { ws: { kind: "lost" }, sse: { kind: "replayed", at: dropEnd } };
+  }
+  return {
+    ws: { kind: "lost" },
+    sse: { kind: "delivered", at: t },
+  };
+}
+
+export function ReconnectGap() {
+  const [dropAt, setDropAt] = useState(3500);
+  const [dropMs, setDropMs] = useState(2200);
+  const dropEnd = Math.min(dropAt + dropMs, DURATION_MS);
+
+  const classified = EVENT_TIMES_MS.map((t, idx) => ({
+    id: idx + 1,
+    t,
+    ...classify(t, dropAt, dropEnd),
+  }));
+
+  const wsLost = classified.filter((e) => e.ws.kind === "lost").length;
+  const sseDelivered = classified.filter((e) => e.sse.kind !== "lost").length;
+
+  const lastBeforeDrop = classified.filter((e) => e.t < dropAt).slice(-1)[0];
+  const lastSseId = lastBeforeDrop?.id ?? 0;
+
+  return (
+    <WidgetShell
+      title="WebSocket forgets, SSE remembers"
+      measurements={`delivered: WS ${classified.length - wsLost}/${classified.length} · SSE ${sseDelivered}/${classified.length}`}
+      caption={
+        <>
+          Drag the dropout. WebSocket has no built-in way to recover the missed
+          events — the spec contains no reconnect. SSE auto-reconnects with a{" "}
+          <code>Last-Event-ID</code>{" "}header so the server can replay whatever the
+          browser missed.
+        </>
+      }
+      controls={
+        <div className="grid grid-cols-1 gap-[var(--spacing-sm)] sm:grid-cols-2">
+          <Scrubber
+            label="drop@"
+            value={dropAt}
+            min={400}
+            max={DURATION_MS - 1400}
+            step={100}
+            onChange={setDropAt}
+            format={(v) => `${(v / 1000).toFixed(1)}s`}
+          />
+          <Scrubber
+            label="for"
+            value={dropMs}
+            min={400}
+            max={4500}
+            step={100}
+            onChange={setDropMs}
+            format={(v) => `${(v / 1000).toFixed(1)}s`}
+          />
+        </div>
+      }
+    >
+      <ReconnectCanvas
+        classified={classified}
+        dropAt={dropAt}
+        dropEnd={dropEnd}
+        lastSseId={lastSseId}
+      />
+    </WidgetShell>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+type Event = {
+  id: number;
+  t: number;
+  ws: EventFate;
+  sse: EventFate;
+};
+
+function ReconnectCanvas({
+  classified,
+  dropAt,
+  dropEnd,
+  lastSseId,
+}: {
+  classified: Event[];
+  dropAt: number;
+  dropEnd: number;
+  lastSseId: number;
+}) {
+  const WIDTH = 760;
+  const HEIGHT = 260;
+  const LEFT = 100;
+  const RIGHT = 20;
+  const TRACK_W = WIDTH - LEFT - RIGHT;
+  const WS_Y = 64;
+  const SSE_Y = 176;
+  const x = (t: number) => LEFT + (t / DURATION_MS) * TRACK_W;
+
+  return (
+    <div style={{ overflowX: "auto", overflowY: "hidden", maxWidth: "100%" }}>
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width={WIDTH}
+      height={HEIGHT}
+      style={{ maxWidth: "100%", minWidth: 520, height: "auto", display: "block" }}
+      role="img"
+      aria-label="Dropout recovery: WebSocket row vs SSE row"
+    >
+      {/* Row labels */}
+      <text
+        x={8}
+        y={WS_Y - 18}
+        fontFamily="var(--font-sans)"
+        fontSize={13}
+        fontWeight={500}
+        fill="var(--color-text-muted)"
+      >
+        WebSocket
+      </text>
+      <text
+        x={8}
+        y={WS_Y + 2}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        no reconnect
+      </text>
+
+      <text
+        x={8}
+        y={SSE_Y - 18}
+        fontFamily="var(--font-sans)"
+        fontSize={13}
+        fontWeight={500}
+        fill="var(--color-text-muted)"
+      >
+        SSE
+      </text>
+      <text
+        x={8}
+        y={SSE_Y + 2}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        Last-Event-ID
+      </text>
+
+      {/* Timelines */}
+      <line
+        x1={LEFT}
+        x2={LEFT + TRACK_W}
+        y1={WS_Y}
+        y2={WS_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+      <line
+        x1={LEFT}
+        x2={LEFT + TRACK_W}
+        y1={SSE_Y}
+        y2={SSE_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+
+      {/* Time axis */}
+      <text
+        x={LEFT}
+        y={HEIGHT - 8}
+        fontFamily="var(--font-sans)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        0s
+      </text>
+      <text
+        x={LEFT + TRACK_W}
+        y={HEIGHT - 8}
+        textAnchor="end"
+        fontFamily="var(--font-sans)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        {DURATION_MS / 1000}s
+      </text>
+
+      {/* Dropout band spanning both rows. Uses translateX + scaleX (transforms
+          only) instead of animating width — DESIGN.md §9 bans non-transform
+          animation. The base rect is 100px wide at x=0; scaleX stretches it to
+          the real dropout duration, translateX places it. */}
+      <motion.g
+        initial={false}
+        animate={{
+          x: x(dropAt),
+          scaleX: (x(dropEnd) - x(dropAt)) / 100,
+        }}
+        transition={SPRING.snappy}
+        style={{ transformOrigin: "0 0", transformBox: "fill-box" }}
+      >
+        <rect
+          x={0}
+          y={WS_Y - 22}
+          width={100}
+          height={SSE_Y - WS_Y + 44}
+          fill="color-mix(in oklab, var(--color-text-muted) 7%, transparent)"
+          stroke="var(--color-text-muted)"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+          vectorEffect="non-scaling-stroke"
+        />
+      </motion.g>
+      <motion.text
+        initial={false}
+        animate={{ x: x(dropAt) + 6 }}
+        transition={SPRING.snappy}
+        y={WS_Y - 26}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        network dropout
+      </motion.text>
+
+      {/* SSE reconnect marker at dropEnd */}
+      <motion.g
+        initial={false}
+        animate={{ x: x(dropEnd), opacity: dropEnd < DURATION_MS ? 1 : 0 }}
+        transition={SPRING.smooth}
+      >
+        <line
+          y1={SSE_Y - 16}
+          y2={SSE_Y + 18}
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          strokeDasharray="3 2"
+        />
+        <text
+          x={6}
+          y={SSE_Y + 34}
+          fontFamily="var(--font-mono)"
+          fontSize={10}
+          fill="var(--color-accent)"
+        >
+          GET /stream
+        </text>
+        <text
+          x={6}
+          y={SSE_Y + 48}
+          fontFamily="var(--font-mono)"
+          fontSize={10}
+          fill="var(--color-accent)"
+        >
+          Last-Event-ID: evt-{lastSseId}
+        </text>
+      </motion.g>
+
+      {/* Events */}
+      {classified.map((e) => (
+        <EventMark
+          key={e.id}
+          event={e}
+          x={x(e.t)}
+          xReplay={e.sse.kind === "replayed" ? x(e.sse.at) : undefined}
+          wsY={WS_Y}
+          sseY={SSE_Y}
+        />
+      ))}
+    </svg>
+    </div>
+  );
+}
+
+function EventMark({
+  event,
+  x,
+  xReplay,
+  wsY,
+  sseY,
+}: {
+  event: Event;
+  x: number;
+  xReplay?: number;
+  wsY: number;
+  sseY: number;
+}) {
+  const label = `evt-${event.id}`;
+  return (
+    <g>
+      {/* WS: filled if delivered, hollow if lost */}
+      <circle
+        cx={x}
+        cy={wsY}
+        r={event.ws.kind === "delivered" ? 5 : 4}
+        fill={event.ws.kind === "delivered" ? "var(--color-accent)" : "transparent"}
+        stroke={
+          event.ws.kind === "delivered" ? "var(--color-accent)" : "var(--color-text-muted)"
+        }
+        strokeWidth={1.4}
+        strokeDasharray={event.ws.kind === "lost" ? "2 2" : undefined}
+      />
+      {event.ws.kind === "lost" ? (
+        <line
+          x1={x - 3.5}
+          x2={x + 3.5}
+          y1={wsY - 3.5}
+          y2={wsY + 3.5}
+          stroke="var(--color-text-muted)"
+          strokeWidth={1.1}
+        />
+      ) : null}
+      <text
+        x={x}
+        y={wsY - 12}
+        textAnchor="middle"
+        fontFamily="var(--font-mono)"
+        fontSize={9}
+        fill={event.ws.kind === "delivered" ? "var(--color-text)" : "var(--color-text-muted)"}
+      >
+        {label}
+      </text>
+
+      {/* SSE: filled when delivered or replayed */}
+      {event.sse.kind === "replayed" && xReplay !== undefined ? (
+        <g key={`replay-${event.id}-${xReplay.toFixed(0)}`}>
+          {/* ghost at original time */}
+          <circle
+            cx={x}
+            cy={sseY}
+            r={3}
+            fill="transparent"
+            stroke="var(--color-text-muted)"
+            strokeWidth={1}
+            strokeDasharray="2 2"
+          />
+          {/* replay arc — strokes itself from origin to destination. The animation
+              is the teaching signal: "server replayed this missed event after
+              reconnect." Stagger by event.id so a multi-event dropout draws as a
+              sequence, not a burst. */}
+          <motion.path
+            d={`M ${x + 3} ${sseY} Q ${(x + xReplay) / 2} ${sseY - 14} ${xReplay - 3} ${sseY}`}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth={1.2}
+            initial={{ pathLength: 0, opacity: 0.4 }}
+            animate={{ pathLength: 1, opacity: 1 }}
+            transition={{
+              ...SPRING.smooth,
+              delay: 0.1 + event.id * 0.06,
+            }}
+          />
+          {/* delivered dot — pops in at the tail after the arc draws */}
+          <motion.circle
+            cx={xReplay}
+            cy={sseY}
+            r={5}
+            fill="var(--color-accent)"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{
+              ...SPRING.snappy,
+              delay: 0.34 + event.id * 0.06,
+            }}
+            style={{ transformOrigin: `${xReplay}px ${sseY}px` }}
+          />
+          <text
+            x={xReplay}
+            y={sseY - 12}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={9}
+            fill="var(--color-text)"
+          >
+            {label}
+          </text>
+        </g>
+      ) : (
+        <>
+          <circle cx={x} cy={sseY} r={5} fill="var(--color-accent)" />
+          <text
+            x={x}
+            y={sseY - 12}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={9}
+            fill="var(--color-text)"
+          >
+            {label}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}

--- a/app/posts/the-browser-stopped-asking/widgets/UpgradeHandshake.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/UpgradeHandshake.tsx
@@ -93,7 +93,12 @@ export function UpgradeHandshake() {
         </div>
       }
     >
-      <HandshakeCanvas step={step} computed={computed} />
+      <div className="bs-uh-narrow">
+        <HandshakeCanvasNarrow step={step} computed={computed} />
+      </div>
+      <div className="bs-uh-wide">
+        <HandshakeCanvas step={step} computed={computed} />
+      </div>
     </WidgetShell>
   );
 }
@@ -117,22 +122,14 @@ function HandshakeCanvas({ step, computed }: { step: number; computed: Computed 
   const PIPE_X1 = BROWSER_X + BOX_W + 4;
   const PIPE_X2 = SERVER_X - 4;
 
-  const pipeColor =
-    step >= 2 ? "var(--color-accent)" : "var(--color-text-muted)";
-  const pipeWidth = step >= 2 ? 3.5 : 1.4;
-  const pipeDash = step >= 2 ? undefined : "4 4";
-
-  // Preserve intrinsic SVG size so 9-10pt text stays readable. Narrow
-  // containers scroll horizontally inside the outer div — DESIGN.md §7
-  // ("canvas is the subject"): shrinking text into illegibility would let
-  // chrome win over canvas.
+  // Wide variant — browser + server flanking a horizontal pipe. Used at
+  // container widths ≥ --flip-wide. Below that, HandshakeCanvasNarrow flips
+  // the whole arrangement vertical so 10 pt mono doesn't collapse on phone.
   return (
-    <div style={{ overflowX: "auto", overflowY: "hidden", maxWidth: "100%" }}>
     <svg
       viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width={WIDTH}
-      height={HEIGHT}
-      style={{ maxWidth: "100%", minWidth: 620, height: "auto", display: "block" }}
+      width="100%"
+      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
       role="img"
       aria-label={`Upgrade handshake step ${step + 1}`}
     >
@@ -188,16 +185,34 @@ function HandshakeCanvas({ step, computed }: { step: number; computed: Computed 
         active={step === 1}
       />
 
-      {/* The pipe (TCP socket) */}
+      {/* The pipe (TCP socket) — two layers. The muted HTTP base line stays
+          drawn; the terracotta WebSocket overlay strokes itself in when
+          step ≥ 2, left-to-right. Conveys the HTTP→socket transition as a
+          visible act instead of a discrete color swap. */}
       <line
         x1={PIPE_X1}
         x2={PIPE_X2}
         y1={PIPE_Y}
         y2={PIPE_Y}
-        stroke={pipeColor}
-        strokeWidth={pipeWidth}
-        strokeDasharray={pipeDash}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.4}
+        strokeDasharray="4 4"
+        opacity={step >= 2 ? 0.25 : 1}
       />
+      {step >= 2 ? (
+        <motion.line
+          key={`uh-wide-pipe-${step}`}
+          x1={PIPE_X1}
+          x2={PIPE_X2}
+          y1={PIPE_Y}
+          y2={PIPE_Y}
+          stroke="var(--color-accent)"
+          strokeWidth={3.5}
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ ...SPRING.smooth }}
+        />
+      ) : null}
       <text
         x={(PIPE_X1 + PIPE_X2) / 2}
         y={PIPE_Y - 10}
@@ -317,6 +332,498 @@ function HandshakeCanvas({ step, computed }: { step: number; computed: Computed 
         <Transcript step={step} computed={computed} width={WIDTH - BROWSER_X * 2} />
       </g>
     </svg>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Narrow (mobile)                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * HandshakeCanvasNarrow — vertical orientation for phone widths. Browser
+ * panel sits above a vertical TCP pipe; server panel sits below. The
+ * request envelope drops down the pipe on step 0→1; the 101 reply rises
+ * on step 1→2; bidirectional frames fly up/down on step 3. The transcript
+ * panes render as plain HTML below the SVG — mono text readable at
+ * actual type size, not a shrunk SVG <text>.
+ */
+function HandshakeCanvasNarrow({
+  step,
+  computed,
+}: {
+  step: number;
+  computed: Computed;
+}) {
+  const WIDTH = 380;
+  const HEIGHT = 320;
+  const PIPE_X = WIDTH / 2;
+  const BROWSER_Y = 40;
+  const SERVER_Y = 224;
+  const BOX_W = 300;
+  const BOX_H = 84;
+  const BOX_X = (WIDTH - BOX_W) / 2;
+  const PIPE_Y1 = BROWSER_Y + BOX_H + 6;
+  const PIPE_Y2 = SERVER_Y - 6;
+
+  return (
+    <div className="flex flex-col gap-[var(--spacing-sm)]">
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{ maxWidth: WIDTH, height: "auto", display: "block", margin: "0 auto" }}
+        role="img"
+        aria-label={`Upgrade handshake, step ${step + 1} of 3, compact layout`}
+      >
+        {/* Browser panel */}
+        <rect
+          x={BOX_X}
+          y={BROWSER_Y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill="color-mix(in oklab, var(--color-surface) 55%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={BOX_X + 10}
+          y={BROWSER_Y + 18}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text-muted)"
+        >
+          browser
+        </text>
+        <text
+          x={BOX_X + 10}
+          y={BROWSER_Y + 38}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill={step === 0 ? "var(--color-accent)" : "var(--color-text)"}
+          fontWeight={step === 0 ? 500 : 400}
+        >
+          GET /chat HTTP/1.1
+        </text>
+        <text
+          x={BOX_X + 10}
+          y={BROWSER_Y + 56}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill={step === 0 ? "var(--color-accent)" : "var(--color-text)"}
+        >
+          Upgrade: websocket
+        </text>
+        <text
+          x={BOX_X + 10}
+          y={BROWSER_Y + 72}
+          fontFamily="var(--font-mono)"
+          fontSize={10}
+          fill="var(--color-text-muted)"
+        >
+          key = {truncate(computed.key, 20)}
+        </text>
+
+        {/* Vertical pipe — two layers. The muted HTTP base line is always
+            there; the terracotta WebSocket overlay strokes itself in
+            (pathLength 0→1) when step ≥ 2. Conveys the "HTTP became a
+            socket" transformation as a visible act, not a discrete swap. */}
+        <line
+          x1={PIPE_X}
+          x2={PIPE_X}
+          y1={PIPE_Y1}
+          y2={PIPE_Y2}
+          stroke="var(--color-text-muted)"
+          strokeWidth={1.4}
+          strokeDasharray="4 4"
+          opacity={step >= 2 ? 0.25 : 1}
+        />
+        {step >= 2 ? (
+          <motion.line
+            key={`ws-pipe-${step}`}
+            x1={PIPE_X}
+            x2={PIPE_X}
+            y1={PIPE_Y1}
+            y2={PIPE_Y2}
+            stroke="var(--color-accent)"
+            strokeWidth={3.5}
+            initial={{ pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ ...SPRING.smooth }}
+          />
+        ) : null}
+        <text
+          x={PIPE_X + 10}
+          y={(PIPE_Y1 + PIPE_Y2) / 2}
+          fontFamily="var(--font-mono)"
+          fontSize={10}
+          fill={step >= 2 ? "var(--color-accent)" : "var(--color-text-muted)"}
+        >
+          {step >= 2 ? "WebSocket" : "HTTP/1.1"}
+        </text>
+
+        {/* Step 1: request envelope falls from browser to server */}
+        <motion.g
+          initial={false}
+          animate={{
+            opacity: step === 0 ? 1 : 0,
+            y: step >= 1 ? PIPE_Y2 - PIPE_Y1 - 24 : 0,
+          }}
+          transition={{ ...SPRING.smooth, delay: step === 0 ? 0.1 : 0 }}
+        >
+          <g transform={`translate(${PIPE_X - 38}, ${PIPE_Y1 + 8})`}>
+            <rect
+              x={0}
+              y={0}
+              width={76}
+              height={24}
+              rx={4}
+              fill="color-mix(in oklab, var(--color-surface) 70%, transparent)"
+              stroke="var(--color-text-muted)"
+              strokeWidth={1}
+            />
+            <text
+              x={38}
+              y={16}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+            >
+              Upgrade req
+            </text>
+          </g>
+        </motion.g>
+
+        {/* Step 2: 101 response rises from server to browser */}
+        <motion.g
+          initial={false}
+          animate={{
+            opacity: step === 1 ? 1 : 0,
+            y: step >= 2 ? -(PIPE_Y2 - PIPE_Y1 - 30) : 0,
+          }}
+          transition={{ ...SPRING.smooth, delay: step === 1 ? 0.7 : 0 }}
+        >
+          <g transform={`translate(${PIPE_X - 42}, ${PIPE_Y2 - 32})`}>
+            <rect
+              x={0}
+              y={0}
+              width={84}
+              height={24}
+              rx={4}
+              fill="color-mix(in oklab, var(--color-accent) 16%, transparent)"
+              stroke="var(--color-accent)"
+              strokeWidth={1.2}
+            />
+            <text
+              x={42}
+              y={16}
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-accent)"
+            >
+              101 Switching
+            </text>
+          </g>
+        </motion.g>
+
+        {/* Step 3: bidirectional frames */}
+        {step >= 2 ? (
+          <NarrowFrameTraffic
+            pipeX={PIPE_X}
+            y1={PIPE_Y1 + 8}
+            y2={PIPE_Y2 - 8}
+          />
+        ) : null}
+
+        {/* Server panel */}
+        <rect
+          x={BOX_X}
+          y={SERVER_Y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill="color-mix(in oklab, var(--color-surface) 55%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={BOX_X + 10}
+          y={SERVER_Y + 18}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text-muted)"
+        >
+          server
+        </text>
+        <text
+          x={BOX_X + 10}
+          y={SERVER_Y + 38}
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill={step === 1 ? "var(--color-accent)" : "var(--color-text)"}
+          fontWeight={step === 1 ? 500 : 400}
+        >
+          SHA-1(key + GUID)
+        </text>
+        <NarrowAcceptSettle
+          accept={truncate(computed.accept, 20)}
+          x={BOX_X + 10}
+          y={SERVER_Y + 58}
+        />
+        <text
+          x={BOX_X + 10}
+          y={SERVER_Y + 74}
+          fontFamily="var(--font-mono)"
+          fontSize={9}
+          fill="var(--color-text-muted)"
+        >
+          GUID = 258EAFA5-E914-…
+        </text>
+      </svg>
+
+      {/* HTML transcript below. Renders at real --text-small so the reader
+          gets mono text at body-readable size instead of SVG-scaled. */}
+      <div
+        className="grid gap-[var(--spacing-sm)] sm:grid-cols-2"
+        style={{ fontSize: "var(--text-small)" }}
+      >
+        <TranscriptPane
+          title="client → server"
+          active={step === 0}
+          lines={[
+            "GET /chat HTTP/1.1",
+            "Host: docs.example",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Key: ${truncate(computed.key, 20)}`,
+            "Sec-WebSocket-Version: 13",
+          ]}
+          highlight={(line) =>
+            step === 0 &&
+            (line.startsWith("Upgrade:") ||
+              line.startsWith("Connection:") ||
+              line.startsWith("Sec-WebSocket-Key"))
+          }
+        />
+        <TranscriptPane
+          title="server → client"
+          active={step >= 1}
+          lines={[
+            "HTTP/1.1 101 Switching Protocols",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Accept: ${truncate(computed.accept, 20)}`,
+          ]}
+          highlight={(line) =>
+            step === 1 &&
+            (line.startsWith("HTTP/1.1 101") ||
+              line.startsWith("Sec-WebSocket-Accept"))
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function NarrowFrameTraffic({
+  pipeX,
+  y1,
+  y2,
+}: {
+  pipeX: number;
+  y1: number;
+  y2: number;
+}) {
+  const span = y2 - y1;
+  return (
+    <g>
+      {/* Frame traveling ↓ */}
+      <motion.g
+        initial={{ y: 0, opacity: 0 }}
+        animate={{
+          y: [0, span, 0, span],
+          opacity: [0, 1, 0, 1, 0],
+        }}
+        transition={{
+          times: [0, 0.25, 0.5, 0.75, 1],
+          duration: 2.4,
+          ease: [0.22, 1, 0.36, 1],
+        }}
+      >
+        <rect
+          x={pipeX - 18}
+          y={y1}
+          width={14}
+          height={18}
+          rx={2}
+          fill="var(--color-accent)"
+        />
+        <text
+          x={pipeX - 11}
+          y={y1 + 12}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-bg)"
+        >
+          0x1
+        </text>
+      </motion.g>
+      {/* Frame traveling ↑ */}
+      <motion.g
+        initial={{ y: 0, opacity: 0 }}
+        animate={{
+          y: [0, -span, 0, -span],
+          opacity: [0, 1, 0, 1, 0],
+        }}
+        transition={{
+          times: [0, 0.25, 0.5, 0.75, 1],
+          duration: 2.4,
+          ease: [0.22, 1, 0.36, 1],
+          delay: 0.9,
+        }}
+      >
+        <rect
+          x={pipeX + 4}
+          y={y2 - 18}
+          width={14}
+          height={18}
+          rx={2}
+          fill="var(--color-accent)"
+        />
+        <text
+          x={pipeX + 11}
+          y={y2 - 6}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-bg)"
+        >
+          0x2
+        </text>
+      </motion.g>
+      {/* Ambient endpoint pulses */}
+      <motion.circle
+        cx={pipeX}
+        cy={y1}
+        r={3}
+        fill="var(--color-accent)"
+        initial={{ opacity: 0.5 }}
+        animate={{ opacity: [0.5, 0.9, 0.5] }}
+        transition={{ duration: 2.2, repeat: Infinity, ease: [0.22, 1, 0.36, 1] }}
+      />
+      <motion.circle
+        cx={pipeX}
+        cy={y2}
+        r={3}
+        fill="var(--color-accent)"
+        initial={{ opacity: 0.5 }}
+        animate={{ opacity: [0.5, 0.9, 0.5] }}
+        transition={{
+          duration: 2.2,
+          repeat: Infinity,
+          ease: [0.22, 1, 0.36, 1],
+          delay: 1.1,
+        }}
+      />
+    </g>
+  );
+}
+
+function NarrowAcceptSettle({
+  accept,
+  x,
+  y,
+}: {
+  accept: string;
+  x: number;
+  y: number;
+}) {
+  const SPLIT = Math.max(0, accept.length - 8);
+  const head = accept.slice(0, SPLIT);
+  const tail = accept.slice(SPLIT).split("");
+  return (
+    <text
+      key={accept}
+      x={x}
+      y={y}
+      fontFamily="var(--font-mono)"
+      fontSize={11}
+    >
+      <tspan fill="var(--color-accent)">{head}</tspan>
+      {tail.map((ch, i) => (
+        <motion.tspan
+          key={`${accept}-${i}`}
+          initial={{ fill: "var(--color-text-muted)" }}
+          animate={{ fill: "var(--color-accent)" }}
+          transition={{
+            duration: 0.24,
+            ease: [0.22, 1, 0.36, 1],
+            delay: 0.08 + i * 0.028,
+          }}
+        >
+          {ch}
+        </motion.tspan>
+      ))}
+    </text>
+  );
+}
+
+function TranscriptPane({
+  title,
+  lines,
+  active,
+  highlight,
+}: {
+  title: string;
+  lines: string[];
+  active: boolean;
+  highlight: (line: string) => boolean;
+}) {
+  return (
+    <div
+      className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)]"
+      style={{
+        background: "color-mix(in oklab, var(--color-surface) 50%, transparent)",
+        border: "1px solid var(--color-rule)",
+        opacity: active ? 1 : 0.6,
+      }}
+    >
+      <div
+        className="font-sans uppercase"
+        style={{
+          fontSize: "var(--text-small)",
+          letterSpacing: "0.04em",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--spacing-2xs)",
+        }}
+      >
+        {title}
+      </div>
+      <pre
+        className="font-mono"
+        style={{
+          fontSize: "var(--text-small)",
+          lineHeight: 1.5,
+          color: "var(--color-text)",
+          margin: 0,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-all",
+        }}
+      >
+        {lines.map((line, i) => (
+          <div
+            key={i}
+            style={{
+              color: highlight(line) ? "var(--color-accent)" : undefined,
+              fontWeight: highlight(line) ? 500 : undefined,
+            }}
+          >
+            {line}
+          </div>
+        ))}
+      </pre>
     </div>
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/UpgradeHandshake.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/UpgradeHandshake.tsx
@@ -1,0 +1,677 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { PRESS, SPRING } from "@/lib/motion";
+import { Stepper } from "@/components/viz/Stepper";
+import { WidgetShell } from "./WidgetShell";
+
+const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+type Computed = {
+  key: string;
+  accept: string;
+};
+
+const PLACEHOLDER: Computed = {
+  key: "dGhlIHNhbXBsZSBub25jZQ==",
+  // SHA-1("dGhlIHNhbXBsZSBub25jZQ==" + GUID) base64-encoded — the literal example from RFC 6455 §1.3.
+  accept: "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+};
+
+function bytesToB64(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+async function makeAccept(key: string): Promise<string> {
+  const combined = new TextEncoder().encode(key + GUID);
+  const digest = await crypto.subtle.digest("SHA-1", combined);
+  return bytesToB64(new Uint8Array(digest));
+}
+
+function randomKey(): string {
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  return bytesToB64(buf);
+}
+
+export function UpgradeHandshake() {
+  const [step, setStep] = useState(0);
+  const [computed, setComputed] = useState<Computed>(PLACEHOLDER);
+  const [rerolling, setRerolling] = useState(false);
+  const [hashMs, setHashMs] = useState<number | null>(null);
+  const mounted = useRef(false);
+
+  const reroll = useCallback(async () => {
+    setRerolling(true);
+    const key = randomKey();
+    const t0 =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    const accept = await makeAccept(key);
+    const t1 =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    setHashMs(t1 - t0);
+    setComputed({ key, accept });
+    setRerolling(false);
+  }, []);
+
+  // Compute once on mount so the reader sees *their* browser's hash, not the spec's sample.
+  useEffect(() => {
+    if (mounted.current) return;
+    mounted.current = true;
+    void reroll();
+  }, [reroll]);
+
+  const timingLabel =
+    hashMs != null ? `SHA-1 in ${hashMs.toFixed(2)} ms` : "SHA-1 ready";
+
+  return (
+    <WidgetShell
+      title="how HTTP ends mid-socket"
+      measurements={`step ${step + 1}/3 · ${timingLabel}`}
+      caption={CAPTIONS[step]}
+      controls={
+        <div className="flex flex-wrap items-center gap-[var(--spacing-md)]">
+          <Stepper value={step} total={3} onChange={setStep} />
+          <motion.button
+            type="button"
+            onClick={reroll}
+            disabled={rerolling}
+            aria-label="Regenerate key and recompute accept hash"
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] min-h-[44px] inline-flex items-center font-mono transition-colors"
+            style={{
+              fontSize: "var(--text-small)",
+              color: "var(--color-text)",
+              border: "1px solid var(--color-rule)",
+            }}
+            {...PRESS}
+          >
+            {rerolling ? "hashing…" : "regenerate key"}
+          </motion.button>
+        </div>
+      }
+    >
+      <HandshakeCanvas step={step} computed={computed} />
+    </WidgetShell>
+  );
+}
+
+const CAPTIONS: string[] = [
+  "Step 1 — the browser sends a regular HTTP/1.1 request. Three headers ask the server to stop being HTTP: Upgrade, Connection, and a random 16-byte key.",
+  "Step 2 — the server glues the key onto a hardcoded GUID, SHA-1s it, base64s the digest, and sends that hash back. 101 Switching Protocols rides along.",
+  "Step 3 — HTTP is over. The same TCP socket now carries WebSocket frames (2–14 bytes of overhead). Either side can send, anytime.",
+];
+
+/* -------------------------------------------------------------------------- */
+
+function HandshakeCanvas({ step, computed }: { step: number; computed: Computed }) {
+  const WIDTH = 820;
+  const HEIGHT = 460;
+
+  const BROWSER_X = 20;
+  const SERVER_X = 580;
+  const BOX_W = 220;
+  const PIPE_Y = 240;
+  const PIPE_X1 = BROWSER_X + BOX_W + 4;
+  const PIPE_X2 = SERVER_X - 4;
+
+  const pipeColor =
+    step >= 2 ? "var(--color-accent)" : "var(--color-text-muted)";
+  const pipeWidth = step >= 2 ? 3.5 : 1.4;
+  const pipeDash = step >= 2 ? undefined : "4 4";
+
+  // Preserve intrinsic SVG size so 9-10pt text stays readable. Narrow
+  // containers scroll horizontally inside the outer div — DESIGN.md §7
+  // ("canvas is the subject"): shrinking text into illegibility would let
+  // chrome win over canvas.
+  return (
+    <div style={{ overflowX: "auto", overflowY: "hidden", maxWidth: "100%" }}>
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width={WIDTH}
+      height={HEIGHT}
+      style={{ maxWidth: "100%", minWidth: 620, height: "auto", display: "block" }}
+      role="img"
+      aria-label={`Upgrade handshake step ${step + 1}`}
+    >
+      <defs>
+        <marker
+          id="uh-arrow"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
+        </marker>
+        <marker
+          id="uh-arrow-accent"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
+        </marker>
+      </defs>
+
+      {/* Browser box */}
+      <PanelBox
+        x={BROWSER_X}
+        y={20}
+        w={BOX_W}
+        h={PIPE_Y - 40}
+        label="browser"
+      />
+      <RequestPane x={BROWSER_X + 12} y={52} w={BOX_W - 24} key96={computed.key} highlight={step === 0} />
+
+      {/* Server box */}
+      <PanelBox
+        x={SERVER_X}
+        y={20}
+        w={BOX_W}
+        h={PIPE_Y - 40}
+        label="server"
+      />
+      <ComputeBox
+        x={SERVER_X + 12}
+        y={52}
+        w={BOX_W - 24}
+        key96={computed.key}
+        accept={computed.accept}
+        active={step === 1}
+      />
+
+      {/* The pipe (TCP socket) */}
+      <line
+        x1={PIPE_X1}
+        x2={PIPE_X2}
+        y1={PIPE_Y}
+        y2={PIPE_Y}
+        stroke={pipeColor}
+        strokeWidth={pipeWidth}
+        strokeDasharray={pipeDash}
+      />
+      <text
+        x={(PIPE_X1 + PIPE_X2) / 2}
+        y={PIPE_Y - 10}
+        textAnchor="middle"
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill={step >= 2 ? "var(--color-accent)" : "var(--color-text-muted)"}
+      >
+        {step >= 2 ? "WebSocket · framed binary" : "HTTP/1.1 over TCP"}
+      </text>
+
+      {/* Step 1: request envelope travels →. Fully hide once past step 0 so the
+          pipe carries only one message at a time — otherwise the request
+          envelope lingers dimmed while the server reply appears at the same x. */}
+      <motion.g
+        initial={false}
+        animate={{
+          opacity: step === 0 ? 1 : 0,
+          x: step >= 1 ? PIPE_X2 - PIPE_X1 - 90 : 0,
+        }}
+        transition={{ ...SPRING.smooth, delay: step === 0 ? 0.1 : 0 }}
+      >
+        <g transform={`translate(${PIPE_X1 + 8}, ${PIPE_Y - 18})`}>
+          <rect
+            x={0}
+            y={0}
+            width={90}
+            height={32}
+            rx={4}
+            fill="color-mix(in oklab, var(--color-surface) 70%, transparent)"
+            stroke="var(--color-text-muted)"
+            strokeWidth={1}
+          />
+          <text
+            x={45}
+            y={14}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill="var(--color-text-muted)"
+          >
+            GET /chat
+          </text>
+          <text
+            x={45}
+            y={26}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={9}
+            fill="var(--color-text-muted)"
+          >
+            Upgrade: websocket
+          </text>
+        </g>
+      </motion.g>
+
+      {/* Step 2: 101 response travels ← */}
+      <motion.g
+        initial={false}
+        animate={{
+          opacity: step === 1 ? 1 : step >= 2 ? 0 : 0,
+          x: step >= 2 ? -(PIPE_X2 - PIPE_X1 - 110) : 0,
+        }}
+        transition={{ ...SPRING.smooth, delay: step === 1 ? 0.7 : 0 }}
+      >
+        <g transform={`translate(${PIPE_X2 - 108}, ${PIPE_Y - 18})`}>
+          <rect
+            x={0}
+            y={0}
+            width={100}
+            height={32}
+            rx={4}
+            fill="color-mix(in oklab, var(--color-accent) 16%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={1.2}
+          />
+          <text
+            x={50}
+            y={14}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill="var(--color-accent)"
+          >
+            101 Switching
+          </text>
+          <text
+            x={50}
+            y={26}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={9}
+            fill="var(--color-accent)"
+          >
+            Sec-WebSocket-Accept
+          </text>
+        </g>
+      </motion.g>
+
+      {/* Step 3: bidirectional WS frames */}
+      {step >= 2 ? <FrameTraffic x1={PIPE_X1} x2={PIPE_X2} y={PIPE_Y} /> : null}
+
+      {/* Response transcript below the pipe */}
+      <g transform={`translate(${BROWSER_X}, ${PIPE_Y + 40})`}>
+        <text
+          x={0}
+          y={0}
+          fontFamily="var(--font-sans)"
+          fontSize={11}
+          fontWeight={500}
+          fill="var(--color-text-muted)"
+        >
+          what goes on the wire
+        </text>
+      </g>
+      <g transform={`translate(${BROWSER_X}, ${PIPE_Y + 56})`}>
+        <Transcript step={step} computed={computed} width={WIDTH - BROWSER_X * 2} />
+      </g>
+    </svg>
+    </div>
+  );
+}
+
+function PanelBox({
+  x,
+  y,
+  w,
+  h,
+  label,
+}: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  label: string;
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-surface) 55%, transparent)"
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+      />
+      <text
+        x={x + 12}
+        y={y + 20}
+        fontFamily="var(--font-mono)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
+function RequestPane({
+  x,
+  y,
+  w,
+  key96,
+  highlight,
+}: {
+  x: number;
+  y: number;
+  w: number;
+  key96: string;
+  highlight: boolean;
+}) {
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      {[
+        "GET /chat HTTP/1.1",
+        "Host: docs.example",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        `Sec-WebSocket-Key: ${truncate(key96, 16)}`,
+        "Sec-WebSocket-Version: 13",
+      ].map((line, i) => {
+        const isUpgrade = line.startsWith("Upgrade") || line.startsWith("Connection") || line.startsWith("Sec-WebSocket-Key");
+        return (
+          <text
+            key={line}
+            x={0}
+            y={i * 16 + 10}
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill={
+              highlight && isUpgrade
+                ? "var(--color-accent)"
+                : "var(--color-text)"
+            }
+            fontWeight={highlight && isUpgrade ? 500 : 400}
+          >
+            {line}
+          </text>
+        );
+      })}
+      {/* An unused `w` rect keeps the pane size stable across re-renders. */}
+      <rect x={0} y={0} width={w} height={1} fill="transparent" />
+    </g>
+  );
+}
+
+function ComputeBox({
+  x,
+  y,
+  w,
+  key96,
+  accept,
+  active,
+}: {
+  x: number;
+  y: number;
+  w: number;
+  key96: string;
+  accept: string;
+  active: boolean;
+}) {
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <text x={0} y={10} fontFamily="var(--font-mono)" fontSize={10} fill="var(--color-text-muted)">
+        key = {truncate(key96, 14)}
+      </text>
+      <text x={0} y={28} fontFamily="var(--font-mono)" fontSize={10} fill="var(--color-text-muted)">
+        GUID = 258EAFA5-E914-…
+      </text>
+      <motion.text
+        x={0}
+        y={50}
+        fontFamily="var(--font-mono)"
+        fontSize={11}
+        fill={active ? "var(--color-accent)" : "var(--color-text)"}
+        initial={false}
+        animate={{ opacity: active ? 1 : 0.75 }}
+        transition={SPRING.smooth}
+      >
+        SHA-1(key + GUID)
+      </motion.text>
+      <line x1={0} x2={w - 8} y1={58} y2={58} stroke="var(--color-rule)" strokeWidth={1} strokeDasharray="2 3" />
+      <text
+        x={0}
+        y={76}
+        fontFamily="var(--font-mono)"
+        fontSize={10}
+        fill="var(--color-text-muted)"
+      >
+        base64 →
+      </text>
+      <AcceptSettle accept={truncate(accept, 18)} y={94} />
+      <rect x={0} y={0} width={w} height={1} fill="transparent" />
+    </g>
+  );
+}
+
+/**
+ * AcceptSettle — renders the Sec-WebSocket-Accept value so the trailing
+ * characters flash terracotta then settle to text colour on each regenerate.
+ * Only characters that change on a re-roll (the full string, in practice)
+ * animate; keying on the value itself forces a remount, so no manual diffing.
+ * Teaching signal: the reader sees which bytes their browser just produced.
+ */
+function AcceptSettle({ accept, y }: { accept: string; y: number }) {
+  // Split: keep the first few characters static as an anchor, animate the tail.
+  const SPLIT = Math.max(0, accept.length - 8);
+  const head = accept.slice(0, SPLIT);
+  const tail = accept.slice(SPLIT).split("");
+  return (
+    <text
+      key={accept}
+      x={0}
+      y={y}
+      fontFamily="var(--font-mono)"
+      fontSize={11}
+    >
+      <tspan fill="var(--color-accent)">{head}</tspan>
+      {tail.map((ch, i) => (
+        <motion.tspan
+          key={`${accept}-${i}`}
+          initial={{ fill: "var(--color-text-muted)" }}
+          animate={{ fill: "var(--color-accent)" }}
+          transition={{
+            duration: 0.24,
+            ease: [0.22, 1, 0.36, 1],
+            delay: 0.08 + i * 0.028,
+          }}
+        >
+          {ch}
+        </motion.tspan>
+      ))}
+    </text>
+  );
+}
+
+/**
+ * FrameTraffic — step-3 bidirectional frame demo.
+ *
+ * Pre-fix: two `repeat: Infinity` loops with `ease: "linear"`. DESIGN.md §9
+ * bans linear easing for UI motion, and ambient decoration after the first
+ * pass teaches nothing. Now: each direction animates exactly twice on entry,
+ * then settles into a pair of muted "socket is open, either side may speak"
+ * endpoint pulses using `SPRING.gentle` on opacity only.
+ */
+function FrameTraffic({ x1, x2, y }: { x1: number; x2: number; y: number }) {
+  return (
+    <g>
+      {/* Frame traveling →, plays twice then ends at rest */}
+      <motion.g
+        initial={{ x: x1 + 20, opacity: 0 }}
+        animate={{
+          x: [x1 + 20, x2 - 30, x1 + 20, x2 - 30],
+          opacity: [0, 1, 0, 1, 0],
+        }}
+        transition={{
+          times: [0, 0.25, 0.5, 0.75, 1],
+          duration: 2.4,
+          ease: [0.22, 1, 0.36, 1],
+        }}
+      >
+        <rect x={0} y={y - 8} width={22} height={14} rx={2} fill="var(--color-accent)" />
+        <text
+          x={11}
+          y={y + 1}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-bg)"
+        >
+          0x1
+        </text>
+      </motion.g>
+      {/* Frame traveling ←, staggered, plays twice then ends at rest */}
+      <motion.g
+        initial={{ x: x2 - 40, opacity: 0 }}
+        animate={{
+          x: [x2 - 40, x1 - 10, x2 - 40, x1 - 10],
+          opacity: [0, 1, 0, 1, 0],
+        }}
+        transition={{
+          times: [0, 0.25, 0.5, 0.75, 1],
+          duration: 2.4,
+          ease: [0.22, 1, 0.36, 1],
+          delay: 0.9,
+        }}
+      >
+        <rect x={0} y={y + 12} width={22} height={14} rx={2} fill="var(--color-accent)" />
+        <text
+          x={11}
+          y={y + 21}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={8}
+          fill="var(--color-bg)"
+        >
+          0x2
+        </text>
+      </motion.g>
+      {/* After the two passes settle, a subtle ambient pulse on each endpoint
+          signals "socket is open, both ends may speak" — state-conveying, not
+          decoration. Uses opacity only and a gentle spring keyframe. */}
+      <EndpointPulse cx={x1 + 2} cy={y} />
+      <EndpointPulse cx={x2 - 2} cy={y} />
+      <text
+        x={(x1 + x2) / 2}
+        y={y + 44}
+        textAnchor="middle"
+        fontFamily="var(--font-mono)"
+        fontSize={9}
+        fill="var(--color-text-muted)"
+      >
+        opcodes: 0x1 text · 0x2 binary · 0x8 close · 0x9 ping · 0xA pong
+      </text>
+    </g>
+  );
+}
+
+function EndpointPulse({ cx, cy }: { cx: number; cy: number }) {
+  return (
+    <motion.circle
+      cx={cx}
+      cy={cy}
+      r={3}
+      fill="var(--color-accent)"
+      initial={{ opacity: 0.5 }}
+      animate={{ opacity: [0.5, 0.9, 0.5] }}
+      transition={{ duration: 2.2, repeat: Infinity, ease: [0.22, 1, 0.36, 1] }}
+    />
+  );
+}
+
+function Transcript({
+  step,
+  computed,
+  width,
+}: {
+  step: number;
+  computed: Computed;
+  width: number;
+}) {
+  const reqLines = [
+    "GET /chat HTTP/1.1",
+    "Host: docs.example",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${truncate(computed.key, 24)}`,
+    "Sec-WebSocket-Version: 13",
+    "",
+  ];
+  const resLines = [
+    "HTTP/1.1 101 Switching Protocols",
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Accept: ${truncate(computed.accept, 24)}`,
+    "",
+  ];
+  const rightX = width / 2 + 10;
+
+  return (
+    <g>
+      {/* Left: request */}
+      <text x={0} y={0} fontFamily="var(--font-mono)" fontSize={9} fill="var(--color-text-muted)">
+        client → server
+      </text>
+      {reqLines.map((line, i) => {
+        const isSpecial =
+          line.startsWith("Upgrade:") ||
+          line.startsWith("Connection:") ||
+          line.startsWith("Sec-WebSocket-Key");
+        return (
+          <text
+            key={`req-${i}`}
+            x={0}
+            y={16 + i * 13}
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill={isSpecial && step === 0 ? "var(--color-accent)" : "var(--color-text)"}
+            opacity={step >= 2 ? 0.55 : 1}
+          >
+            {line}
+          </text>
+        );
+      })}
+
+      {/* Right: response */}
+      <text x={rightX} y={0} fontFamily="var(--font-mono)" fontSize={9} fill="var(--color-text-muted)">
+        server → client
+      </text>
+      {resLines.map((line, i) => {
+        const isSpecial =
+          line.startsWith("HTTP/1.1 101") || line.startsWith("Sec-WebSocket-Accept");
+        const visible = step >= 1;
+        return (
+          <text
+            key={`res-${i}`}
+            x={rightX}
+            y={16 + i * 13}
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill={isSpecial && step === 1 ? "var(--color-accent)" : "var(--color-text)"}
+            opacity={visible ? (step >= 2 ? 0.7 : 1) : 0.25}
+          >
+            {line}
+          </text>
+        );
+      })}
+    </g>
+  );
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}

--- a/app/posts/the-browser-stopped-asking/widgets/WidgetShell.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/WidgetShell.tsx
@@ -1,0 +1,1 @@
+export { WidgetShell } from "@/components/viz/WidgetShell";

--- a/app/posts/the-browser-stopped-asking/widgets/index.ts
+++ b/app/posts/the-browser-stopped-asking/widgets/index.ts
@@ -1,0 +1,3 @@
+export { PipeCompare } from "./PipeCompare";
+export { UpgradeHandshake } from "./UpgradeHandshake";
+export { ReconnectGap } from "./ReconnectGap";

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -25,7 +25,7 @@ export const POSTS: PostMeta[] = [
   {
     slug: "the-function-that-remembered",
     title: "The function that remembered",
-    date: "2026-04-24",
+    date: "2026-04-19",
     hook: "how a function outlives the scope it was born in — and why half of your JS bugs start there.",
     readingMinutes: 10,
     tags: ["javascript", "language-internals"],
@@ -33,7 +33,7 @@ export const POSTS: PostMeta[] = [
   {
     slug: "the-browser-stopped-asking",
     title: "The browser stopped asking",
-    date: "2026-04-22",
+    date: "2026-04-20",
     hook: "real-time apps didn't teach the server to speak first — they taught the browser to stop hanging up.",
     readingMinutes: 9,
     tags: ["web", "protocols", "real-time"],

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -31,6 +31,14 @@ export const POSTS: PostMeta[] = [
     tags: ["javascript", "language-internals"],
   },
   {
+    slug: "the-browser-stopped-asking",
+    title: "The browser stopped asking",
+    date: "2026-04-22",
+    hook: "real-time apps didn't teach the server to speak first — they taught the browser to stop hanging up.",
+    readingMinutes: 9,
+    tags: ["web", "protocols", "real-time"],
+  },
+  {
     slug: "why-fetch-fails-only-in-browser",
     title: "Why `fetch` works in curl but the browser blocks it",
     date: "2026-04-20",

--- a/lib/shiki.ts
+++ b/lib/shiki.ts
@@ -29,6 +29,7 @@ export function getHighlighter(): Promise<HighlighterCore> {
           import("shiki/langs/bash.mjs"),
           import("shiki/langs/python.mjs"),
           import("shiki/langs/json.mjs"),
+          import("shiki/langs/http.mjs"),
         ],
         engine: createJavaScriptRegexEngine(),
       });


### PR DESCRIPTION
## Summary
- **Topic.** How Google Docs shows a teammate's cursor live. Thesis: real-time apps didn't teach the server to speak first — they taught the browser to stop hanging up. Every mechanism is a different degree of "how long will the browser leave one request unfinished?"
- **Pedagogy.** 8 sections, ~2,400 words, ~9 min read. Scene opens on Jordan's cursor, progresses polling → long polling (with the BrowserChannel history) → WebSocket (with live SHA-1 against the RFC 6455 magic GUID) → SSE (with the auto-reconnect trade) → the catch (Socket.IO, reconnect storms, fanout) → back to scene. Cliffhanger into the CRDT/OT merge post.
- **Widgets (3, all post-local):**
  - `PipeCompare` — three protocol timelines on a 10-second window. Play/pause/scrub. Live byte and cycle counters per row. Messages pop in with `SPRING.snappy` scale-from-0.6 entry motion.
  - `UpgradeHandshake` — 3-step stepper showing the RFC 6455 upgrade. Computes `SHA-1(Sec-WebSocket-Key + GUID)` in the browser via Web Crypto and renders the reader's own accept hash. Regenerate button re-rolls a 16-byte key and settles the fresh base64 trailing characters in terracotta.
  - `ReconnectGap` — WebSocket vs SSE side-by-side over a draggable network dropout. SSE's replay arc strokes itself path-length 0→1 to reconnect, with the delivered dot popping at the tail.
- **Primitives composed from.** `<Prose>`, `<H1/H2/H3>`, `<P>`, `<Code>`, `<Em>`, `<Term>`, `<Callout>`, `<Dots>`, `<A>`, `<FullBleed>`, `<HeroTile>`, `<CodeBlock>` from `components/prose` + `components/code`; `<WidgetShell>`, `<Scrubber>`, `<Stepper>` from `components/viz`. No new shared components.
- **One shared-file change.** `lib/shiki.ts` adds `http` to the bundled languages (for the wire-format transcripts).

## Design reviews — action items resolved
Six skill reviews ran in parallel (clarify / layout / critique / animate / delight / bolder). All P0s resolved, most P1s shipped. Full ledger at `research/the-browser-stopped-asking/action-items.md`.

**Resolved P0s:**
- Planted the "stopped hanging up" phrase at end of §3 so the aha lands before §7 (critique).
- Reframed PipeCompare's WebSocket preview as a promise, not a spoiler (critique).
- Fixed "Web Crypto hardware" → "Web Crypto API" (clarify — factual).
- "laziest" → "crudest" in §2 (clarify — unearned judgment).
- Killed `repeat: Infinity` + `ease: "linear"` on UpgradeHandshake step-3 frames (animate — §9 ban). Replaced with 2-pass playback + gentle endpoint pulses conveying "socket is open."
- `ReconnectGap` dropout band: `width` animation → `scaleX` + `translateX` (animate — §9 ban).
- PipeCompare arrows: scale-from-0.6 entry motion so events visibly arrive on the wire (animate).
- Both complex widgets wrap in `overflow-x: auto` with `minWidth` on the SVG so narrow containers scroll instead of shrinking text to illegibility (layout — §7 compliance).

**Key P1s shipped:**
- Split §4: magic GUID now gets its own display `<CodeBlock>` and the one-line algorithm (`base64(sha1(key + GUID))`) sits below it. Widget reveals, prose follows.
- §6 "three things" restructured as three `<H3>`s, each opening with a concrete moment ("Discord learned this at 5M sessions").
- Typographic peak on the closing sentence; cliffhanger hand-off with small-caps "next —" label.
- Widget titles dropped the `PascalCaseName ·` prefix. aria-labels shortened. Stepper captions tightened.
- `ReconnectGap` replay arc strokes itself via `pathLength` 0→1 per event, staggered.
- `UpgradeHandshake` exposes measured SHA-1 duration in the measurements slot; the trailing base64 chars flash terracotta → text on regenerate.

**Deferred P2** (listed in `action-items.md`): a few minor term-consistency and cosmetic items batched in-line; a handful of nice-to-haves left for a later housekeeping pass.

## Validation (Phase H)
`research/the-browser-stopped-asking/validation.md` — all 5 checks pass:

1. **Technical correctness** — every cited fact maps to `facts-1/2/3.md`. The one `[UNCERTAIN]` (current Docs transport) is handled with an explicit honest hedge.
2. **Code correctness** — 6 runnable or literal-wire snippets; each conforms to its respective spec. The widget's live SHA-1 against the RFC 6455 sample key produces the RFC's sample accept value.
3. **A11y** — keyboard-operable, reduced-motion-respecting (`MotionConfigProvider`), 44×44 tap targets, color-only-info paired with shape/label everywhere (verified case-by-case).
4. **Build** — `pnpm build` passes clean; route prerenders as static. Lighthouse to verify on the preview URL.
5. **Reading-sanity** — end-to-end read done via the critique agent + a second manual pass. Voice matches both sibling posts.

`node scripts/audit-prose.mjs` — 0 errors, 0 post-specific warnings after fixing 3 fragile-space-after-italic cases.

## Open questions
- Lighthouse ≥ 95 on all four axes — to verify on the Vercel preview at Checkpoint 4.
- Mobile smoke on a real device — the two SVG-heavy widgets depend on `overflow-x: auto` so text stays legible; should be spot-checked on a phone.

## Cliffhanger
The pipe is the easy part. Next post: when Jordan types `B → BC` at the same moment you type `B → AB`, why doesn't the document collapse into `ABC` on one screen and `BC` on the other? That's the CRDT/OT merge post.

## Test plan
- [ ] Open the Vercel preview URL in light + dark themes.
- [ ] Exercise every widget: play/pause/scrub `PipeCompare`; step through `UpgradeHandshake` and click `regenerate key`; drag the dropout and dropout-length sliders on `ReconnectGap`.
- [ ] Keyboard-only: Tab through the page; arrow keys on `Stepper`; arrow keys on `<input type="range">`.
- [ ] `prefers-reduced-motion: reduce` in OS — confirm animations collapse to instant and every widget still teaches.
- [ ] Mobile (phone-width): verify the SVGs scroll horizontally rather than shrinking text.
- [ ] Lighthouse on the post page: ≥ 95 on Performance / Accessibility / SEO / Best Practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)