### PR TITLE
playbook: distil the agent-traps pipeline into reusable docs

### DIFF
--- a/.claude/commands/improve-an-article.md
+++ b/.claude/commands/improve-an-article.md
@@ -1,0 +1,134 @@
+# `/improve-an-article` — iterate an existing post with the full playbook
+
+Apply the latest voice, widget, pipeline, and skill-review knowledge to an existing bytesize post. Use this when:
+
+- A post shipped before a playbook doc existed and is due a refresh.
+- A new widget shape or pedagogy lesson has been added to the playbook and would strengthen an older article.
+- The user flags specific feedback and wants a proper multi-lens review rather than an ad-hoc edit.
+
+Arguments:
+- **Required**: a post slug or path (e.g. `the-function-that-remembered` or `app/posts/the-function-that-remembered/`).
+- **Optional**: a short brief of what the user thinks is off. If absent, fire the full Phase F audit.
+
+## Hard rules (inviolable)
+
+1. **Never skip the user checkpoints** (Checkpoint 0, 2, 3 below). Gate on each.
+2. **Never commit or push without explicit "yes push it"** at the closing checkpoint.
+3. **Never silently rewrite voice.** Every tone-altering change is a decision the user confirms. Prose restructuring surfaces as a diff, not a fait accompli.
+4. **Never implement a DESIGN.md-banned pattern** even if a review skill suggests it. Reject with the ban cited.
+5. **Work on a new branch** `posts/<slug>-polish` off `main`. Never modify a shipped post on `main` directly.
+6. **Never touch other posts' code** unless fixing a shared primitive (`components/viz/*`, `components/fancy/*`, `lib/*`). If a shared-primitive change is needed, surface it and require explicit approval.
+
+## Bail-out rules
+
+- If the post is in a branch that isn't merged to `main`, stop and check with the user — they may have in-flight edits.
+- If the audit's combined P0s would require rewriting > 30% of the prose, stop at Checkpoint 2 and propose a narrower scope (or recommend `/new-post` for a full rewrite).
+- If validation fails after iteration, do not advance to the closing checkpoint. Report back with specifics.
+
+---
+
+## Phase 0 — Load context
+
+Before any audit, load:
+
+1. [`docs/voice-profile.md`](../../docs/voice-profile.md)
+2. [`docs/interactive-components.md`](../../docs/interactive-components.md)
+3. [`docs/pipeline-playbook.md`](../../docs/pipeline-playbook.md)
+4. [`DESIGN.md`](../../DESIGN.md)
+5. The target post directory (`page.tsx`, `metadata.ts`, `widgets/*`, `widgets/index.ts`).
+6. The post's manifest entry in [`content/posts-manifest.ts`](../../content/posts-manifest.ts).
+7. Optional user brief from command args.
+
+Write `research/<slug>-polish/context.md` with:
+- Post slug, current reading-minutes, shipped date, current widget inventory.
+- User-supplied brief (if any).
+- First-pass skim findings: things the playbook now forbids that appear in the post. (Not a full review — just the obvious.)
+
+## Phase 1 — Scope proposal (Checkpoint 1)
+
+Given context, propose a scope:
+
+- **Minor polish** — tighten microcopy, fix any DESIGN.md violations, update 1–2 widgets. ~2h.
+- **Medium revision** — also restructure the lede/closer, trim citations, adopt argument-claim H2s if appropriate. ~4h.
+- **Major revision** — above + replace or add widgets, rework structural spine. ~8h. May warrant `/new-post` instead.
+
+Surface at **Checkpoint 1**: scope choice + named changes. Wait for user. If scope > "minor" and the user's brief implies "minor," clarify before proceeding.
+
+## Phase 2 — Design review via skill orchestration
+
+Same six parallel agents as `/new-post` Phase F, but briefs now reference the playbook directly. Each agent reads `docs/voice-profile.md`, `docs/interactive-components.md`, `DESIGN.md`, and the post. Each writes `research/<slug>-polish/review-<skill>.md`.
+
+Agent briefs are canonical templates — adjust the "what to review" list if the user brief narrows scope.
+
+1. **clarify** — microcopy, labels, aria, button text. P0/P1/P2 with `file:line` and proposed text.
+2. **layout** — spacing rhythm, widget-prose ratio, mobile-first fidelity, DESIGN.md §2/§7/§12 compliance.
+3. **critique** — pedagogy, IA, cognitive load, citation density, widget-weight vs evidentiary-weight balance. X/10 score.
+4. **animate** — DESIGN.md §9 compliance. Motion inventory with spring choice + reduced-motion pass per widget.
+5. **delight** — ≤ 12 proposals; every proposal cites a DESIGN.md rule; every rejection cites a specific ban.
+6. **bolder** — amplifications without ban violations. Section titles, ledes, closers, buried highlights.
+
+Budget per agent: ≤ 20 WebFetches, ≤ 15 min, ≤ 400-word summary.
+
+## Phase 3 — Aggregation + user approval (Checkpoint 2)
+
+Aggregate into `research/<slug>-polish/action-items.md` with:
+- Deduplicated P0/P1/P2 items, source-attributed (`[c]`/`[l]`/`[t]`/`[a]`/`[d]`/`[b]`).
+- Convergent findings (≥ 2 reviewers flagging the same issue) promoted to P0.
+- Rejected-with-ban-cited section for any DESIGN.md violation.
+- Plan of attack: mechanical (motion/a11y/microcopy) → prose restructure → citation trim → delight polish.
+
+Surface at **Checkpoint 2**: user reviews `action-items.md` and confirms priorities. They may strike items, add their own, or flip P1→P0.
+
+## Phase 4 — Iteration
+
+Work the approved list in priority order:
+
+1. **Mechanical fixes** — motion compliance, microcopy parity, aria-labels, missing `<Dots />`. Do these in a single batch, re-run `pnpm exec tsc --noEmit` + `pnpm build`.
+2. **Prose restructure** — lede, closer, section titles, class expansions, paragraph promotions. Before any large prose change, diff the old vs new paragraph-by-paragraph in the chat for user eyes.
+3. **Citation + density trim** — only after the structural moves settle.
+4. **Delight polish** — the small moments. Skip if time-constrained.
+
+After each batch: `pnpm exec tsc --noEmit`, `pnpm build`, `node scripts/audit-prose.mjs`. Tick items in `action-items.md`.
+
+## Phase 5 — Validation
+
+Write `research/<slug>-polish/validation.md`:
+
+1. Technical correctness — every numeric claim traces to a citation.
+2. Code correctness — tsc + build pass.
+3. A11y — keyboard, focus, reduced-motion, colour-only-info.
+4. Build + Lighthouse (if preview available) ≥ 95.
+5. Reading-sanity — end-to-end read for voice drift.
+
+Also update `docs/` if anything new was learned (new anti-pattern, new widget shape, new voice rule).
+
+## Phase 6 — PR + preview (Checkpoint 3)
+
+1. Stage only post-scoped + shared-primitive files. Never `git add -A`.
+2. Commit on branch `posts/<slug>-polish` with a descriptive message:
+   - What changed structurally.
+   - Which P0s resolved.
+   - Any new DESIGN.md-ban-enforcement actions.
+3. Push the branch. `gh pr create` with title `polish: <original post title> — <one-line summary>` and body covering: summary, resolved-item table, new playbook learnings, test plan.
+4. Wait for Vercel preview URL. Surface to user with test cues per widget.
+5. **Checkpoint 3**: user reviews preview. On explicit "yes push it": `gh pr merge --squash`. Otherwise iterate per their feedback.
+6. After merge: archive `research/<slug>-polish/` → `research/archive/<slug>-polish/`. Delete the local branch. Update `docs/` with any new learnings.
+
+---
+
+## Time budget (for user expectations)
+
+| Phase | Time |
+|---|---|
+| 0. Load context | 5 min |
+| 1. Scope proposal | 5 min active |
+| 2. Design review | 15 min (parallel) |
+| 3. Aggregation | 10 min active |
+| 4. Iteration | 30 min – 2h depending on scope |
+| 5. Validation | 15 min |
+| 6. PR + preview | 5 min active |
+| **Total** | **~1–3 hours**, most of it in Phase 4 |
+
+## Parallel runs
+
+Two `/improve-an-article` invocations with different slugs are supported — each has its own `research/<slug>-polish/` dir and its own `posts/<slug>-polish` branch. Switch branches carefully between sessions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,21 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+<!-- BEGIN:playbook-pointer -->
+# Before touching articles
+
+Every Claude session that touches a post, widget, or design primitive must load the playbook first:
+
+- **[`docs/README.md`](./docs/README.md)** — the index. Points at everything else.
+- **[`docs/voice-profile.md`](./docs/voice-profile.md)** — the taste file. Tone, framing, prose rules, widget rules, calibration examples.
+- **[`docs/interactive-components.md`](./docs/interactive-components.md)** — widget-shape taxonomy, external primitives catalogue, DESIGN.md compliance invariants, per-widget lessons.
+- **[`docs/pipeline-playbook.md`](./docs/pipeline-playbook.md)** — the nine-phase authoring pipeline, per-phase lessons, per-skill lessons from Phase F design reviews.
+- **[`DESIGN.md`](./DESIGN.md)** — the design-system spec (tokens, motion, type, absolute bans).
+
+Commands for the two authoring workflows:
+- `/new-post` — full nine-phase pipeline for a brand-new article. Definition: [`.claude/commands/new-post.md`](./.claude/commands/new-post.md).
+- `/improve-an-article` — iterate an existing post with the full playbook. Definition: [`.claude/commands/improve-an-article.md`](./.claude/commands/improve-an-article.md).
+
+After a post ships, update the playbook with any new lesson learned — see `docs/README.md` §"Keeping these docs honest" for the update protocol.
+<!-- END:playbook-pointer -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# bytesize — documentation index
+
+The canonical reference set for authoring, reviewing, and shipping bytesize posts. Load these before writing or revising any article.
+
+## Start here
+
+1. **[`voice-profile.md`](./voice-profile.md)** — how posts should *sound* and *feel*. Tone, framing, prose rules, widget rules, tone-calibration examples. The taste file.
+2. **[`interactive-components.md`](./interactive-components.md)** — widget-shape taxonomy, external primitives we've integrated (`TextHighlighter`, `DragElements`, `MediaBetweenText`), DESIGN.md compliance invariants, anti-patterns from actual review feedback, widget catalogue with per-widget lessons.
+3. **[`pipeline-playbook.md`](./pipeline-playbook.md)** — the nine-phase authoring pipeline, per-phase lessons, session-resumption rules, checkpoint crib sheet, and per-skill lessons from Phase F design-review orchestration.
+
+## Secondary references
+
+- **[`mobile-first-verification.md`](./mobile-first-verification.md)** — the mobile-first migration trace. Useful for container-query rules.
+- **[`../DESIGN.md`](../DESIGN.md)** — the design-system spec. Tokens, motion, type, absolute bans.
+- **[`../AGENTS.md`](../AGENTS.md)** — Next.js 16 breaking-changes notice.
+
+## Commands
+
+- **[`../.claude/commands/new-post.md`](../.claude/commands/new-post.md)** — `/new-post`: the full nine-phase authoring pipeline for a fresh article.
+- **[`../.claude/commands/improve-an-article.md`](../.claude/commands/improve-an-article.md)** — `/improve-an-article`: iterate on an existing post using the accumulated playbook and Phase F/G discipline.
+
+## When to reach for which doc
+
+| You are about to… | Load |
+|---|---|
+| Start a new article | `voice-profile.md` → `pipeline-playbook.md` → run `/new-post` |
+| Improve an existing article | `voice-profile.md` → `interactive-components.md` → `pipeline-playbook.md §5` → run `/improve-an-article <slug>` |
+| Design a new widget | `interactive-components.md §1` (shapes) → `../DESIGN.md §7` → `§6` (catalogue lessons) |
+| Run a single design-review skill | `pipeline-playbook.md §5` for the brief template |
+| Write a callout, aside, or microcopy | `voice-profile.md §3` |
+| Audit code for DESIGN.md compliance | `interactive-components.md §3` (the invariants checklist) |
+
+## Keeping these docs honest
+
+After a post ships, update the playbook:
+
+1. **Any new widget shape** → add to `interactive-components.md §1` with a canonical example.
+2. **Any new external primitive** → add to `interactive-components.md §2` with use-cases and anti-use-cases.
+3. **Any new anti-pattern discovered during review** → add to `interactive-components.md §5`.
+4. **Any voice-drift the user corrected** → add to `voice-profile.md §9` (or the appropriate earlier section).
+5. **Any pipeline lesson learned** → add to `pipeline-playbook.md §2` for the phase or `§6` for common pitfalls.
+6. **Any new skill-review insight** → add to `pipeline-playbook.md §5`.
+
+The playbook is the shipping version of what we learned. Memories are the raw capture; these docs are the refined rules. If they go out of sync, the docs win.

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -1,0 +1,258 @@
+# bytesize — interactive components playbook
+
+The reference catalogue of every widget shape we've shipped, every external primitive integrated, and every DESIGN.md-compliance lesson learned the hard way. Load this before designing or building a new widget.
+
+Cross-reference: [`DESIGN.md`](../DESIGN.md), [`voice-profile.md`](./voice-profile.md).
+
+---
+
+## 1. The widget-shape taxonomy
+
+Every widget we've shipped collapses to one of seven shapes. Pick the shape that matches the teaching claim before picking the widget's visual design.
+
+| Shape | Teaches | Example | Core primitive |
+|---|---|---|---|
+| **Scripted stepper** | An ordered aha — A happens, then B, then C | `HashLane`, `BloomProbe`, `MemoryPoisonTimeline` | `<Stepper>` + SVG/HTML scenes |
+| **Scrubber parameter space** | The shape of a tradeoff — "as X grows, Y does Z" | `FalsePositiveLab`, `FilterCompare` | `<Scrubber>` + live measurement bar |
+| **Scenario branch** | "What happens on path X vs path Y" | `FlowDemo` | segmented control + divergent canvases |
+| **Time-axis race** | Interleaving / concurrency insight | `SignupRace` | dual-lane timeline + tick controls |
+| **Collapse diagram** | Many-to-one normalisation | `NormalisationMap` | SVG with layered arrows |
+| **Scan / reveal** | "What the human saw vs what the agent saw" (unmask) | `HostilePageScan`, `ParseVsRender` | transform-based sweep OR segmented toggle |
+| **Propagation network** | "One signal becomes many" / contagion | `InfectiousJailbreak` | SVG graph + tick-based state spread |
+| **Coverage matrix** | "This defence reaches these stages, not those" | `DefenceCoverage` | CSS grid with intensity-coded cells |
+
+**Rule**: if a proposed widget doesn't fit one of these, ask whether the teaching claim is actually one claim. Most "doesn't fit" widgets are two claims in a trench coat.
+
+## 2. External primitives we've integrated
+
+All three live under [`components/fancy/`](../components/fancy/) and were added in the AI-agent-traps post. Keep this folder small and deliberate — every new primitive is overhead.
+
+### `TextHighlighter` (✅ ubiquitous)
+
+Animated text-background swipe on in-view / hover / auto / ref.
+
+- **Use case**: pacing device inside prose (every load-bearing sentence), and inside widget captions (on verb cues: "Press scan", "Switch sides").
+- **Colour binding** (mandatory): `var(--color-accent)` at ~28% via `color-mix(in oklab, var(--color-accent) 28%, transparent)`. Never a competing colour.
+- **Trigger picking**:
+  - `inView` (with `once: true`, `amount: 0.55`) for prose
+  - `auto` for widget-caption imperatives where the caption is already visible on mount
+  - `hover` only for term-definitions in prose; never decorative
+  - `ref` for controlled replays (rare)
+- **Direction**: default `ltr`; never mix multiple directions in one post — that becomes decoration.
+- **Density**: ≤ 2 per section. Target 10–17 per article. Beyond ~20 the signal decays; critique skill will flag.
+- **Do not** use on pure decorative words. Only on thesis phrases, numbers, or action cues.
+- **Alias pattern** (see article `page.tsx`): define a local `HL` helper that injects the standard transition/options so prose stays readable:
+  ```tsx
+  function HL({ children }: { children: React.ReactNode }) {
+    return (
+      <TextHighlighter transition={HL_TX} highlightColor={HL_COLOR}
+        useInViewOptions={HL_OPTS} className="rounded-[0.2em] px-[1px]">
+        {children}
+      </TextHighlighter>
+    );
+  }
+  ```
+
+### `DragElements` (⚠️ niche)
+
+Free-drag layout for multiple children, with optional momentum and `initialPositions` per child.
+
+- **Use case**: rare. Consider before using: does editorial-calm register want dragging? Usually no.
+- **What we learned**: the article-tarp post first used `<TrapDeck>` as a 6-card drag hero. Reader feedback: *"chaotic"*. Replaced with the `HostilePageScan` scanner-reveal. Lesson: **drag as a primary hero interaction doesn't fit the editorial-calm register**. Keep the primitive for future experiments but don't reach for it first.
+- **If you use it**: set `dragMomentum={false}` (no physics in editorial-calm), strip any `shadow-2xl` from the card demos (§12 ban), axis-align (no random tilt), and pass `initialPositions` to distribute children — the default stacks everything at (0,0).
+
+### `MediaBetweenText` (✅ surgical)
+
+Inline text reveal: `<firstText> [media that expands on trigger] <secondText>`.
+
+- **Use case**: one per article max. Inline micro-reveal that teases a widget's claim in prose.
+- **Trigger**: `inView` with `once: true, amount: 0.6`. Never `hover` in prose — touch users miss it.
+- **Media payload**: a small terracotta chip (not a photo) keeps it editorial. See `DomReveal.tsx`.
+- **RSC caveat**: `renderMedia` is a function prop — not serialisable across the RSC boundary. If your page.tsx is RSC (no `"use client"`), wrap the `MediaBetweenText` usage in its own `"use client"` component and import it into the page. We do this with `DomReveal.tsx` exactly because `page.tsx` is RSC.
+
+## 3. Design-system invariants — the non-negotiables
+
+Every widget must clear every bullet. Reviewer's first pass checks these mechanically.
+
+### Motion (DESIGN.md §9)
+
+- [ ] Animate **only `transform` + `opacity`**. Never `top`, `height`, `width`, `margin`, `padding`. Use `translateY`/`translateX`/`scaleY`/`scaleX`.
+- [ ] Springs over tweens: `SPRING.snappy` for taps/toggles, `SPRING.smooth` for reveals, `SPRING.gentle` for ambient, `SPRING.dramatic` for hero moments.
+- [ ] **Never** `ease-in-out`, `linear`, `bounce`, `elastic` for UI motion.
+- [ ] Every widget with timed sequences: gate durations via `useReducedMotion()` so the sequence collapses to instant under reduced motion. `motion.*` will auto-collapse transforms via the project-level `MotionConfig reducedMotion="user"`, but **animation scheduling you control** (e.g. `setTimeout`, `setInterval`) must also respect it.
+- [ ] Stagger siblings at 60 ms. Not 100, not 120.
+
+### Decoration bans (DESIGN.md §12)
+
+- [ ] No decorative `box-shadow`. Shadows only for elevation (and even then, subtle `0 1px 2px color-mix(…)`).
+- [ ] No `border-left > 1px` as a coloured accent stripe (#1 AI-slop tell).
+- [ ] No gradient text.
+- [ ] No glassmorphism.
+- [ ] No centred-everything layouts.
+- [ ] No sparkline decoration.
+- [ ] No rounded-rectangle-with-shadow buttons.
+
+### One-accent rule (DESIGN.md §3 + §10)
+
+- [ ] Terracotta (`var(--color-accent)`) is the **only** colour with semantic load. If a widget introduces a second colour (even a "friendly" blue), strip it.
+- [ ] State-set = terracotta. Active interactive = terracotta. Focus ring = 2px terracotta.
+- [ ] Carve-out: code-block chrome dots (`--code-dot-red/-yellow/-green`) and transient press-pulses. Nothing else.
+
+### Accessibility (DESIGN.md §11)
+
+- [ ] Every interactive element ≥ 44 × 44 CSS px. Expand with transparent padding + negative margin where the visible glyph is smaller.
+- [ ] Real `<button>` / `<input type="range">`. Never `<div onClick>`.
+- [ ] Focus ring visible — never `outline: none` without a replacement.
+- [ ] Information conveyed by colour must also be conveyed by shape/position/label.
+- [ ] State-dependent `aria-label`s: if the widget has state 0 and state N, the label should describe the *current* state, not a future outcome.
+
+### State-0 on arrival (earned the hard way)
+
+- [ ] On mount, widgets must sit at state 0 and **wait for user interaction**. Never auto-play a teaching animation before the reader has agency.
+- [ ] Captions in state 0 explicitly tell the reader what interaction to perform ("Press scan", "Tap a row", "Step through"). Highlight that verb with `TextHighlighter triggerType="auto"`.
+- [ ] Reset returns to state 0, not a "nearly-done" intermediate.
+
+## 4. `WidgetShell` conventions
+
+Every widget wraps in `<WidgetShell>`. Consistent header/canvas/controls/caption grammar across the whole site.
+
+```tsx
+<WidgetShell
+  title="hostile page · scan"                 // Plex Sans muted
+  measurements="3 injections · hidden"        // Plex Mono tabular-nums, right
+  captionTone="prominent"                     // "muted" (default) or "prominent"
+  caption={<>teacher-voice explanation with <HL>highlighted verb cue</HL>.</>}
+  controls={<button>▸ scan</button>}
+>
+  <svg viewBox="0 0 360 360">…</svg>          {/* canvas */}
+</WidgetShell>
+```
+
+- **Title** — the widget's name. Keep to 1–4 words. Avoid jargon not introduced in prose.
+- **Measurements** — always Plex Mono tabular-nums. Digits not word-numbers (`3 layers · 6 stages`, not `three layers · six stages`).
+- **Caption tone**:
+  - `muted` (default, pre-existing posts) — Plex Sans small, muted colour. Sidenote voice.
+  - `prominent` (introduced in the agent-traps post) — Plex Serif body, full contrast, leading terracotta diamond marker. Teacher voice. Use this when the caption carries the teaching moment. Also embed a `TextHighlighter` on the key phrase for visual pull.
+- **Controls** — below the canvas, left-aligned. Minimum 44×44 tap targets. Button glyphs (`▸` play, `↻` reset, `❚❚` pause) are a tactile shorthand, not decoration — use them consistently across widgets.
+
+## 5. Anti-patterns (from actual review feedback)
+
+### Auto-playing on mount
+**What happened**: `HostilePageScan` and `InfectiousJailbreak` initially looped their teaching animation on mount. User: *"executed before the user interacts with them."*
+**Fix**: state 0, explicit trigger, caption tells the reader what to press.
+
+### Caption muted when teaching
+**What happened**: captions used Plex Sans `--text-small` + `--color-text-muted` — readers skimmed past them.
+**Fix**: `captionTone="prominent"` prop added to WidgetShell. Body size, full contrast, terracotta marker.
+
+### SVG with decorative `box-shadow` glow
+**What happened**: scanline had a 14 px terracotta glow. Looked atmospheric but violated DESIGN §12.
+**Fix**: removed the shadow. The 2 px accent bar alone carries the affordance; the progressive gradient wash underneath does the rest.
+
+### Animating `top` or `height`
+**What happened**: scanline animated `top: 0 → 100%`, gradient wash animated `height: 0 → 100%`. Both DESIGN §9 bans.
+**Fix**: `useLayoutEffect` to measure the parent canvas height into state, then animate `transform: y` (px). For the wash, `scaleY(0 → 1)` with `transformOrigin: "top"`.
+
+### `ease-in-out` on an infinite pulse
+**What happened**: `InfectiousJailbreak` seed node used `ease: "easeInOut"` on an infinite scale repeat.
+**Fix**: dropped the infinite pulse entirely. The seed-node's terracotta fill + halo already reads as "patient zero"; the pulse was decorative.
+
+### Label/verb mismatch across widget + caption
+**What happened**: tab said `agent`, caption cue said "Tap **agent view**". Reader eye has to reconcile.
+**Fix**: either rename the tab to match, or (better) rewrite the cue to an intent word — *"Switch sides"* instead of literal "Tap agent view".
+
+### Duration-based tweens where springs belong
+**What happened**: Three `duration: 0.2` tween crossfades on caption/centre-text transitions.
+**Fix**: `SPRING.snappy` for interactive responses, `SPRING.smooth` for reveals. Tweens read as "not quite right" against the rest of the motion vocabulary.
+
+### The drop-shadow decorative glow trap
+**What happened**: whenever a widget wants to signal "something important is happening here", the first instinct is a coloured glow. Banned.
+**Fix**: use typography, position, size, or a single transient press-pulse on commit (the §9 carve-out).
+
+## 6. Widget catalogue — lessons from each
+
+Direct links to the widgets we've shipped and what each taught us.
+
+### `HostilePageScan.tsx` ([hero, agent-traps post](../app/posts/the-webpage-that-reads-the-agent/widgets/HostilePageScan.tsx))
+
+- **Shape**: scan/reveal.
+- **Teaches**: the parse-vs-render gap that Content Injection exploits. *Before* any prose.
+- **Lessons**:
+  - Hero widgets must start at state 0 with an affordance.
+  - Measure the canvas with `useLayoutEffect` + `ResizeObserver` to animate `transform: y` (px) instead of CSS `top`.
+  - `scaleY` from 0 → 1 with `transform-origin: top` replaces `height: 0 → 100%` perfectly.
+  - Chip-track layout: CSS grid flips from 1-column to 2-column at `@container widget (min-width: 640px)`. Mobile-first.
+
+### `AgentLoopMap.tsx`
+
+- **Shape**: coverage/taxonomy map (ring).
+- **Teaches**: the six-class taxonomy keyed to stages.
+- **Lessons**:
+  - SVG `viewBox` authored to 360×360 units — scales fluidly with parent.
+  - Label anchor (`start`/`middle`/`end`) computed from the angle so labels don't overrun on 360 px phones.
+  - Active stage: node radius + fill transition via `SPRING.snappy`. Next-stage edge highlighted via `SPRING.smooth`. Centre caption morphs via `AnimatePresence`.
+
+### `ParseVsRender.tsx`
+
+- **Shape**: scenario branch (human/agent toggle).
+- **Teaches**: the same page rendered two ways.
+- **Lessons**:
+  - Tab labels must match the caption's verb cue verbatim (e.g., cue says "Switch sides" → tabs are `human view`/`agent view`).
+  - Row-by-row stagger (60 ms) on the agent view creates legible reveal without feeling decorative.
+  - A real HTML comment embedded in the JSX is a straight-faced craft moment — the page is literally doing what the widget teaches. Don't call attention to it; let careful readers discover it.
+
+### `MemoryPoisonTimeline.tsx`
+
+- **Shape**: scripted stepper (3 steps).
+- **Teaches**: delayed-tool attack via memory poisoning.
+- **Lessons**:
+  - Two panels (context + memory) framed with consistent header/separator grammar. Stacked on mobile.
+  - Memory state has three phases (empty / waiting / poisoned) animated via springs on chip arrival.
+  - Captions embed `TextHighlighter auto` on the commit sentence so the punchline is unmissable.
+
+### `InfectiousJailbreak.tsx`
+
+- **Shape**: propagation network.
+- **Teaches**: one-to-many jailbreak spread.
+- **Lessons**:
+  - 14 nodes, ring + 5 chord edges = readable small-world graph without crowding.
+  - Deterministic positions + seeded jitter (via `(i * 13) % 7`) — no random-per-render.
+  - Propagation tick is user-triggered. Each tick picks one uninfected neighbour of any infected node. The done-state is reached organically.
+  - **State 0 matters** here: on mount, only the seed is infected, paused. Button flips to "reset" once done.
+
+### `DefenceCoverage.tsx`
+
+- **Shape**: coverage matrix.
+- **Teaches**: where three defence layers reach on the agent's six stages.
+- **Lessons**:
+  - The previous SVG-arcs version (`DefenceSurface.tsx`, now deleted) was fragile at mobile widths. A CSS-grid matrix is inherently responsive.
+  - Tap-to-isolate instead of hover — works on touch.
+  - Tri-state cells (none / partial / strong) via three `color-mix` accent percentages. Shape stays the same.
+  - Stage-name column headers shrink on narrow containers via `@container widget (max-width: 560px)`.
+
+### `DomReveal.tsx` (wrapping `MediaBetweenText`)
+
+- **Shape**: inline text reveal.
+- **Teaches**: the "dom" glyph surfaces as the reader reads — a micro-echo of ParseVsRender.
+- **Lessons**:
+  - Must be `"use client"` because `MediaBetweenText` takes a `renderMedia` function prop; the parent page is RSC.
+  - Use once per article. Two uses become decoration.
+
+## 7. When to build a new widget
+
+Ship a bespoke widget when:
+- The teaching claim is sharp enough to fit one sentence.
+- None of the seven shapes in §1 already fits.
+- You expect the shape to be reused in a future post (lift to `components/viz/` at that point).
+
+Do NOT ship a widget when:
+- The claim can be taught in 2 paragraphs of prose with one code block and one `<HL>`.
+- You're building a "dashboard" (multiple measurements without a single teaching insight).
+- The widget's caption would be longer than the claim it teaches.
+
+## 8. Placement rules
+
+- **Post-local first**: `app/posts/<slug>/widgets/<Name>.tsx`. Every widget starts here.
+- **Lift to `components/viz/`** only when a second post wants the same widget. Confirm with the user before lifting.
+- **Shared primitives** (`Block`, `Arrow`, `Scrubber`, `Stepper`, `SvgDefs`, `WidgetShell`) are in `components/viz/`. Don't duplicate.
+- **Fancy primitives** (`TextHighlighter`, `DragElements`, `MediaBetweenText`) are in `components/fancy/`. Add new fancy primitives sparingly.

--- a/docs/pipeline-playbook.md
+++ b/docs/pipeline-playbook.md
@@ -1,0 +1,203 @@
+# bytesize — authoring pipeline playbook
+
+The pipeline for shipping a bytesize post, derived from the first four posts and hardened on the AI-agent-traps post. Load this before starting a new article or running `/new-post`. Skill-review lessons from Phase F live in §5.
+
+Cross-reference: [`voice-profile.md`](./voice-profile.md), [`interactive-components.md`](./interactive-components.md), [`.claude/commands/new-post.md`](../.claude/commands/new-post.md).
+
+---
+
+## 1. Pipeline overview — nine phases, four checkpoints
+
+```
+A  Intake                   → Checkpoint 1 (slug + title + pitch)
+B  Research                 → Checkpoint 2 (kernel + angle)
+C  Interactive design
+D  Pedagogy analysis        → Checkpoint 3 (outline)
+E  Draft
+F  Design review (skills)
+G  Iteration on action items
+H  Correctness validation
+I  PR + preview             → Checkpoint 4 (merge or revise)
+```
+
+Hard rules (never skip):
+- Gate the four checkpoints. Never proceed without explicit user approval.
+- Never commit or push without explicit "yes push it" at Checkpoint 4.
+- Research, design, and validation artefacts live in `research/<slug>/` (gitignored). The run is resumable across sessions because every decision is on disk.
+- Never implement a DESIGN.md-banned pattern even if a design skill suggests it — reject with the ban cited in the review file.
+
+## 2. Phase-by-phase lessons
+
+### Phase A — Intake
+- Pattern that works: slug matches existing post-title grammar (*"The X that Y"*, *"How X does Y"*). Lyrical observations beat literal labels.
+- Propose 3 slugs, a working title, a one-line pitch. Let the user pick.
+- Record in `research/<slug>/intake.md` including a stated goal (*"teach X to a confident Y in Z minutes"*) and author notes. The goal makes Phase C choices easier.
+
+### Phase B — Research
+- Launch 2–3 parallel agents with scoped briefs (primary sources / teaching explainers / misconceptions & incidents).
+- **Verify `WebFetch` permission before launching**. If denied, agents fail fast and waste time. Suggest `/permissions` or `update-config` skill early.
+- When a source document is in hand (e.g. a PDF), extract it yourself; don't ask a sub-agent to re-derive material you already have.
+- The kernel file (`kernel.md`) distils: the one-sentence "aha", the 3–5 supporting facts, and what to leave out.
+- Seek **differentiation** — don't re-write Simon Willison's essay. Ask what angle, framing, or interactive nobody else has used.
+
+### Phase C — Interactive design
+- Enumerate 4–6 candidate widgets against the seven widget shapes in [`interactive-components.md §1`](./interactive-components.md).
+- Rank on impact × cost; pick 2–3 to build.
+- Write `widgets.md` with prop sketches and the single teaching claim each serves.
+- **Lesson from the agent-traps post**: don't over-commit before the user has seen the outline. Widgets can be reshuffled in Phase D.
+
+### Phase D — Pedagogy analysis
+- Read one reference post from each inspiration site (nan.fyi, ivov.dev/notes, blog.maximeheckel.com) to calibrate pacing.
+- Write `outline.md` — numbered sections with widget placement, word count estimate, and pedagogy reference per section.
+- This is the last cheap edit point before code. User gets Checkpoint 3 here.
+
+### Phase E — Draft
+- Order: scaffold `metadata.ts` + post entry first, then widgets, then narrative TSX.
+- **Build widgets in isolation**: create a dev-only scratch page at `app/_scratch/<slug>/<Name>/page.tsx` for each, remove before Checkpoint 4.
+- RSC caveat: `page.tsx` is server-rendered. Any client-only interaction (drag, refs, function props) must live in a `"use client"` wrapper. We discovered this at build time when `MediaBetweenText`'s `renderMedia` function couldn't cross the RSC boundary — fixed by introducing `DomReveal.tsx` as a `"use client"` component.
+- Shiki language grammar: verify `lib/shiki.ts` has the language you want to `<CodeBlock>` with. Adding `html` to the grammar list cost us one build.
+- `cn` utility: the fancy primitives imported from `@/lib/utils/cn`. That file didn't exist in the project — add a 3-line helper if missing before importing components that depend on it.
+- Run `pnpm exec tsc --noEmit` + `pnpm build` before Phase F. Every non-trivial issue surfaces at build time.
+- Audit prose: `node scripts/audit-prose.mjs`. Fix `em-abuse` errors. Bulk-fix fragile-space-after-italic with the one-liner:
+  ```python
+  # apply to any .tsx with Em/Term tags
+  re.sub(r'</(Em|Term)>(\s+)([^\s<{])', lambda m: f'</{m.group(1)}>{{" "}}{m.group(3)}', src)
+  ```
+
+### Phase F — Design review via skill orchestration
+- Launch six sub-agents in parallel. Each reads the post + DESIGN.md through its lens and writes a review file. See §5 for per-skill briefs.
+- Sub-agents are better than direct Skill-tool invocation because: (a) agents stay bounded to a tight brief and don't bloat main context, (b) agent output is a review file we control, (c) parallel execution finishes in ~10 min vs sequential in ~45.
+- Budget each agent to ≤ 20 WebFetches, ≤ 15 minutes, and ≤ 400 words of summary back to main context.
+
+### Phase G — Iteration
+- Aggregate reviews into `action-items.md` with P0/P1/P2 priority, deduplicated, with source attribution per item.
+- Work P0 → P1 → P2 in that order. Skip P2 if time is scarce.
+- Mechanical fixes first (motion compliance, microcopy, a11y). They unblock the review pass and clear the ground for prose work.
+- Prose restructuring second (lede, closer, section titles, class expansions).
+- Citation trim last — it's hard to know what's load-bearing until the rest has settled.
+- Re-run `pnpm build` + audit after each batch.
+
+### Phase H — Validation
+- Write `validation.md` with five checks:
+  1. Technical correctness — every numeric claim traces to `facts-primary.md` / `facts-incidents.md`
+  2. Code correctness — every runnable snippet typechecks and runs
+  3. A11y — keyboard nav, reduced-motion, focus visibility, colour-only-info
+  4. Build + Lighthouse targets ≥ 95
+  5. Reading-sanity — end-to-end read for voice drift, undefined terms, flow breaks
+- Any failing check blocks Checkpoint 4 until resolved.
+
+### Phase I — PR + preview
+- Stage only post-scoped files. **Never `git add -A`** — other in-progress work on the branch may not be yours.
+- Research dir stays gitignored. Confirm with `git status` before committing.
+- Remove `app/_scratch/<slug>/` if present.
+- Commit on the feature branch. Push with `-u`. `gh pr create` with a full body: summary, widgets shipped, P0 action resolution table, test plan, cliffhanger.
+- Wait for the Vercel preview URL. Surface to user with test cues. Only merge on explicit "yes push it" / approval.
+- After merge: archive `research/<slug>/` → `research/archive/<slug>/`. Delete the local branch. Distill user edits into `voice-profile.md` if substantial.
+
+## 3. Session-resumption rules
+
+Every run is resumable because everything important lives in `research/<slug>/`:
+
+```
+research/<slug>/
+  intake.md          # Phase A
+  source-pdf.txt     # primary source extract
+  sources-*.md       # tiered URL lists from research agents
+  facts-*.md         # extracted claims with citations
+  kernel.md          # the aha + load-bearing facts
+  questions.md       # unresolved items for checkpoints
+  widgets.md         # Phase C output
+  outline.md         # Phase D output
+  review-clarify.md  # Phase F outputs (×6)
+  review-layout.md
+  review-critique.md
+  review-animate.md
+  review-delight.md
+  review-bolder.md
+  action-items.md    # Phase G aggregator
+  validation.md      # Phase H output
+```
+
+When a new Claude session picks up an in-flight article, it should read these in order and know exactly where we left off.
+
+## 4. Checkpoint crib sheet
+
+### Checkpoint 1 — Intake approval
+Surface: 3 slug options + working title + pitch + date + reading target. User picks one or edits.
+
+### Checkpoint 2 — Kernel + angle approval
+Surface: `kernel.md` (1 aha + 5 facts + differentiation notes) and `questions.md` (open items). User confirms the angle and answers blockers.
+
+### Checkpoint 3 — Outline approval
+Surface: `outline.md` — section-by-section, widget placement, word targets. Last cheap edit point.
+
+### Checkpoint 4 — PR approval
+Surface: `validation.md`, a preview URL, and explicit asks for widget/theme/kb testing. Block on explicit "yes push it" before merge.
+
+## 5. Skill-review lessons (Phase F)
+
+Each of the six design-review skills targets a specific quality axis. Run all six in parallel; aggregate into `action-items.md`. Every rejected suggestion must cite the specific DESIGN.md ban.
+
+### `/clarify` — microcopy, labels, aria, button text
+**Finds**: verb/label mismatches (tab says "agent", caption says "Tap agent view"); un-introduced jargon in titles; state-dependent aria-labels that describe the wrong state; tone drift (word-numbers vs digits).
+**Does not find**: anything outside microcopy scope. Keep its brief narrow.
+**Best items per article**: 10–15 specific (file:line + proposed fix).
+
+### `/layout` — spacing, rhythm, widget-prose ratio, DESIGN.md compliance
+**Finds**: missing `<Dots />` ornaments; prose-only sections between widget-heavy ones ("skim cliffs"); fixed pixel dimensions that break at 360 px; undersized labels; hover-only styling leaking onto touch.
+**Does not find**: pedagogical problems or prose quality.
+**Best items per article**: 15–20 total (3–5 P0).
+
+### `/critique` — pedagogy, UX, hierarchy, cognitive load
+**Finds**: citation parades; tell-don't-show; mismatched widget weight vs evidentiary weight; cognitive-load spikes; HL inflation; unmotivated jargon; unearned Terms.
+**Does not find**: motion / layout / microcopy details.
+**Scoring**: always asks for an X/10 verdict — useful for accountability.
+
+### `/animate` — motion purpose + DESIGN §9 compliance
+**Finds**: banned properties (`top`/`height`/`width`/`margin`); `ease-in-out` / `linear` on UI motion; tweens where springs belong; reduced-motion gaps; stagger inconsistencies.
+**Also audits**: `TextHighlighter` density and trigger-type correctness.
+**Pass rates**: expect a per-widget "pass / partial / fail" table.
+
+### `/delight` — understated joy within editorial-calm register
+**Finds**: small typographic flourishes, micro-interactions, completion beats.
+**Hard constraint**: every proposal must cite a DESIGN.md rule it respects. Every rejection must cite the specific ban.
+**Rejects**: confetti, emoji, brighter accents, drop-shadows, border-stripes, gradient text — always cited.
+**Best items**: 8–12 proposals, half rejected-by-design.
+
+### `/bolder` — amplify safe choices without violating bans
+**Finds**: hedged ledes, filing-cabinet section titles, buried highlights, trailing-off closers.
+**Key discipline**: boldness = fewer words, emptier space, one sentence landing alone. Not brighter, not louder.
+**Proposed patterns**:
+- Lede: lead with the thesis, not the backstory.
+- Section titles: argument-claims, not labels. Numerals as Plex Mono eyebrows.
+- Closers: cut the recap; end on the inversion.
+
+### Aggregation discipline
+- Deduplicate cross-agent overlaps (e.g. /layout and /animate both catching the scanline drop-shadow).
+- Promote convergent findings (two reviewers flagging the same issue) to P0 regardless of individual priority.
+- Reject-with-ban-cited for any DESIGN.md violation. Note in `action-items.md`.
+- Apply P0 → P1 in order. P2 usually deferred unless cheap.
+
+## 6. Common pitfalls (accumulated from shipped posts)
+
+- **Skipping `<Dots />`** between sections — breaks the rhythm DESIGN.md §2 specifies.
+- **Animating CSS properties** instead of transforms.
+- **Un-measured container for transform-based sweeps** — use `useLayoutEffect` + `ResizeObserver`.
+- **RSC boundary with function props** — wrap in a `"use client"` component.
+- **Missing languages in `lib/shiki.ts`** — add before using a new language in `<CodeBlock>`.
+- **`cn` utility not present** — add `lib/utils/cn.ts` with a 3-line helper.
+- **Fragile `</Em> word` spacing** — audit flags these; bulk-fix with the regex above.
+- **Citation parade** — ≥ 3 attributed studies in consecutive sentences; critique will flag.
+- **HL inflation** — > 2 per section dilutes the signal.
+- **Auto-playing widgets on mount** — always require user interaction.
+- **Muted captions when they're teaching** — use `captionTone="prominent"`.
+- **Under-represented persona hyperstition / speculative-class content** — treat it at the weight its weirdness deserves, not the weight its evidence does.
+
+## 7. Reference reading order for a new Claude session
+
+1. This file (`pipeline-playbook.md`) — the pipeline + lessons.
+2. [`voice-profile.md`](./voice-profile.md) — tone, prose rules, widget rules.
+3. [`interactive-components.md`](./interactive-components.md) — widget shapes and primitive catalogue.
+4. [`../DESIGN.md`](../DESIGN.md) — the design system (tokens, motion, bans).
+5. A recent shipped post (e.g. `app/posts/the-webpage-that-reads-the-agent/page.tsx`) — how it all composes.
+6. The `/new-post` command at `.claude/commands/new-post.md` — the canonical workflow definition.

--- a/docs/voice-profile.md
+++ b/docs/voice-profile.md
@@ -84,7 +84,56 @@ From the retired bloom-filters draft, all voice-drift:
 - ❌ *"For any m worth caring about is approximately e^(−kn/m)"* (paper voice)
 - ❌ *"The corrected formula was itself flawed, derives the correct exact formula using a balls-and-bins model, and provides a numerically stable way to compute it."* (derivation drift)
 
-## 9. Feedback memory cross-reference
+## 9. Post-style patterns (added after the agent-traps post)
+
+A post where the subject is an abstract framework (vs a concrete product moment) justifies some additional moves. These don't replace §§1–8; they extend them for framework-explaining posts.
+
+### Argument-claim H2s with a numeric eyebrow
+
+For taxonomy/framework posts with numbered classes, replace label-style H2s (*"1 · Content Injection — Perception"*) with argument-claim H2s preceded by a Plex Mono eyebrow carrying the numeric filing tag:
+
+```tsx
+<SectionH2 eyebrow="1 · Content Injection" id="content-injection">
+  The page the agent reads is not the page you see.
+</SectionH2>
+```
+
+The eyebrow does the encyclopedic work; the H2 carries the claim. Combined, they outperform a label by a wide margin — a scanner sees *"The page the agent reads is not the page you see."* and reads on; they see *"1 · Content Injection — Perception"* and skim past.
+
+### Lede pattern: inversion first, backstory as contrast
+
+For framework posts, open `§1` on the thesis itself, not on the history that led to it. The recap becomes a contrast clause in paragraph 2, not the opening move.
+
+```
+❌  For a decade, attacking a model meant …  [then arrives at the inversion in ¶2]
+✅  You don't break the model — you break the page it reads.  [¶1 opens here, already highlighted]
+    For a decade the fight was inside the network — gradients, adversarial pixels,
+    poisoned weights. That's not what's happening to AI agents on the web.  [¶2 contrast]
+```
+
+### Closer pattern: the inversion, alone
+
+Framework posts reward ending on the inversion stated plainly, often borrowing the paper's own closing line. The sibling post ends by correcting its own title in one italic sentence. The agent-traps post ends on *"what our most powerful tools will be made to believe."* followed by a single centred terracotta dot.
+
+Don't recap the sections. The dot-line ornament + the closing `<HL>` carry it.
+
+### `<TextHighlighter>` (HL) as a pacing device
+
+Used for the single load-bearing phrase of its paragraph — 1–2 per section, target ~10–17 across the post. Binds to `var(--color-accent)` at 28% via `color-mix`. Never a second colour, never a second direction. See [`interactive-components.md §2`](./interactive-components.md) for trigger discipline.
+
+### The "every defence is already bypassed" rhythm
+
+When demonstrating that the obvious defence has already failed, a three-item list with named CVEs / incidents hits harder than three chained sentences:
+
+```
+Every "obvious" defence a reader in 2023 might propose has been bypassed in a shipped POC:
+
+- **CSP** — bypassed, repeatedly. EchoLeak routed exfil through an open redirect on a Teams subdomain …
+- **User confirmation on tool calls** — bypassed (CVE-2025-53773). Copilot wrote …
+- **Command allowlists** — bypassed (CVE-2025-55284). Claude Code's allowlisted ping became …
+```
+
+## 10. Feedback memory cross-reference
 
 Four memories back this document. If any gets updated, this doc must update too.
 


### PR DESCRIPTION
## Summary

Capture voice, widget vocabulary, and authoring-pipeline lessons from the agent-traps article so every future session loads them before touching a post.

Every lesson in here was paid for in a review cycle during #23.

## What shipped

### `docs/`

- **`README.md`** — index that points at every playbook doc, with a "when to reach for which doc" table and an update protocol for keeping the playbook honest after each post.
- **`voice-profile.md`** — augmented with a new `§9` covering:
  - **Argument-claim H2s with Plex Mono numeric eyebrows** (*"The page the agent reads is not the page you see."* with a `1 · Content Injection` eyebrow) — the `bolder` review's biggest teaching win.
  - **Inversion-first lede** — open on the thesis, backstory becomes a contrast clause.
  - **Closer discipline** — end on the inversion alone; the title becomes the epitaph.
  - **The "every defence is bypassed" three-item-list** rhythm.
  - **`<TextHighlighter>` pacing** — 1–2 per section, ~10–17 per article, one direction, one colour.
- **`interactive-components.md`** — new.
  - **Seven canonical widget shapes**: scripted stepper, scrubber parameter space, scenario branch, time-axis race, collapse diagram, scan/reveal, propagation network, coverage matrix. Every bytesize widget collapses to one of these.
  - **Three external primitives catalogued**: `TextHighlighter` (✅ ubiquitous), `DragElements` (⚠️ niche, doesn't fit editorial-calm as a hero), `MediaBetweenText` (✅ surgical — one per article, wrap in a `"use client"` component for RSC pages).
  - **DESIGN.md invariants checklist**: motion (transform + opacity only, springs, no easeInOut), decoration bans (§12), one-accent rule, a11y (44×44 tap, state-dependent aria-labels, state-0-on-arrival).
  - **`WidgetShell` conventions** including the new `captionTone` prop.
  - **Anti-patterns from actual review feedback** — auto-playing widgets, muted teaching captions, decorative drop-shadows, animated `top`/`height`, `easeInOut` on infinite pulses, label/verb mismatches.
  - **Per-widget catalogue** with what each widget in the agent-traps post taught us.
- **`pipeline-playbook.md`** — new.
  - The nine-phase pipeline, each phase with hard-won lessons (verify `WebFetch` permission early; measure canvas with `useLayoutEffect` for transform-based sweeps; check `lib/shiki.ts` grammar list before using a new `<CodeBlock>` language; RSC boundary + function props needs a `"use client"` wrapper).
  - **Session-resumption rules** — the `research/<slug>/` file layout that lets any new Claude session pick up an in-flight article.
  - **Four-checkpoint crib sheet**.
  - **§5 — per-skill lessons from Phase F** — what `/clarify`, `/layout`, `/critique`, `/animate`, `/delight`, `/bolder` each catch, best item counts per article, aggregation discipline, DESIGN.md-ban rejection pattern.
  - **§6 common pitfalls** — skipping `<Dots />`, animating CSS properties, un-measured containers, RSC boundaries, fragile `</Em> word` spacing, citation parades, HL inflation, auto-playing widgets, muted teaching captions.

### `.claude/commands/`

- **`improve-an-article.md`** — new `/improve-an-article` slash command. Six-phase workflow with three user checkpoints: scope proposal → parallel design review → aggregation → iteration → validation → PR + preview. Works on a `posts/<slug>-polish` branch off `main`. Never commits without explicit approval. Never touches other posts' code.

### `AGENTS.md`

- New playbook-pointer block so every session that loads `AGENTS.md` gets routed to `docs/` before touching any post or widget.

### Session memory

- Also registered a `reference` memory at `~/.claude/projects/<project>/memory/playbook_reference.md` + `MEMORY.md` so auto-memory auto-loads the playbook pointer on every Claude session startup (not part of this PR — lives outside the repo).

## Update protocol

After any post ships, update the playbook. See `docs/README.md` §"Keeping these docs honest":

- New widget shape → `interactive-components.md §1`
- New external primitive → `interactive-components.md §2`
- New anti-pattern → `interactive-components.md §5`
- Voice drift the user corrected → `voice-profile.md`
- Pipeline lesson → `pipeline-playbook.md §2` or `§6`
- Skill-review insight → `pipeline-playbook.md §5`

## Test plan

- [ ] `docs/README.md` renders and links resolve
- [ ] `docs/voice-profile.md` — new §9 is coherent with §§1–8
- [ ] `docs/interactive-components.md` and `docs/pipeline-playbook.md` read cleanly end to end
- [ ] `AGENTS.md` playbook-pointer block renders
- [ ] `.claude/commands/improve-an-article.md` loads as a slash command (type `/improve-an-article` in a fresh session to verify discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)