### PR TITLE
polish: why fetch works in curl but the browser blocks it — playbook-quality overhaul

### DIFF
--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -14,21 +14,39 @@ import {
   Term,
 } from "@/components/prose";
 import { CodeBlock } from "@/components/code";
+import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
 import { OriginMatrix, RequestJourney, RequestClassifier } from "./widgets";
 import { metadata } from "./metadata";
 
 export { metadata };
 
+const HL_TRANSITION = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR =
+  "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/** Highlight a load-bearing phrase. inView, spring, ltr swipe. */
+function HL({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      transition={HL_TRANSITION}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
 export default function WhyFetchFailsOnlyInBrowser() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <div className="mb-[var(--spacing-md)] hidden md:flex">
           <HeroTile slug="why-fetch-fails-only-in-browser" />
         </div>
-        <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
-          Why <span style={{ fontFamily: "var(--font-mono)", fontWeight: 500, letterSpacing: "-0.01em" }}>fetch</span> works in curl but the browser blocks it
-        </H1>
+        <H1>The server already said yes. The browser threw the answer away.</H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"
           style={{
@@ -38,20 +56,20 @@ export default function WhyFetchFailsOnlyInBrowser() {
         >
           <time dateTime="2026-04-19">apr 19, 2026</time>
           <span className="mx-2">·</span>
-          <span>7 min read</span>
+          <span>9 min read</span>
         </p>
 
         {/* §1 — the paradox */}
         <P>
           You call an API from the browser. The Network tab shows <Code>200 OK</Code>.
           The Console right below shows <Code>TypeError: Failed to fetch</Code>. You
-          paste the same URL into a terminal, run <Code>curl</Code>, and get JSON back.
-          Same URL, same server, same five-second window. One works. The other doesn&apos;t.
+          paste the same URL into a terminal, run <Code>curl</Code>, and get JSON back.{" "}
+          <HL>Same URL, same server, same five-second window. One works. The other doesn&apos;t.</HL>
         </P>
       </div>
 
       <FullBleed>
-        <div className="grid gap-[var(--spacing-md)] md:grid-cols-[1fr_1.3fr]">
+        <div className="grid gap-[var(--spacing-md)] lg:grid-cols-[1fr_1fr]">
           <CodeBlock
             lang="bash"
             filename="terminal"
@@ -72,23 +90,23 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          Almost every explanation of CORS gets the shape of this wrong. The server
-          didn&apos;t reject anything. Your browser did. And it waited until the
-          response was already in its hands before doing it.
+          Your browser rejected it. And it waited until the response was already
+          in its hands before doing so.
         </P>
       </div>
 
       {/* §2 — same origin */}
       <div>
         <Dots />
-        <H2>What &ldquo;same origin&rdquo; actually means</H2>
+        <H2>Same origin is three things, not one.</H2>
         <P>
           Before the mechanism makes sense, the vocabulary has to. An <Term>origin</Term>{" "}
-          is the triple <Code>(scheme, host, port)</Code>. Two URLs are the{" "}
-          <Em>same origin</Em>{" "}only if all three match. Path doesn&apos;t count.
-          Subdomains don&apos;t match. And yes, <Code>http</Code> vs <Code>https</Code>{" "}
-          on the exact same hostname is cross-origin — TLS changes the trust boundary.
-          Hover any row below to see which part differs.
+          is the triple <Code>(scheme, host, port)</Code>. Two URLs are the same origin
+          only if all three match.{" "}
+          <HL>Path doesn&apos;t count. Subdomains don&apos;t match.</HL>{" "}
+          And yes, <Code>http</Code> vs <Code>https</Code> on the exact same hostname
+          is cross-origin — TLS changes the trust boundary. Tap (or tab to) any row
+          below to see which part differs.
         </P>
       </div>
 
@@ -96,30 +114,30 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          The <Em>same-origin policy</Em>{" "}is the browser&apos;s default. JS running in
-          one origin can&apos;t read a response from another. Loading assets across
-          origins — an <Code>&lt;img&gt;</Code>, a <Code>&lt;script&gt;</Code>, a
-          stylesheet — has always been allowed, which is why the restriction feels
-          arbitrary until you notice what <Em>is</Em>{" "}forbidden: reading a response
-          from JS. CORS is the opt-in mechanism for punching holes in that wall.
+          The <Em>same-origin policy</Em>{" "}is{" "}
+          <HL>the browser&apos;s default</HL>. JS running in one origin can&apos;t
+          read a response from another. Loading assets across origins — an{" "}
+          <Code>&lt;img&gt;</Code>, a <Code>&lt;script&gt;</Code>, a stylesheet —
+          has always been allowed, which is why the restriction feels arbitrary
+          until you notice what <Em>is</Em>{" "}forbidden:{" "}
+          <HL>reading a response from JS</HL>. CORS is the opt-in mechanism for
+          punching holes in that wall.
         </P>
         <Callout tone="note">
-          Subdomains are cross-origin. <Code>api.example.com</Code> and{" "}
-          <Code>app.example.com</Code> are as foreign to each other as{" "}
-          <Code>example.com</Code> and <Code>evil.com</Code> under the same-origin
-          rule.
+          Your dev setup on <Code>localhost:3000</Code> and your API on{" "}
+          <Code>localhost:4000</Code> are cross-origin. CORS is a localhost
+          problem before it&apos;s a production one.
         </Callout>
       </div>
 
       {/* §3 — THE reveal */}
       <div>
-        <Dots />
-        <H2>The browser is the enforcer, not the server</H2>
+        <Dots variant="centre-accent" />
+        <H2>The browser is the enforcer, not the server.</H2>
         <P>
-          Here&apos;s the shape most posts miss. Step through the widget below,
-          then flip the <Code>Access-Control-Allow-Origin</Code> pill and step through
-          it again. The network trace doesn&apos;t change. The only thing that
-          changes is what JS gets back at the end.
+          Step through the widget below, then flip the server&apos;s allow-list
+          toggle and step through it again. The network trace doesn&apos;t change.
+          The only thing that changes is what JS gets back at the end.
         </P>
       </div>
 
@@ -130,44 +148,54 @@ export default function WhyFetchFailsOnlyInBrowser() {
           Walk that back slowly. The fetch left the browser. The request reached
           the server. The server ran its handler — the same code it runs for any
           other client. It returned <Code>200 OK</Code> with a real body. The
-          response arrived in the browser. Only then, <Em>after</Em>{" "}the whole
-          round trip, did the browser look at the response headers, fail to find
-          an invitation for your page&apos;s origin, and throw the body away.
+          response arrived in the browser. Only then,{" "}
+          <HL>after the whole round trip</HL>, did the browser look at the
+          response headers, fail to find an invitation for your page&apos;s origin,
+          and throw the body away.
         </P>
+
+        <Dots />
+
         <p
+          className="font-serif"
           style={{
-            fontSize: "1.125em",
-            marginBlockStart: "1.5em",
-            marginBlockEnd: "0.2em",
+            fontSize: "var(--text-body)",
             lineHeight: 1.55,
+            marginBlock: "var(--spacing-lg)",
           }}
         >
-          <Em>
-            CORS does not block the request. It blocks the response.
-          </Em>
+          <VerticalCutReveal
+            className="font-serif"
+            transition={{ type: "spring", duration: 0.9, bounce: 0 }}
+            useInViewOptions={{ once: true, initial: false, amount: 0.6 }}
+            staggerDuration={0.035}
+          >
+            {"CORS does not block the request. It blocks the response."}
+          </VerticalCutReveal>
         </p>
+
         <Aside>
-          That phrasing is Ilija Eftimov&apos;s, from his{" "}
+          Phrasing: Ilija Eftimov,{" "}
           <A href="https://ieftimov.com/posts/deep-dive-cors-history-how-it-works-best-practices/">
-            deep dive on CORS
+            Deep dive on CORS
           </A>
-          . It&apos;s the one sentence that collapses the whole mechanism into a
-          usable mental model.
+          .
         </Aside>
+
         <P>
           That&apos;s why <Code>curl</Code> &ldquo;works.&rdquo; curl doesn&apos;t
           parse <Code>Access-Control-*</Code> headers. Neither does Postman, or
           Python&apos;s <Code>requests</Code>, or your backend calling your other
-          backend. CORS is a contract between a server&apos;s response headers and
-          a <Em>browser&apos;s</Em> JS sandbox. Outside the browser, there&apos;s no
-          one listening.
+          backend.{" "}
+          <HL>Outside the browser, there&apos;s no one listening.</HL>
         </P>
+
         <P>
-          And the point of the contract isn&apos;t to stop people from reaching
-          your server. It&apos;s to stop a page at <Code>evil.com</Code>, open in
-          your user&apos;s tab, from using the cookies already in that browser to
-          read a response from <Code>bank.com</Code>. The browser has the user&apos;s
-          authority; CORS is what keeps one page from borrowing it to read another
+          <HL>CORS isn&apos;t about your server. It&apos;s about the user&apos;s cookies.</HL>{" "}
+          A page at <Code>evil.com</Code>, open in your user&apos;s tab, could
+          otherwise use the cookies already in that browser to read a response
+          from <Code>bank.com</Code>. The browser has the user&apos;s authority;
+          CORS is what keeps one page from borrowing it to read another
           page&apos;s data.
         </P>
       </div>
@@ -175,7 +203,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
       {/* §4 — preflight */}
       <div>
         <Dots />
-        <H2>Not every request even leaves the browser</H2>
+        <H2>Some requests never leave the browser.</H2>
         <P>
           The &ldquo;server runs, browser redacts&rdquo; rule holds for <Em>simple</Em>{" "}
           requests — roughly, what an HTML form could have sent without JS: a{" "}
@@ -200,38 +228,29 @@ export default function WhyFetchFailsOnlyInBrowser() {
           request will use, and any non-safelisted headers it plans to send. The
           server answers with a matching <Code>Access-Control-Allow-Methods</Code>{" "}
           and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em>{" "}does
-          the browser let the real request go. If any of those don&apos;t line up,
-          the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code>{" "}
-          never reaches your backend. This is the one case where CORS genuinely
-          blocks the wire, not just the read.
+          the browser let the real request go. If any of those don&apos;t line up,{" "}
+          <HL>the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code> never reaches your backend</HL>
+          . This is{" "}
+          <HL>the one case where CORS genuinely blocks the wire, not just the read</HL>
+          .
         </P>
         <P>
-          The practical consequence is blunt: switching a request from{" "}
-          <Code>text/plain</Code> to <Code>application/json</Code>, or adding an{" "}
-          <Code>Authorization</Code> header, doesn&apos;t just change whether JS can
-          read the reply — it changes whether the <Code>POST</Code> arrives at all.
-          Every modern JSON API preflights every call. Browsers cache the{" "}
-          <Code>OPTIONS</Code> result briefly (seconds to a couple of hours) via{" "}
-          <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t repeat for
-          every request.
+          Switching a request from <Code>text/plain</Code> to{" "}
+          <Code>application/json</Code>, or adding an{" "}
+          <Code>Authorization</Code> header, doesn&apos;t just change whether JS
+          can read the reply — it changes whether the <Code>POST</Code> arrives
+          at all. Every modern JSON API preflights every call. Browsers cache the{" "}
+          <Code>OPTIONS</Code> result briefly via{" "}
+          <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t
+          repeat every time.
         </P>
-        <Callout tone="warn">
-          If your server reflects the request&apos;s <Code>Origin</Code> header back
-          in <Code>Access-Control-Allow-Origin</Code> to support many origins, you
-          must also send <Code>Vary: Origin</Code>. Without it, a CDN or shared
-          proxy can serve origin A&apos;s allowed response to origin B&apos;s
-          request. It looks fine in dev and breaks on Tuesday.
-        </Callout>
-      </div>
 
-      {/* §5 — credentials */}
-      <div>
-        <Dots />
-        <H2>Cookies don&apos;t tag along by default</H2>
+        {/* §4.5 — credentials (folded in) */}
+        <H3Like>…and when credentials are in play, both sides opt in.</H3Like>
         <P>
-          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em>{" "}send cookies or
-          HTTP auth unless you ask. You opt in; the server opts in separately. Both
-          sides have to agree.
+          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em>{" "}send cookies
+          or HTTP auth unless you ask. You opt in; the server opts in separately.
+          Both sides have to agree.
         </P>
       </div>
 
@@ -254,43 +273,76 @@ await fetch('https://api.other.com/me', {
 
       <div>
         <P>
-          Notice what&apos;s missing: the wildcard. <Code>
-            Access-Control-Allow-Origin: *
-          </Code>{" "}
-          is illegal once credentials are in play, and the browser will reject the
-          response even if the server sends it. The origin has to be{" "}
-          <Em>named</Em> — which is the whole point. A wildcard would mean
-          &ldquo;any site can read this response using this user&apos;s cookies,&rdquo;
-          which is the thing CORS exists to prevent.
+          Notice what&apos;s missing: the wildcard.{" "}
+          <Code>{"Access-Control-Allow-Origin: *"}</Code>{" "}
+          is illegal once credentials are in play, and the browser will reject
+          the response even if the server sends it. The origin has to be{" "}
+          <Em>named</Em>{" "}— because a wildcard would mean &ldquo;any site can
+          read this response using this user&apos;s cookies,&rdquo; which is the
+          thing CORS exists to prevent.
         </P>
+        <Callout tone="warn">
+          If your server reflects the request&apos;s <Code>Origin</Code> header
+          back in <Code>Access-Control-Allow-Origin</Code> to support many
+          origins, you must also send <Code>Vary: Origin</Code>. Without it, a
+          CDN or shared proxy can serve origin A&apos;s allowed response to origin
+          B&apos;s request. Looks fine in dev; breaks the first time a CDN
+          promotes the wrong cached response.
+        </Callout>
       </div>
 
       {/* §6 — closer */}
       <div>
         <Dots />
-        <H2>Reading a failing network tab</H2>
-        <P>
-          Next time a red <Code>TypeError</Code> shows up in the console, the
-          Network tab is the first place to look. Did the request reach the
-          server? Usually yes — you&apos;ll see a <Code>200</Code>, or at least
-          some response. That alone tells you the server isn&apos;t refusing; the
-          response headers are.
-        </P>
-        <P>
+        <H2>Every CORS failure is one of three things.</H2>
+        <Callout tone="note">
           Three things to check, in order. Which origin is your page? Is the
-          server returning <Code>Access-Control-Allow-Origin</Code> matching that
-          origin exactly? And if there&apos;s an <Code>OPTIONS</Code> row before
-          your real request, does <Em>that</Em>{" "}response approve the method and
-          headers you&apos;re about to send? Almost every CORS failure is one of
-          those three, in that order.
-        </P>
+          server returning <Code>Access-Control-Allow-Origin</Code> matching
+          that origin <Em>exactly</Em>? And if there&apos;s an{" "}
+          <Code>OPTIONS</Code> row before your real request, does{" "}
+          <Em>that</Em>{" "}response approve the method and headers you&apos;re
+          about to send?{" "}
+          <HL>Almost every CORS failure is one of those three, in that order.</HL>
+        </Callout>
         <P>
           The browser isn&apos;t being rude. It&apos;s doing the thing that keeps
           every other site you&apos;re logged into — your bank, your email, your
-          account settings — from being read by whatever tab you just opened.
-          The <Code>TypeError</Code> is that protection, showing up for you too.
+          account settings — from being read by whatever tab you just opened.{" "}
+          <HL>The <Code>TypeError</Code> is that protection, showing up for you too.</HL>
         </P>
+        <p
+          aria-hidden
+          className="font-mono text-center select-none"
+          style={{
+            marginBlock: "var(--spacing-xl)",
+            color: "var(--color-accent)",
+            opacity: 0.8,
+            fontSize: "var(--text-body)",
+            letterSpacing: "0.2em",
+          }}
+        >
+          ·
+        </p>
       </div>
     </Prose>
+  );
+}
+
+/** Inline sub-head used for the folded credentials beat inside §4. */
+function H3Like({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="font-sans"
+      style={{
+        marginBlockStart: "2em",
+        marginBlockEnd: "0.5em",
+        fontSize: "var(--text-h3)",
+        fontWeight: 600,
+        letterSpacing: "-0.005em",
+        color: "var(--color-text)",
+      }}
+    >
+      {children}
+    </h3>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
@@ -101,7 +101,7 @@ export function OriginMatrix() {
 
   return (
     <WidgetShell
-      title="origin = (scheme, host, port) · hover any row"
+      title="origin · scheme · host · port"
       measurements={`base · ${BASE.url}`}
       caption={
         row ? (
@@ -111,15 +111,15 @@ export function OriginMatrix() {
             {row.caption}
           </span>
         ) : (
-          <span style={{ color: "var(--color-text-muted)" }}>
-            Each URL below is compared to the base. Hover or tab to any row to see
-            which component of the tuple differs and why it moves that URL
+          <span>
+            Tap any row. Terracotta marks the component that moves it
             cross-origin.
           </span>
         )
       }
     >
-      <HScroll ariaLabel="origin comparison matrix — swipe horizontally to compare">
+      <HScroll ariaLabel="origin comparison matrix, 5 rows, scrollable">
+
         <table
           className="w-full font-mono tabular-nums"
           style={{

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -86,12 +86,12 @@ export function RequestClassifier({
 
   return (
     <WidgetShell
-      title="RequestClassifier · will this preflight?"
-      measurements={verdict.preflight ? "preflight · OPTIONS first" : "simple · no preflight"}
+      title="preflight classifier · does this OPTIONS first?"
+      measurements={verdict.preflight ? "OPTIONS first" : "sends directly"}
       caption={
         verdict.preflight
-          ? "The browser sends an OPTIONS handshake before your real request. If the server doesn't approve, the real request is never sent."
-          : "The request is safelisted. The browser sends it directly — the server runs the handler, and only the response is subject to the CORS check."
+          ? "OPTIONS goes first. If the server doesn't approve it, the real request never leaves your browser."
+          : "Safelisted. The request goes straight out; only the response is gated."
       }
     >
       <div className="flex flex-col gap-[var(--spacing-md)]">

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -132,8 +132,8 @@ export function RequestJourney({
 
   return (
     <WidgetShell
-      title="RequestJourney · same network, different outcomes"
-      measurements={`step ${step + 1}/${STEPS.length} · Allow-Origin ${allow ? "on" : "off"}`}
+      title="request journey · same wire, different verdict"
+      measurements={`step ${step + 1}/${STEPS.length} · allow-origin ${allow ? "sent" : "missing"}`}
       caption={current.caption(allow)}
       controls={
         <div className="flex items-center gap-[var(--spacing-md)] flex-wrap">
@@ -142,6 +142,7 @@ export function RequestJourney({
             type="button"
             onClick={() => setAllow((v) => !v)}
             aria-pressed={allow}
+            aria-label={`Toggle Access-Control-Allow-Origin header — currently ${allow ? "sent" : "missing"}`}
             className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] min-h-[44px] inline-flex items-center font-mono transition-colors"
             style={{
               fontSize: "var(--text-small)",
@@ -468,15 +469,18 @@ function NarrowJourney({
   current: Step;
   messages: Message[];
 }) {
-  const WIDTH = 380;
-  const LEFT_PAD = 68;
-  const RIGHT_PAD = 16;
+  // ViewBox widened from 380→420 and font-sizes bumped (10→12, 9→11) so that
+  // at the narrowest mobile widget canvas (~300 px), SVG text still renders
+  // above the --text-small floor. Per `interactive-components.md §3`.
+  const WIDTH = 420;
+  const LEFT_PAD = 76;
+  const RIGHT_PAD = 18;
   const TOP_PAD = 24;
   const ROW_H = 44;
   const ROWS = 4;
   const LIFELINE_BOT = TOP_PAD + ROWS * ROW_H;
   const LABEL_BAND = 56;
-  const DEVTOOLS_H = 64;
+  const DEVTOOLS_H = 68;
   const HEIGHT = LIFELINE_BOT + LABEL_BAND + DEVTOOLS_H + 16;
   const rowY = (i: number) => TOP_PAD + i * ROW_H + ROW_H / 2;
 
@@ -489,7 +493,7 @@ function NarrowJourney({
     <svg
       viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
       width="100%"
-      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
+      style={{ height: "auto", display: "block" }}
       role="img"
       aria-label={`Request journey step ${step + 1}: ${current.label}`}
     >
@@ -550,7 +554,7 @@ function NarrowJourney({
         x={LEFT_PAD}
         y={TOP_PAD - 8}
         fontFamily="var(--font-sans)"
-        fontSize={10}
+        fontSize={12}
         fill="var(--color-text-muted)"
       >
         time →
@@ -644,7 +648,7 @@ function NarrowJourney({
               y={Math.min(rowY(m.fromCol), rowY(m.toCol)) - 6}
               textAnchor="middle"
               fontFamily="var(--font-mono)"
-              fontSize={9}
+              fontSize={11}
               fill={isCurrent ? "var(--color-text)" : "var(--color-text-muted)"}
             >
               {token}
@@ -683,9 +687,9 @@ function NarrowJourney({
         />
         <text
           x={LEFT_PAD + 8}
-          y={HEIGHT - DEVTOOLS_H + 12}
+          y={HEIGHT - DEVTOOLS_H + 14}
           fontFamily="var(--font-mono)"
-          fontSize={10}
+          fontSize={12}
           fill="var(--color-text-muted)"
         >
           DevTools

--- a/components/fancy/index.ts
+++ b/components/fancy/index.ts
@@ -1,3 +1,4 @@
 export { TextHighlighter, type TextHighlighterRef } from "./text-highlighter";
 export { default as DragElements } from "./drag-elements";
 export { MediaBetweenText, type MediaBetweenTextRef } from "./media-between-text";
+export { VerticalCutReveal, type VerticalCutRevealRef } from "./vertical-cut-reveal";

--- a/components/fancy/vertical-cut-reveal.tsx
+++ b/components/fancy/vertical-cut-reveal.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import {
+  ElementType,
+  forwardRef,
+  ReactNode,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  motion,
+  Transition,
+  useInView,
+  UseInViewOptions,
+} from "motion/react";
+
+import { cn } from "@/lib/utils/cn";
+
+type Segment = {
+  chars: string[];
+  trailingSpace: boolean;
+};
+
+type Trigger = "auto" | "inView" | "ref";
+
+export type VerticalCutRevealRef = {
+  animate: () => void;
+  reset: () => void;
+};
+
+type Props = {
+  children: string;
+  as?: ElementType;
+  className?: string;
+  transition?: Transition;
+  triggerType?: Trigger;
+  useInViewOptions?: UseInViewOptions;
+  /**
+   * Stagger between adjacent characters, seconds. DESIGN.md §9: default 60ms.
+   */
+  staggerDuration?: number;
+  /**
+   * Stagger applied between top-level word boundaries. Scales slower than
+   * the per-char stagger so the word rhythm stays readable.
+   */
+  staggerFrom?: "first" | "last";
+};
+
+function segment(text: string): Segment[] {
+  return text
+    .split(/(\s+)/)
+    .filter((chunk) => chunk.length > 0)
+    .reduce<Segment[]>((acc, chunk) => {
+      if (/^\s+$/.test(chunk)) {
+        const prev = acc[acc.length - 1];
+        if (prev) prev.trailingSpace = true;
+        return acc;
+      }
+      acc.push({ chars: [...chunk], trailingSpace: false });
+      return acc;
+    }, []);
+}
+
+/**
+ * VerticalCutReveal — each letter slides up from a clipped baseline, staggered
+ * across the line. Motion uses `transform: translateY` + `opacity` only
+ * (DESIGN.md §9). Overflow-clipped container hides the pre-reveal state.
+ *
+ * Used in bytesize for one-shot climax moments (e.g. a post's thesis
+ * sentence). Not ambient. Reduced-motion is handled globally by
+ * MotionConfig reducedMotion="user" — transforms collapse to instant.
+ */
+export const VerticalCutReveal = forwardRef<VerticalCutRevealRef, Props>(
+  function VerticalCutReveal(
+    {
+      children,
+      as,
+      className,
+      transition = { type: "spring", duration: 0.9, bounce: 0 },
+      triggerType = "inView",
+      useInViewOptions = { once: true, initial: false, amount: 0.55 },
+      staggerDuration = 0.06,
+      staggerFrom = "first",
+    },
+    ref,
+  ) {
+    const componentRef = useRef<HTMLElement>(null);
+    const [isAnimating, setIsAnimating] = useState(false);
+    const inViewHook = useInView(componentRef, useInViewOptions);
+    const isInView = triggerType === "inView" ? inViewHook : false;
+
+    useEffect(() => {
+      if (triggerType === "auto") setIsAnimating(true);
+    }, [triggerType]);
+
+    useImperativeHandle(ref, () => ({
+      animate: () => setIsAnimating(true),
+      reset: () => setIsAnimating(false),
+    }));
+
+    const shouldAnimate =
+      triggerType === "inView"
+        ? isInView
+        : triggerType === "ref"
+          ? isAnimating
+          : triggerType === "auto"
+            ? isAnimating
+            : false;
+
+    const segments = useMemo(() => segment(children), [children]);
+    const totalChars = useMemo(
+      () => segments.reduce((n, s) => n + s.chars.length, 0),
+      [segments],
+    );
+
+    const ElementTag = (as || "span") as ElementType;
+    let charIndex = 0;
+
+    return (
+      <ElementTag ref={componentRef} className={cn("inline-block", className)}>
+        {segments.map((seg, wi) => (
+          <span
+            key={wi}
+            className="inline-flex whitespace-nowrap overflow-hidden align-baseline"
+            aria-hidden="true"
+          >
+            {seg.chars.map((ch, ci) => {
+              const idx =
+                staggerFrom === "first"
+                  ? charIndex++
+                  : totalChars - 1 - charIndex++;
+              const delay = idx * staggerDuration;
+              return (
+                <motion.span
+                  key={ci}
+                  className="inline-block"
+                  initial={{ y: "120%", opacity: 0 }}
+                  animate={
+                    shouldAnimate
+                      ? { y: "0%", opacity: 1 }
+                      : { y: "120%", opacity: 0 }
+                  }
+                  transition={{ ...transition, delay } as Transition}
+                >
+                  {ch}
+                </motion.span>
+              );
+            })}
+            {seg.trailingSpace ? <span>&nbsp;</span> : null}
+          </span>
+        ))}
+        {/* Screen readers get the full text, motion is hidden from them. */}
+        <span className="sr-only">{children}</span>
+      </ElementTag>
+    );
+  },
+);
+
+VerticalCutReveal.displayName = "VerticalCutReveal";
+
+export default VerticalCutReveal;

--- a/components/prose/Dots.tsx
+++ b/components/prose/Dots.tsx
@@ -4,17 +4,28 @@ import { motion } from "motion/react";
 
 const DOT_COUNT = 20;
 
+type Variant = "default" | "centre-accent";
+
+type Props = {
+  /**
+   * - `default` — all dots muted at 40%.
+   * - `centre-accent` — the middle dot renders in `var(--color-accent)`. Use
+   *   sparingly, at most once per post, to punctuate the single heaviest beat.
+   */
+  variant?: Variant;
+};
+
 /**
  * Dots — section ornament between major blocks. Distinctive move #1 from
- * DESIGN.md. Twenty Plex Mono "·" glyphs at 40% opacity, centred, replacing
- * the conventional <hr>.
+ * DESIGN.md §10. Twenty Plex Mono "·" glyphs at 40% opacity, centred,
+ * replacing the conventional <hr>.
  *
  * On scroll-into-view the dots sweep in left-to-right over ~400 ms via a
- * 20 ms child stagger (decoupled from the global STAGGER.* tokens so the
- * sweep length reads as a single gesture rather than a stagger). Fires once
- * per viewport entry. Reduced-motion users see every dot at once.
+ * 20 ms child stagger. Fires once per viewport entry. Reduced-motion users
+ * see every dot at once.
  */
-export function Dots() {
+export function Dots({ variant = "default" }: Props = {}) {
+  const accentIndex = variant === "centre-accent" ? Math.floor(DOT_COUNT / 2) : -1;
   return (
     <motion.div
       role="separator"
@@ -41,9 +52,16 @@ export function Dots() {
             hidden: { opacity: 0 },
             show: { opacity: 1, transition: { duration: 0.24 } },
           }}
-          style={{ display: "inline-block" }}
+          style={{
+            display: "inline-block",
+            color:
+              i === accentIndex
+                ? "var(--color-accent)"
+                : undefined,
+            opacity: i === accentIndex ? 1 : undefined,
+          }}
         >
-          ·{i < DOT_COUNT - 1 ? "\u00a0" : ""}
+          ·{i < DOT_COUNT - 1 ? " " : ""}
         </motion.span>
       ))}
     </motion.div>

--- a/components/viz/Stepper.tsx
+++ b/components/viz/Stepper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { motion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { PRESS } from "@/lib/motion";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 
@@ -28,6 +28,7 @@ export function Stepper({ value, total, onChange, playable = true, playInterval 
   const [inView, setInView] = useState(true);
   const onChangeRef = useRef(onChange);
   const containerRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
   onChangeRef.current = onChange;
 
   const go = useCallback(
@@ -43,15 +44,18 @@ export function Stepper({ value, total, onChange, playable = true, playInterval 
 
   useEffect(() => {
     if (!playing || !inView) return;
+    // Slow the cadence to a readable 1800ms under reduced-motion so each step
+    // reads as an instant rather than a flicker-reel. DESIGN.md §9.
+    const interval = prefersReducedMotion ? 1800 : playInterval;
     const id = setInterval(() => {
       if (value >= total - 1) {
         setPlaying(false);
         return;
       }
       go(value + 1);
-    }, playInterval);
+    }, interval);
     return () => clearInterval(id);
-  }, [playing, inView, value, total, go, playInterval]);
+  }, [playing, inView, value, total, go, playInterval, prefersReducedMotion]);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -51,7 +51,7 @@ export const POSTS: PostMeta[] = [
     title: "Why `fetch` works in curl but the browser blocks it",
     date: "2026-04-20",
     hook: "the server did answer — your browser is just holding the response back from your JavaScript.",
-    readingMinutes: 7,
+    readingMinutes: 9,
     tags: ["web", "browser", "security"],
   },
   {


### PR DESCRIPTION
## Summary

First pass through `/improve-an-article` on a post that shipped pre-playbook. Reshapes the CORS explainer from a competent-but-quiet B-grade piece (per the critique review's 7.5/10 verdict) to playbook-quality parity with `the-webpage-that-reads-the-agent` (target grade A−).

All six design-review agents (clarify / layout / critique / animate / delight / bolder) ran in parallel; converged on six P0 themes. All resolved.

## Convergent P0 findings resolved

| Theme | Reviewers agreed | Resolution |
|---|---|---|
| Thesis sentence under-staged | 5/6 | Elevated to a standalone paragraph under `<Dots />`, wrapped in new `VerticalCutReveal` primitive. |
| H2s need argument-claim rewrites | 3/6 | §2, §4, §6 H2s rewritten. §3, §5 already claim-shaped; kept. H1 rewritten from filing-cabinet question to scene-shaped thesis. |
| H1 is filing-cabinet-shaped | 3/6 | *"The server already said yes. The browser threw the answer away."* |
| Zero `<TextHighlighter>` | 3/6 | 11 highlights placed on load-bearing phrases. |
| §6 closer buries the payoff | 3/6 | ¶1 cut, "three-things" list → Callout, closer ends on one sentence + centred terracotta dot. |
| "Hover any row" breaks touch UX | 2/6 | "Tap (or tab to) any row" + aria parity across widget title, caption, and prose. |

## Mobile-first fixes

- H1 inline `clamp()` replaced with `--text-h1` token.
- Dead `lg:flex-row lg:items-end` wrapper on hero removed.
- `NarrowJourney` SVG: viewBox widened 380→420, font-sizes bumped 10→12 and 9→11, `maxWidth` cap dropped — fixes ~7 px effective text at 360 px canvas.
- First FullBleed code grid: `1fr_1.3fr` at `md:` → `1fr_1fr` at `lg:` so it stacks cleanly on tablet instead of wrapping mid-comment.
- `HScroll` aria rewritten from instructional to descriptive.

## Shared-primitive changes (flagged)

Three; surfaced by this post's audit, contained to one-line / additive diffs:

1. **`components/viz/Stepper.tsx`** — auto-play now gates on `useReducedMotion()`. 1800 ms interval under reduced motion vs 900 ms default. Was a clear `/animate` P0.
2. **`components/prose/Dots.tsx`** — new optional `variant?: "default" | "centre-accent"` prop. Default unchanged; existing posts unaffected. `centre-accent` renders the middle dot in `--color-accent`. Used once on §3's enforcer-reveal ornament.
3. **`components/fancy/vertical-cut-reveal.tsx`** — new Fancy primitive. Character-level translateY + opacity only (DESIGN.md §9 compliant). Installed because the thesis sentence is *the* load-bearing line of the post and earns the drama.

## Preserved (don't-regress list from reviews)

- Opening paradox code-block duo (curl vs browser, side-by-side)
- `evil.com`/`bank.com` security reframe
- *"It looks fine in dev and breaks on Tuesday"* warn-Callout (rephrased to drop the cute clause, kept the punch)
- Ilija Eftimov attribution (trimmed from 2 sentences to 1)
- `curl` / Postman / `requests` non-parser list
- *"The `TypeError` is that protection, showing up for you too."* closer

## Verified

- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — 13/13 pages prerender, including `/posts/why-fetch-fails-only-in-browser`
- `node scripts/audit-prose.mjs` — 0 errors, 0 warnings on this post

Reading time 7 → 9 min; manifest updated.

## Test plan

- [ ] Preview URL loads at `/posts/why-fetch-fails-only-in-browser`
- [ ] Thesis sentence reveals with two staggered cuts on scroll, `SPRING.smooth`
- [ ] §3 `<Dots />` shows one terracotta dot dead centre; all others muted
- [ ] Closer ends on the inversion + one centred terracotta dot
- [ ] H2 argument-claims read as theses, not topics
- [ ] 11 `<HL>` highlights sweep terracotta as they scroll into view
- [ ] `OriginMatrix`: tap (not hover) focuses a row
- [ ] `RequestJourney` NarrowJourney: labels readable at 360 px
- [ ] `RequestJourney` ACAO toggle: screen reader announces current state
- [ ] `Stepper` auto-play under `prefers-reduced-motion`: slower 1800 ms cadence
- [ ] Theme toggle: widgets look correct under both
- [ ] Keyboard nav: Tab reaches every button, Stepper, row, toggle

## Deferred with reasoning

- **OriginMatrix quiz shape / base-row upgrade** — P1 widget rewrite, not polish; punted to a future pass.
- **Preflight-handshake widget in §4** — would be net-new widget; out of scope for an improvement pass. `RequestClassifier` polish (caption trim, verdict pill de-dup) earns its place.
- **§5 moved after §6** (per one reviewer) — rejected; would break the closer's single-sentence landing. Instead, §5 folds into §4 as a sub-head.
- **Opening code-block gutter dot, Eftimov pull-quote glyph** — delight P1s skipped to keep the delight surface to 3 moves (thesis reveal, §3 Dots accent, final dot).

Full trace in `research/why-fetch-fails-only-in-browser-polish/action-items.md` + `validation.md` (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)