### PR TITLE
feat: go anonymous — strip author links and subscribe CTA

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,7 +152,7 @@ Every custom widget follows this skeleton. This is what "uniform UI" means.
 - **Sliders**: native `<input type="range">` styled — thumb visual is 14 px terracotta square. **Hit target is 44 × 44 px** via transparent `padding` + `background-clip: content-box` on the thumb pseudo-element; the visible square stays 14 px while the draggable region grows to meet the WCAG 44-px minimum.
 - **Focus rings**: 2px solid `--color-accent`, 2px offset. Never removed.
 - **"State set" color**: always `--color-accent`. Readers learn `terracotta = the algorithm is doing something here.`
-- **Press identity**: every interactive surface gets `PRESS` feedback (`whileTap: { scale: 0.96 }` + `SPRING.snappy`). High-frequency controls (Stepper prev/next, subscribe CTA) add a `.bs-press` ring pulse ≤ 300 ms on commit. Consistent across buttons, toggles, links — so the site speaks one tactile language.
+- **Press identity**: every interactive surface gets `PRESS` feedback (`whileTap: { scale: 0.96 }` + `SPRING.snappy`). High-frequency controls (Stepper prev/next) add a `.bs-press` ring pulse ≤ 300 ms on commit. Consistent across buttons, toggles, links — so the site speaks one tactile language.
 - **Hydration canvas**: every widget SSR-renders a single 6 × 6 terracotta square centred in its canvas container; the real interactive surface fades in on hydrate with `SPRING.smooth`. No spinners, no skeleton shimmer — the dot is the loading state.
 - **Orientation flips**: widgets drive layout via `@container widget (…)` queries against `--flip-narrow` / `--flip-wide`, not global viewport breakpoints, so a widget embedded in a narrow column flips for its container rather than waiting for the viewport.
 
@@ -174,16 +174,14 @@ Home splits into two columns at ≥ 768px:
 │ │   per post. ten     ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌       │ │
 │ │   minutes of …      [ico]  (next post)                       │ │
 │ │                                                              │ │
-│ │  [subscribe]                                                 │ │
+│ │  Read by 12,483 readers   © 2026                             │ │
 │ │                                                              │ │
-│ │  ⌂ github     © 2026                                         │ │
-│ │                                                              │ │
-│ │ bytesize · built by An Anonymous Engineer </> subscribe (rss) │ │
+│ │ bytesize · built by An Anonymous Engineer </>                │ │
 │ └──────────────────────────────────────────────────────────────┘ │
 └ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ╲ ┘
 ```
 
-- **Left column** (`AboutColumn`, 320px fixed): big Plex Serif wordmark (clamp 3–4.5rem, 0.95 line-height, -0.03em tracking), about paragraph (Plex Serif body, muted, max 26ch), terracotta **subscribe** pill (`--color-accent` fill, `--color-bg` text, `--radius-md`), bottom-left meta row (GitHub icon + copyright in Plex Mono small). Sticky on md+.
+- **Left column** (`AboutColumn`, 320px fixed): big Plex Serif wordmark (clamp 3–4.5rem, 0.95 line-height, -0.03em tracking), about paragraph (Plex Serif body, muted, max 26ch), bottom-left meta row (reader count as a terracotta dot-matrix glyph + copyright, both in Plex Mono small). Sticky on md+.
 - **Right column** (`PostList`): year heading (small muted Plex Sans caps) + list of rows. Each row is a 4-column grid on md+ (`80px · 1.1fr · 1.2fr · 32px`): square cover tile · title + date stacked · hook description · arrow. On mobile it collapses to `64px · 1fr · 24px` with the hook stacking on a second row spanning all columns. Dashed top-border (`--color-rule`) separates rows; the first row has none.
 - Covers are auto-generated at `/cover/[slug]` via `@vercel/og`, per-slug hue-shifted within the terracotta family; optional `coverImage?: string` on `PostMeta` for hand-crafted overrides.
 - Row hover: subtle background tint (`color-mix(accent 4%, transparent)`), cover lifts `-2px`, title shifts to `--color-accent`, arrow translates 3px right. All on the same 200ms timing.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ See [`DESIGN.md`](./DESIGN.md) — the single source of truth for tokens, palett
 
 ## Author
 
-Built by [An Anonymous Engineer](https://github.com/iamartyaa).
+Built by An Anonymous Engineer.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,13 +7,7 @@ import { Footer } from "@/components/nav/Footer";
 import { CozyFrame } from "@/components/nav/CozyFrame";
 import { MotionConfigProvider } from "@/components/providers/motion-config";
 import { GoatCounter } from "@/components/analytics/GoatCounter";
-import {
-  SITE_AUTHOR,
-  SITE_AUTHOR_URL,
-  SITE_DESCRIPTION,
-  SITE_NAME,
-  SITE_URL,
-} from "@/lib/site";
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/site";
 
 // Path B-lite: pre-flight grep found no `font-bold` / fontWeight 700 usage
 // (600 is the heaviest actually rendered weight via `font-semibold`), so we
@@ -49,7 +43,6 @@ export const metadata: Metadata = {
     template: `%s · ${SITE_NAME}`,
   },
   description: SITE_DESCRIPTION,
-  authors: [{ name: SITE_AUTHOR, url: SITE_AUTHOR_URL }],
   openGraph: {
     title: SITE_NAME,
     description: SITE_DESCRIPTION,

--- a/components/nav/AboutColumn.tsx
+++ b/components/nav/AboutColumn.tsx
@@ -1,34 +1,25 @@
 "use client";
 
-import Link from "next/link";
 import { motion } from "motion/react";
-import { PRESS, SPRING } from "@/lib/motion";
+import { SPRING } from "@/lib/motion";
 import { useFirstVisit } from "@/lib/hooks/use-first-visit";
-import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { ReaderCount } from "@/components/nav/ReaderCount";
-import {
-  SITE_ABOUT,
-  SITE_AUTHOR_DISPLAY,
-  SITE_AUTHOR_URL,
-  SITE_NAME,
-} from "@/lib/site";
-
-const MotionLink = motion.create(Link);
+import { SITE_ABOUT, SITE_NAME } from "@/lib/site";
 
 const COPYRIGHT_START = 2026;
 const COPYRIGHT_NOW = new Date().getFullYear();
 
 /**
- * AboutColumn — the left pane of the home page. Big serif wordmark
- * carries the brand; the subscribe pill is the primary CTA; bottom row
- * holds the small meta (author/source links + copyright). Sticky on md+
- * so it stays visible while the post list scrolls.
+ * AboutColumn — the left pane of the home page. Big serif wordmark carries
+ * the brand; an about paragraph sets the tone; the bottom row holds the
+ * small meta (reader count + copyright). Sticky on md+ so it stays visible
+ * while the post list scrolls.
  *
  * Two entry choreographies keyed on session state:
  *   - First visit: wordmark settles with a transform-only scale+y (LCP-safe,
  *     no opacity animation on the biggest text), paragraph reveals via a
- *     left-to-right mask-position sweep, subscribe pill fades in last.
- *   - Return visit: a short 60 ms stagger across the four children.
+ *     left-to-right mask-position sweep, meta row fades in last.
+ *   - Return visit: a short stagger across the children.
  * Reduced-motion users collapse to the final state via MotionConfigProvider.
  */
 type AboutColumnProps = {
@@ -37,7 +28,6 @@ type AboutColumnProps = {
 
 export function AboutColumn({ readerCount }: AboutColumnProps) {
   const { ready, firstVisit } = useFirstVisit();
-  const subscribe = useTapPulse<HTMLAnchorElement>();
   const years =
     COPYRIGHT_NOW === COPYRIGHT_START
       ? `${COPYRIGHT_START}`
@@ -109,43 +99,7 @@ export function AboutColumn({ readerCount }: AboutColumnProps) {
         {SITE_ABOUT}
       </motion.p>
 
-      {/* Subscribe CTA — terracotta pill, primary action */}
-      <motion.div
-        className="mt-[var(--spacing-lg)]"
-        initial={false}
-        animate={variant}
-        variants={{
-          static: { opacity: 1, y: 0 },
-          hero: {
-            opacity: [0, 1],
-            y: [6, 0],
-            transition: { duration: 0.24, delay: 1.0, ease: [0.22, 1, 0.36, 1] },
-          },
-          return: {
-            opacity: [0, 1],
-            y: [4, 0],
-            transition: { ...SPRING.smooth, delay: 0.12 },
-          },
-        }}
-      >
-        <MotionLink
-          ref={subscribe.ref}
-          href="/rss.xml"
-          aria-label="Subscribe via RSS"
-          onClick={subscribe.pulse}
-          className="inline-flex min-h-[44px] items-center gap-[var(--spacing-2xs)] rounded-[var(--radius-md)] px-[var(--spacing-md)] py-[var(--spacing-2xs)] font-sans font-medium transition-colors hover:bg-[color:var(--color-accent-pressed)]"
-          style={{
-            background: "var(--color-accent)",
-            color: "var(--color-bg)",
-            fontSize: "var(--text-ui)",
-          }}
-          {...PRESS}
-        >
-          subscribe
-        </MotionLink>
-      </motion.div>
-
-      {/* Bottom-left meta row — icons + copyright */}
+      {/* Bottom-left meta row — reader count + copyright */}
       <motion.div
         className="mt-auto pt-[var(--spacing-2xl)] flex items-center gap-[var(--spacing-lg)] font-mono"
         style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
@@ -155,42 +109,19 @@ export function AboutColumn({ readerCount }: AboutColumnProps) {
           static: { opacity: 1 },
           hero: {
             opacity: [0, 1],
-            transition: { duration: 0.3, delay: 1.2 },
+            transition: { duration: 0.3, delay: 1.0 },
           },
           return: {
             opacity: [0, 1],
-            transition: { ...SPRING.smooth, delay: 0.18 },
+            transition: { ...SPRING.smooth, delay: 0.12 },
           },
         }}
       >
-        <Link
-          href={SITE_AUTHOR_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={`${SITE_AUTHOR_DISPLAY} on GitHub`}
-          className="transition-colors hover:text-[color:var(--color-text)]"
-        >
-          <GitHubIcon />
-        </Link>
         <ReaderCount count={readerCount} />
         <span className="tabular-nums" aria-label={`copyright ${years}`}>
           © {years}
         </span>
       </motion.div>
     </aside>
-  );
-}
-
-function GitHubIcon() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      width="14"
-      height="14"
-      fill="currentColor"
-      aria-hidden
-    >
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-    </svg>
   );
 }

--- a/components/nav/Footer.tsx
+++ b/components/nav/Footer.tsx
@@ -1,12 +1,3 @@
-"use client";
-
-import Link from "next/link";
-import { motion } from "motion/react";
-import { PRESS } from "@/lib/motion";
-import { SITE_AUTHOR_DISPLAY, SITE_AUTHOR_URL } from "@/lib/site";
-
-const MotionLink = motion.create(Link);
-
 export function Footer() {
   return (
     <footer
@@ -17,30 +8,13 @@ export function Footer() {
         color: "var(--color-text-muted)",
       }}
     >
-      <div className="mx-auto flex max-w-[65ch] flex-col gap-[var(--spacing-xs)] sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto flex max-w-[65ch] items-center">
         <span>
-          bytesize · built by{" "}
-          <motion.a
-            href={SITE_AUTHOR_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="bs-prose-link hover:text-[color:var(--color-text)] transition-colors"
-            {...PRESS}
-          >
-            {SITE_AUTHOR_DISPLAY}
-          </motion.a>
+          bytesize · built by An Anonymous Engineer
           <span aria-hidden className="ml-[0.25em] opacity-70">
             {"</>"}
           </span>
         </span>
-        <MotionLink
-          href="/rss.xml"
-          aria-label="Subscribe via RSS"
-          className="hover:text-[color:var(--color-text)] transition-colors"
-          {...PRESS}
-        >
-          subscribe (rss)
-        </MotionLink>
       </div>
     </footer>
   );

--- a/docs/mobile-first-verification.md
+++ b/docs/mobile-first-verification.md
@@ -55,9 +55,9 @@ re-walk the same flow.
 | MacBook Safari               | 1280 / 1920              |  |
 
 **Pass criteria**: no horizontal overflow, no stuck hover after tap-release
-on PostList rows or prose links, ring-pulse visible on Stepper prev/next
-and subscribe CTA, address bar doesn't flash a white background on first
-paint, slider thumb draggable with a thumb finger (44 × 44 hit target).
+on PostList rows or prose links, ring-pulse visible on Stepper prev/next,
+address bar doesn't flash a white background on first paint, slider thumb
+draggable with a thumb finger (44 × 44 hit target).
 
 ---
 
@@ -72,11 +72,7 @@ covers every consumer.
 
 1. Header → `bytesize` wordmark (`<MotionLink href="/">`)
 2. Header → theme toggle (`<motion.button>`)
-3. AboutColumn → subscribe CTA (`<MotionLink href="/rss.xml">`)
-4. AboutColumn → GitHub icon link
-5. PostList → each row (`<MotionLink>`) in document order
-6. Footer → author GitHub link
-7. Footer → `subscribe (rss)` link
+3. PostList → each row (`<MotionLink>`) in document order
 
 ### Tab order inside a widget
 

--- a/lib/hooks/use-tap-pulse.ts
+++ b/lib/hooks/use-tap-pulse.ts
@@ -8,8 +8,8 @@ import { useCallback, useRef } from "react";
  * class; forcing a reflow between remove and add is the cheapest way to
  * restart the animation reliably across browsers.
  *
- * Reserved for heavy-commit actions (Stepper advance, subscribe CTA). Other
- * buttons should stick to `PRESS` scale-only to avoid visual noise.
+ * Reserved for heavy-commit actions (Stepper advance). Other buttons should
+ * stick to `PRESS` scale-only to avoid visual noise.
  */
 export function useTapPulse<T extends HTMLElement = HTMLButtonElement>() {
   const ref = useRef<T | null>(null);

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -8,14 +8,6 @@ export const SITE_URL = "https://bytesize.vercel.app";
 
 export const SITE_NAME = "bytesize";
 
-/** SEO / metadata truth. Used by `app/layout.tsx` metadata.authors only. */
-export const SITE_AUTHOR = "Amartya";
-
-export const SITE_AUTHOR_URL = "https://github.com/iamartyaa";
-
-/** User-visible label. Every rendered surface (footer, nav, aria) uses this. */
-export const SITE_AUTHOR_DISPLAY = "An Anonymous Engineer";
-
 /** Meta description, RSS channel description, OG default subtitle. */
 export const SITE_DESCRIPTION =
   "long-form essays on software and AI, each built around interactive widgets that show how the thing actually works.";


### PR DESCRIPTION
## Summary

Removes every on-site hint that links back to the developer (GitHub profile, author name), and removes both subscribe affordances. The `/rss.xml` route itself is untouched — existing feed-reader subscribers keep working.

## What's gone from the live site

- **Author name + GitHub link** in `<Footer>` → replaced with plain text "An Anonymous Engineer" (phrase kept, link dropped).
- **GitHub icon + link** in `<AboutColumn>` meta row → removed entirely; meta row is now just the reader count + copyright.
- **Subscribe pill** (the terracotta CTA in `<AboutColumn>`) → removed.
- **Subscribe (rss) text link** in `<Footer>` → removed.
- **`authors` metadata** in `app/layout.tsx` (`<meta name="author">`, OG author fields) → removed.

## What's gone from `lib/site.ts`

Deleted constants: `SITE_AUTHOR`, `SITE_AUTHOR_URL`, `SITE_AUTHOR_DISPLAY`.
Kept: `SITE_URL`, `SITE_NAME`, `SITE_DESCRIPTION`, `SITE_TAGLINE`, `SITE_ABOUT`, `GOATCOUNTER_CODE`.

## Docs updated

- `README.md` — drops the `github.com/iamartyaa` link from the Author section.
- `DESIGN.md` — updates the ASCII home-page mock + the `AboutColumn` description to reflect no subscribe pill / no GitHub icon.
- `docs/mobile-first-verification.md` — trims the tab-order checklist and pass-criteria accordingly.
- `lib/hooks/use-tap-pulse.ts` — removes the stale "subscribe CTA" reference in the JSDoc.

## Still out of this PR's reach (heads-up)

- The repo URL itself (`github.com/iamartyaa/bytesize`) embeds the GitHub username. Only a repo transfer or account rename fixes this.
- The deployment URL `bytesize.vercel.app` is tied to a Vercel account handle. A custom domain would hide it.
- Git commit history / author emails are untouched.

## Test plan

- [ ] `pnpm build` passes; no unused-import warnings from removed constants.
- [ ] Homepage left column: wordmark + about + meta row `[reader count] © 2026`. No subscribe pill, no GitHub icon.
- [ ] Footer: single line `bytesize · built by An Anonymous Engineer </>`. No RSS link, no clickable author.
- [ ] View page source on prod → no `<meta name="author">`, no `github.com/iamartyaa` anywhere.
- [ ] `/rss.xml` still returns a valid feed (existing subscribers unaffected).
- [ ] Motion entry choreography still plays cleanly on first visit and return visit (the meta row timing was retuned since the subscribe pill is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)