### PR TITLE
fix: home post list fades fast on back-nav (no spring stagger)

### DIFF
--- a/components/nav/PostListMotion.tsx
+++ b/components/nav/PostListMotion.tsx
@@ -1,36 +1,38 @@
 "use client";
 
 import { motion } from "motion/react";
-import { SPRING, STAGGER } from "@/lib/motion";
+import { TIMING } from "@/lib/motion";
 import type { ReactNode } from "react";
 
 /**
  * PostListMotion — client-only wrapper around each <li> in PostList.
- * Parent <ul> uses `variants` + `staggerChildren: STAGGER.tight` to reveal
- * rows one at a time on mount. Each child fades + lifts from y=8 to y=0
- * via SPRING.smooth.
+ * Each child fades in (opacity-only, no displacement) on TIMING.fast,
+ * with a tiny inter-row stagger. Reveal is intentionally lightning-fast
+ * on back-navigation; the only "slow" part is the optional first-visit
+ * delayChildren that holds the cascade until the hero choreography
+ * settles (set in PostList.tsx, not here).
  *
- * Respects prefers-reduced-motion via the global MotionConfigProvider —
- * durations collapse to near-instant, no per-component handling needed.
+ * Respects prefers-reduced-motion via the global MotionConfigProvider.
  */
+
+const ITEM_STAGGER = 0.02; // 20ms — perceptible texture, no visible build-up
 
 const makeListVariants = (delayChildren: number) => ({
   hidden: { opacity: 1 }, // keep the list itself visible; stagger drives children
   show: {
     opacity: 1,
     transition: {
-      staggerChildren: STAGGER.tight,
+      staggerChildren: ITEM_STAGGER,
       delayChildren,
     },
   },
 });
 
 const itemVariants = {
-  hidden: { opacity: 0, y: 8 },
+  hidden: { opacity: 0 },
   show: {
     opacity: 1,
-    y: 0,
-    transition: SPRING.smooth,
+    transition: TIMING.fast,
   },
 };
 


### PR DESCRIPTION
## Summary

Home article list was reentering with `SPRING.smooth` + y=8→0 + 60ms stagger across ~5 rows on every back-navigation. The spring tail (~500ms) plus stagger compounded into a ~1s reveal that felt sluggish.

## Fix

`components/nav/PostListMotion.tsx`:
- Per-item motion: opacity-only fade (no y displacement) on `TIMING.fast` (160ms ease).
- Stagger reduced from `STAGGER.tight` (60ms) to 20ms — perceptible texture, no visible build-up.
- Total reveal now lands in ~260ms.

First-visit hero choreography preserved — `delayChildren` is set in `PostList.tsx` and untouched.

## Test plan

- [ ] Click any post from the home list, then click the bytesize wordmark to return → the list should appear in ~250ms with a smooth fade.
- [ ] Mobile back-nav (browser back, bottom nav button) → same.
- [ ] First visit (sessionStorage cleared) → hero choreography still plays; list still arrives after ~1.2s delay (intentional).
- [ ] `prefers-reduced-motion: reduce` → list arrives instantly via `MotionConfigProvider` collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)