### PR TITLE
feat: reader counter — dot-matrix display in about column

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Header } from "@/components/nav/Header";
 import { Footer } from "@/components/nav/Footer";
 import { CozyFrame } from "@/components/nav/CozyFrame";
 import { MotionConfigProvider } from "@/components/providers/motion-config";
+import { GoatCounter } from "@/components/analytics/GoatCounter";
 import {
   SITE_AUTHOR,
   SITE_AUTHOR_URL,
@@ -92,6 +93,7 @@ export default function RootLayout({
             </CozyFrame>
           </MotionConfigProvider>
         </ThemeProvider>
+        <GoatCounter />
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { PostList } from "@/components/nav/PostList";
 import { AboutColumn } from "@/components/nav/AboutColumn";
 import { POSTS_NEWEST_FIRST } from "@/content/posts-manifest";
+import { getUniqueReaderCount } from "@/lib/stats";
 
 /**
  * Home page — single column below lg:, two-column from lg: up.
@@ -8,11 +9,12 @@ import { POSTS_NEWEST_FIRST } from "@/content/posts-manifest";
  * so the grid stays single-column until there's real room at 1024.
  * Left: AboutColumn (~320px, sticky). Right: PostList (flex fill).
  */
-export default function Home() {
+export default async function Home() {
+  const readerCount = await getUniqueReaderCount();
   return (
     <div className="w-full px-[var(--spacing-md)] sm:px-[var(--spacing-lg)] md:px-[var(--spacing-xl)] lg:px-[var(--spacing-2xl)] pt-[var(--spacing-lg)] sm:pt-[var(--spacing-xl)] md:pt-[var(--spacing-2xl)] lg:pt-[var(--spacing-3xl)] pb-[var(--spacing-3xl)]">
       <div className="grid gap-[var(--spacing-xl)] lg:grid-cols-[320px_minmax(0,1fr)] lg:gap-[var(--spacing-3xl)]">
-        <AboutColumn />
+        <AboutColumn readerCount={readerCount} />
         <div>
           <PostList posts={POSTS_NEWEST_FIRST} />
         </div>

--- a/components/analytics/GoatCounter.tsx
+++ b/components/analytics/GoatCounter.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { GOATCOUNTER_CODE } from "@/lib/site";
+
+declare global {
+  interface Window {
+    goatcounter?: { count?: (opts: { path: string }) => void };
+  }
+}
+
+export function GoatCounter() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.goatcounter?.count?.({ path: pathname });
+  }, [pathname]);
+
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV !== "production") return null;
+
+  return (
+    <Script
+      src="https://gc.zgo.at/count.js"
+      strategy="afterInteractive"
+      data-goatcounter={`https://${GOATCOUNTER_CODE}.goatcounter.com/count`}
+    />
+  );
+}

--- a/components/nav/AboutColumn.tsx
+++ b/components/nav/AboutColumn.tsx
@@ -5,6 +5,7 @@ import { motion } from "motion/react";
 import { PRESS, SPRING } from "@/lib/motion";
 import { useFirstVisit } from "@/lib/hooks/use-first-visit";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
+import { ReaderCount } from "@/components/nav/ReaderCount";
 import {
   SITE_ABOUT,
   SITE_AUTHOR_DISPLAY,
@@ -30,7 +31,11 @@ const COPYRIGHT_NOW = new Date().getFullYear();
  *   - Return visit: a short 60 ms stagger across the four children.
  * Reduced-motion users collapse to the final state via MotionConfigProvider.
  */
-export function AboutColumn() {
+type AboutColumnProps = {
+  readerCount: number | null;
+};
+
+export function AboutColumn({ readerCount }: AboutColumnProps) {
   const { ready, firstVisit } = useFirstVisit();
   const subscribe = useTapPulse<HTMLAnchorElement>();
   const years =
@@ -167,6 +172,7 @@ export function AboutColumn() {
         >
           <GitHubIcon />
         </Link>
+        <ReaderCount count={readerCount} />
         <span className="tabular-nums" aria-label={`copyright ${years}`}>
           © {years}
         </span>

--- a/components/nav/DigitMatrix.tsx
+++ b/components/nav/DigitMatrix.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Matrix, digits, type Frame } from "@/components/unlumen-ui/matrix";
+
+type Props = {
+  value: number;
+  ariaLabel?: string;
+};
+
+const MATRIX_ON = "var(--color-accent)";
+const MATRIX_OFF = "color-mix(in oklab, var(--color-text-muted) 18%, transparent)";
+
+export function DigitMatrix({ value, ariaLabel }: Props) {
+  const chars = String(Math.max(0, Math.floor(value))).split("");
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel ?? String(value)}
+      className="inline-flex items-center gap-[3px] align-[-2px]"
+    >
+      {chars.map((char, i) => {
+        const digit = Number(char);
+        const pattern: Frame = digits[digit];
+        return (
+          <Matrix
+            key={i}
+            rows={7}
+            cols={5}
+            pattern={pattern}
+            size={3}
+            gap={1}
+            palette={{ on: MATRIX_ON, off: MATRIX_OFF }}
+            brightness={1}
+            noGlow
+          />
+        );
+      })}
+    </span>
+  );
+}

--- a/components/nav/ReaderCount.tsx
+++ b/components/nav/ReaderCount.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { DigitMatrix } from "./DigitMatrix";
+
+type Props = { count: number | null };
+
+export function ReaderCount({ count }: Props) {
+  if (count === null || count === 0) return null;
+
+  const noun = count === 1 ? "reader" : "readers";
+  const formatted = new Intl.NumberFormat("en-US").format(count);
+
+  return (
+    <span className="inline-flex items-center gap-[var(--spacing-2xs)]">
+      <span>Read by</span>
+      <DigitMatrix value={count} ariaLabel={formatted} />
+      <span>{noun}</span>
+    </span>
+  );
+}

--- a/components/unlumen-ui/matrix.tsx
+++ b/components/unlumen-ui/matrix.tsx
@@ -1,0 +1,614 @@
+"use client";
+
+import * as React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+export type Frame = number[][];
+type MatrixMode = "default" | "vu";
+
+interface CellPosition {
+  x: number;
+  y: number;
+}
+
+interface MatrixProps extends React.HTMLAttributes<HTMLDivElement> {
+  rows: number;
+  cols: number;
+  pattern?: Frame;
+  frames?: Frame[];
+  fps?: number;
+  autoplay?: boolean;
+  loop?: boolean;
+  size?: number;
+  gap?: number;
+  palette?: {
+    on: string;
+    off: string;
+  };
+  brightness?: number;
+  ariaLabel?: string;
+  onFrame?: (index: number) => void;
+  mode?: MatrixMode;
+  levels?: number[];
+  noGlow?: boolean;
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function ensureFrameSize(frame: Frame, rows: number, cols: number): Frame {
+  const result: Frame = [];
+  for (let r = 0; r < rows; r++) {
+    const row = frame[r] || [];
+    result.push([]);
+    for (let c = 0; c < cols; c++) {
+      result[r][c] = row[c] ?? 0;
+    }
+  }
+  return result;
+}
+
+function useAnimation(
+  frames: Frame[] | undefined,
+  options: {
+    fps: number;
+    autoplay: boolean;
+    loop: boolean;
+    onFrame?: (index: number) => void;
+  },
+): { frameIndex: number; isPlaying: boolean } {
+  const [frameIndex, setFrameIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(options.autoplay);
+  const frameIdRef = useRef<number | undefined>(undefined);
+  const lastTimeRef = useRef<number>(0);
+  const accumulatorRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!frames || frames.length === 0 || !isPlaying) {
+      return;
+    }
+
+    const frameInterval = 1000 / options.fps;
+
+    const animate = (currentTime: number) => {
+      if (lastTimeRef.current === 0) {
+        lastTimeRef.current = currentTime;
+      }
+
+      const deltaTime = currentTime - lastTimeRef.current;
+      lastTimeRef.current = currentTime;
+      accumulatorRef.current += deltaTime;
+
+      if (accumulatorRef.current >= frameInterval) {
+        accumulatorRef.current -= frameInterval;
+
+        setFrameIndex((prev) => {
+          const next = prev + 1;
+          if (next >= frames.length) {
+            if (options.loop) {
+              options.onFrame?.(0);
+              return 0;
+            } else {
+              setIsPlaying(false);
+              return prev;
+            }
+          }
+          options.onFrame?.(next);
+          return next;
+        });
+      }
+
+      frameIdRef.current = requestAnimationFrame(animate);
+    };
+
+    frameIdRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (frameIdRef.current) {
+        cancelAnimationFrame(frameIdRef.current);
+      }
+    };
+  }, [frames, isPlaying, options.fps, options.loop, options.onFrame]);
+
+  useEffect(() => {
+    setFrameIndex(0);
+    setIsPlaying(options.autoplay);
+    lastTimeRef.current = 0;
+    accumulatorRef.current = 0;
+  }, [frames, options.autoplay]);
+
+  return { frameIndex, isPlaying };
+}
+
+function emptyFrame(rows: number, cols: number): Frame {
+  return Array.from({ length: rows }, () => Array(cols).fill(0));
+}
+
+function setPixel(frame: Frame, row: number, col: number, value: number): void {
+  if (row >= 0 && row < frame.length && col >= 0 && col < frame[0].length) {
+    frame[row][col] = value;
+  }
+}
+
+export const digits: Frame[] = [
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [0, 0, 1, 0, 0],
+    [0, 1, 1, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [0, 0, 0, 0, 1],
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 0, 0],
+    [1, 1, 1, 1, 1],
+  ],
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [0, 0, 0, 0, 1],
+    [0, 0, 1, 1, 0],
+    [0, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 1, 0],
+    [0, 1, 0, 1, 0],
+    [1, 0, 0, 1, 0],
+    [1, 1, 1, 1, 1],
+    [0, 0, 0, 1, 0],
+    [0, 0, 0, 1, 0],
+  ],
+  [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 0],
+    [1, 1, 1, 1, 0],
+    [0, 0, 0, 0, 1],
+    [0, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 0],
+    [1, 0, 0, 0, 0],
+    [1, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [1, 1, 1, 1, 1],
+    [0, 0, 0, 0, 1],
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 0, 0],
+    [0, 1, 0, 0, 0],
+    [0, 1, 0, 0, 0],
+  ],
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+  [
+    [0, 1, 1, 1, 0],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [0, 1, 1, 1, 1],
+    [0, 0, 0, 0, 1],
+    [0, 0, 0, 0, 1],
+    [0, 1, 1, 1, 0],
+  ],
+];
+
+export const chevronLeft: Frame = [
+  [0, 0, 0, 1, 0],
+  [0, 0, 1, 0, 0],
+  [0, 1, 0, 0, 0],
+  [0, 0, 1, 0, 0],
+  [0, 0, 0, 1, 0],
+];
+
+export const chevronRight: Frame = [
+  [0, 1, 0, 0, 0],
+  [0, 0, 1, 0, 0],
+  [0, 0, 0, 1, 0],
+  [0, 0, 1, 0, 0],
+  [0, 1, 0, 0, 0],
+];
+
+export const loader: Frame[] = (() => {
+  const frames: Frame[] = [];
+  const size = 7;
+  const center = 3;
+  const radius = 2.5;
+
+  for (let frame = 0; frame < 12; frame++) {
+    const f = emptyFrame(size, size);
+    for (let i = 0; i < 8; i++) {
+      const angle = (frame / 12) * Math.PI * 2 + (i / 8) * Math.PI * 2;
+      const x = Math.round(center + Math.cos(angle) * radius);
+      const y = Math.round(center + Math.sin(angle) * radius);
+      const brightness = 1 - i / 10;
+      setPixel(f, y, x, Math.max(0.2, brightness));
+    }
+    frames.push(f);
+  }
+
+  return frames;
+})();
+
+export const pulse: Frame[] = (() => {
+  const frames: Frame[] = [];
+  const size = 7;
+  const center = 3;
+
+  for (let frame = 0; frame < 16; frame++) {
+    const f = emptyFrame(size, size);
+    const phase = (frame / 16) * Math.PI * 2;
+    const intensity = (Math.sin(phase) + 1) / 2;
+
+    setPixel(f, center, center, 1);
+
+    const radius = Math.floor((1 - intensity) * 3) + 1;
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (Math.abs(dist - radius) < 0.7) {
+          setPixel(f, center + dy, center + dx, intensity * 0.6);
+        }
+      }
+    }
+
+    frames.push(f);
+  }
+
+  return frames;
+})();
+
+export function vu(columns: number, levels: number[]): Frame {
+  const rows = 7;
+  const frame = emptyFrame(rows, columns);
+
+  for (let col = 0; col < Math.min(columns, levels.length); col++) {
+    const level = Math.max(0, Math.min(1, levels[col]));
+    const height = Math.floor(level * rows);
+
+    for (let row = 0; row < rows; row++) {
+      const rowFromBottom = rows - 1 - row;
+      if (rowFromBottom < height) {
+        let brightness = 1;
+        if (row < rows * 0.3) {
+          brightness = 1;
+        } else if (row < rows * 0.6) {
+          brightness = 0.8;
+        } else {
+          brightness = 0.6;
+        }
+        frame[row][col] = brightness;
+      }
+    }
+  }
+
+  return frame;
+}
+
+export const wave: Frame[] = (() => {
+  const frames: Frame[] = [];
+  const rows = 7;
+  const cols = 7;
+
+  for (let frame = 0; frame < 24; frame++) {
+    const f = emptyFrame(rows, cols);
+    const phase = (frame / 24) * Math.PI * 2;
+
+    for (let col = 0; col < cols; col++) {
+      const colPhase = (col / cols) * Math.PI * 2;
+      const height = Math.sin(phase + colPhase) * 2.5 + 3.5;
+      const row = Math.floor(height);
+
+      if (row >= 0 && row < rows) {
+        setPixel(f, row, col, 1);
+        const frac = height - row;
+        if (row > 0) setPixel(f, row - 1, col, 1 - frac);
+        if (row < rows - 1) setPixel(f, row + 1, col, frac);
+      }
+    }
+
+    frames.push(f);
+  }
+
+  return frames;
+})();
+
+export const snake: Frame[] = (() => {
+  const frames: Frame[] = [];
+  const rows = 7;
+  const cols = 7;
+  const path: Array<[number, number]> = [];
+
+  let x = 0;
+  let y = 0;
+  let dx = 1;
+  let dy = 0;
+
+  const visited = new Set<string>();
+  while (path.length < rows * cols) {
+    path.push([y, x]);
+    visited.add(`${y},${x}`);
+
+    const nextX = x + dx;
+    const nextY = y + dy;
+
+    if (
+      nextX >= 0 &&
+      nextX < cols &&
+      nextY >= 0 &&
+      nextY < rows &&
+      !visited.has(`${nextY},${nextX}`)
+    ) {
+      x = nextX;
+      y = nextY;
+    } else {
+      const newDx = -dy;
+      const newDy = dx;
+      dx = newDx;
+      dy = newDy;
+
+      const nextX = x + dx;
+      const nextY = y + dy;
+
+      if (
+        nextX >= 0 &&
+        nextX < cols &&
+        nextY >= 0 &&
+        nextY < rows &&
+        !visited.has(`${nextY},${nextX}`)
+      ) {
+        x = nextX;
+        y = nextY;
+      } else {
+        break;
+      }
+    }
+  }
+
+  const snakeLength = 5;
+  for (let frame = 0; frame < path.length; frame++) {
+    const f = emptyFrame(rows, cols);
+
+    for (let i = 0; i < snakeLength; i++) {
+      const idx = frame - i;
+      if (idx >= 0 && idx < path.length) {
+        const [y, x] = path[idx];
+        const brightness = 1 - i / snakeLength;
+        setPixel(f, y, x, brightness);
+      }
+    }
+
+    frames.push(f);
+  }
+
+  return frames;
+})();
+
+export const Matrix = React.forwardRef<HTMLDivElement, MatrixProps>(
+  (
+    {
+      rows,
+      cols,
+      pattern,
+      frames,
+      fps = 12,
+      autoplay = true,
+      loop = true,
+      size = 10,
+      gap = 2,
+      palette = {
+        on: "currentColor",
+        off: "var(--color-text-muted)",
+      },
+      brightness = 1,
+      ariaLabel,
+      onFrame,
+      mode = "default",
+      levels,
+      className,
+      noGlow = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const { frameIndex } = useAnimation(frames, {
+      fps,
+      autoplay: autoplay && !pattern,
+      loop,
+      onFrame,
+    });
+
+    const currentFrame = useMemo(() => {
+      if (mode === "vu" && levels && levels.length > 0) {
+        return ensureFrameSize(vu(cols, levels), rows, cols);
+      }
+
+      if (pattern) {
+        return ensureFrameSize(pattern, rows, cols);
+      }
+
+      if (frames && frames.length > 0) {
+        return ensureFrameSize(frames[frameIndex] || frames[0], rows, cols);
+      }
+
+      return ensureFrameSize([], rows, cols);
+    }, [pattern, frames, frameIndex, rows, cols, mode, levels]);
+
+    const cellPositions = useMemo(() => {
+      const positions: CellPosition[][] = [];
+
+      for (let row = 0; row < rows; row++) {
+        positions[row] = [];
+        for (let col = 0; col < cols; col++) {
+          positions[row][col] = {
+            x: col * (size + gap),
+            y: row * (size + gap),
+          };
+        }
+      }
+
+      return positions;
+    }, [rows, cols, size, gap]);
+
+    const svgDimensions = useMemo(() => {
+      return {
+        width: cols * (size + gap) - gap,
+        height: rows * (size + gap) - gap,
+      };
+    }, [rows, cols, size, gap]);
+
+    const isAnimating = !pattern && frames && frames.length > 0;
+
+    return (
+      <div
+        ref={ref}
+        role="img"
+        aria-label={ariaLabel ?? "matrix display"}
+        aria-live={isAnimating ? "polite" : undefined}
+        className={cn("relative inline-block", className)}
+        style={
+          {
+            "--matrix-on": palette.on,
+            "--matrix-off": palette.off,
+            "--matrix-gap": `${gap}px`,
+            "--matrix-size": `${size}px`,
+          } as React.CSSProperties
+        }
+        {...props}
+      >
+        <svg
+          width={svgDimensions.width}
+          height={svgDimensions.height}
+          viewBox={`0 0 ${svgDimensions.width} ${svgDimensions.height}`}
+          xmlns="http://www.w3.org/2000/svg"
+          className="block"
+          style={{ overflow: "visible" }}
+        >
+          <defs>
+            <radialGradient id="matrix-pixel-on" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="var(--matrix-on)" stopOpacity="1" />
+              <stop
+                offset="70%"
+                stopColor="var(--matrix-on)"
+                stopOpacity="0.85"
+              />
+              <stop
+                offset="100%"
+                stopColor="var(--matrix-on)"
+                stopOpacity="0.6"
+              />
+            </radialGradient>
+
+            <radialGradient id="matrix-pixel-off" cx="50%" cy="50%" r="50%">
+              <stop
+                offset="0%"
+                stopColor="var(--matrix-off)"
+                stopOpacity="1"
+              />
+              <stop
+                offset="100%"
+                stopColor="var(--matrix-off)"
+                stopOpacity="0.7"
+              />
+            </radialGradient>
+
+            <filter
+              id="matrix-glow"
+              x="-50%"
+              y="-50%"
+              width="200%"
+              height="200%"
+            >
+              <feGaussianBlur stdDeviation="2" result="blur" />
+              <feComposite in="SourceGraphic" in2="blur" operator="over" />
+            </filter>
+          </defs>
+
+          <style>
+            {`
+              .matrix-pixel {
+                transition: opacity 300ms ease-out, transform 150ms ease-out;
+                transform-origin: center;
+                transform-box: fill-box;
+              }
+              .matrix-pixel-active {
+                filter: url(#matrix-glow);
+              }
+            `}
+          </style>
+
+          {currentFrame.map((row, rowIndex) =>
+            row.map((value, colIndex) => {
+              const pos = cellPositions[rowIndex]?.[colIndex];
+              if (!pos) return null;
+
+              const opacity = clamp(brightness * value);
+              const isActive = opacity > 0.5;
+              const isOn = opacity > 0.05;
+              const fill = isOn
+                ? "url(#matrix-pixel-on)"
+                : "url(#matrix-pixel-off)";
+
+              const scale = isActive && !noGlow ? 1.1 : 1;
+              const radius = (size / 2) * 0.9;
+
+              return (
+                <circle
+                  key={`${rowIndex}-${colIndex}`}
+                  className={cn(
+                    "matrix-pixel",
+                    isActive && !noGlow && "matrix-pixel-active",
+                    !isOn && "opacity-20 dark:opacity-[0.1]",
+                  )}
+                  cx={pos.x + size / 2}
+                  cy={pos.y + size / 2}
+                  r={radius}
+                  fill={fill}
+                  opacity={isOn ? opacity : 0.1}
+                  style={{
+                    transform: `scale(${scale})`,
+                  }}
+                />
+              );
+            }),
+          )}
+        </svg>
+      </div>
+    );
+  },
+);
+
+Matrix.displayName = "Matrix";

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -26,3 +26,6 @@ export const SITE_TAGLINE = "engineering essays with widgets you can take apart.
 /** Longer blurb for the home's about column — Phase 3. */
 export const SITE_ABOUT =
   "one question per post. ten minutes of prose, twenty of widgets you can poke at. for engineers who want the details beneath the abstractions.";
+
+/** GoatCounter subdomain for the analytics account backing the reader counter. */
+export const GOATCOUNTER_CODE = "bytesize";

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,27 @@
+import { GOATCOUNTER_CODE } from "./site";
+
+const ENDPOINT = `https://${GOATCOUNTER_CODE}.goatcounter.com/api/v0/stats/total`;
+
+export async function getUniqueReaderCount(): Promise<number | null> {
+  const mock = process.env.READER_COUNT_MOCK;
+  if (mock) {
+    const n = Number(mock);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  const token = process.env.GOATCOUNTER_API_TOKEN;
+  if (!token) return null;
+
+  try {
+    const res = await fetch(ENDPOINT, {
+      headers: { Authorization: `Bearer ${token}` },
+      next: { revalidate: 60 },
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { total?: number };
+    return typeof data.total === "number" ? data.total : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/utils/cn.ts
+++ b/lib/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | false | null | undefined>): string {
+  return inputs.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary

- Adds a cumulative unique-reader count to the homepage, rendered as **terracotta dot-matrix glyphs** in the `AboutColumn` bottom meta row — `[GH]   Read by ●●●●● readers   © 2026`.
- Analytics: **GoatCounter** with the authenticated private API. Counter refreshes every 60s via Next.js ISR. Tracking script is mounted **production only** (`NEXT_PUBLIC_VERCEL_ENV === "production"`) and picks up Next.js App Router client-side nav via a `usePathname()` hook.
- Vendors ElevenLabs UI's `Matrix` component (patched for bytesize tokens: `cn` import path, `--matrix-off` CSS var, new `noGlow` prop).

## Design discipline

- **On-palette**: on-dots use `var(--color-accent)` (terracotta, the single allowed accent); off-dots are an 18% ghost grid of `var(--color-text-muted)`. Both flip automatically between dark and light themes.
- **Singular / zero / null**: hides at 0 and on API failure; "1 reader" singular; "N readers" plural.
- **Accessibility**: `role="img"` + `aria-label={formatted}` so screen readers say "twelve thousand four hundred eighty-three readers" instead of enumerating circles.
- **Reduced motion**: inherits the global `prefers-reduced-motion` reset in `globals.css`.
- **Silent failure**: token missing → `null` → counter hides; no console noise.

## Env vars (set in Vercel dashboard before merge)

- `GOATCOUNTER_API_TOKEN` — scoped to **Production + Preview**.
- `READER_COUNT_MOCK` (optional, local only in `.env.local`) — renders the matrix with a fixed number during dev, e.g. `READER_COUNT_MOCK=12483`.

## Test plan

- [ ] `pnpm build` succeeds; homepage (`/`) prerenders as static.
- [ ] Locally with no env vars → counter hidden, meta row collapses cleanly to `[GH] © 2026`.
- [ ] Locally with `READER_COUNT_MOCK=12483` → terracotta dot-matrix renders; inspect reveals `fill` resolves to `var(--color-accent)`.
- [ ] Toggle theme dark ↔ light → glyph color flips from `terra-60` to `terra-40` automatically.
- [ ] `READER_COUNT_MOCK=0` → hidden; `READER_COUNT_MOCK=1` → "Read by 1 reader" (singular).
- [ ] After Vercel deploy: view-source shows `<script src="https://gc.zgo.at/count.js">` in prod, absent in preview.
- [ ] After one incognito visit: GoatCounter dashboard records 1 visit; counter on homepage shows `Read by 1 reader` within ~60s.
- [ ] Screen reader (VoiceOver) announces the formatted number, not a grid of circles.
- [ ] `prefers-reduced-motion` on → no pixel transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)