### PR TITLE
polish: why-fetch-fails-only-in-browser — mobile-first widgets + fixed-frame classifier + credentials toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -443,21 +443,23 @@ html[data-theme-transitioning] {
   }
 }
 
-/* RequestJourney — orientation flip. Wide (≥ --flip-wide) keeps the
-   conventional sequence-diagram layout with actors as columns. Below the
-   flip point we swap to horizontal lifelines (actors as rows, time flowing
-   left-to-right) so long message labels like "GET /me · Origin: …" have
-   room to breathe instead of being scaled into illegibility. Both SVGs
-   render in SSR; the container query picks which one to show. */
-.bs-rj-narrow {
+/* OriginMatrix (why-fetch-fails-only-in-browser §2) — mobile-first. Default
+   shape is a stacked-list of cards (each row stands alone, URL + diff line +
+   verdict pill). At --flip-wide the table layout returns for denser desktop
+   reading. Authoring source is the stacked list — the table is rendered
+   from the same data. */
+.bs-om-table {
   display: none;
 }
-@container widget (max-width: 640px) {
-  .bs-rj-wide {
+@container widget (min-width: 640px) {
+  .bs-om-base {
     display: none;
   }
-  .bs-rj-narrow {
-    display: block;
+  .bs-om-stack {
+    display: none;
+  }
+  .bs-om-table {
+    display: table;
   }
 }
 

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -135,16 +135,6 @@ export default function WhyFetchFailsOnlyInBrowser() {
       <RequestJourney />
 
       <div>
-        <P>
-          Walk that back slowly. The fetch left the browser. The request reached
-          the server. The server ran its handler — the same code it runs for any
-          other client. It returned <Code>200 OK</Code> with a real body. The
-          response arrived in the browser. Only then,{" "}
-          <HL>after the whole round trip</HL>, did the browser look at the
-          response headers, fail to find an invitation for your page&apos;s origin,
-          and throw the body away.
-        </P>
-
         <Dots />
 
         <p
@@ -196,18 +186,9 @@ export default function WhyFetchFailsOnlyInBrowser() {
         <Dots />
         <H2>Some requests never leave the browser.</H2>
         <P>
-          The &ldquo;server runs, browser redacts&rdquo; rule holds for <Em>simple</Em>{" "}
-          requests — roughly, what an HTML form could have sent without JS: a{" "}
-          <Code>GET</Code>, or a plain <Code>POST</Code> with one of three
-          old content types (<Code>text/plain</Code>,{" "}
-          <Code>application/x-www-form-urlencoded</Code>, or{" "}
-          <Code>multipart/form-data</Code>) and no custom headers. For anything
-          else, the browser sends a second, silent request first — an{" "}
-          <Code>OPTIONS</Code>, asking permission. If permission is denied, the
-          real request is never sent.
-        </P>
-        <P>
-          Flip the controls below and watch the verdict change.
+          Some requests get this treatment. Others trigger a second request
+          first — an <Code>OPTIONS</Code>, asking permission, before the real
+          one is allowed to leave. The widget classifies which is which.
         </P>
       </div>
 
@@ -215,25 +196,14 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          The <Em>preflight</Em>{" "}carries <Code>Origin</Code>, the method the real
-          request will use, and any non-safelisted headers it plans to send. The
-          server answers with a matching <Code>Access-Control-Allow-Methods</Code>{" "}
-          and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em>{" "}does
-          the browser let the real request go. If any of those don&apos;t line up,
-          the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code> never
-          reaches your backend. This is{" "}
-          <HL>the one case where CORS genuinely blocks the wire, not just the read</HL>
-          .
-        </P>
-        <P>
-          Switching a request from <Code>text/plain</Code> to{" "}
-          <Code>application/json</Code>, or adding an{" "}
-          <Code>Authorization</Code> header, doesn&apos;t just change whether JS
-          can read the reply — it changes whether the <Code>POST</Code> arrives
-          at all. Every modern JSON API preflights every call. Browsers cache the{" "}
-          <Code>OPTIONS</Code> result briefly via{" "}
+          The <Em>preflight</Em>{" "}asks the server, in advance, whether the real
+          request is allowed: its method, its custom headers. If the answer
+          doesn&apos;t match, the real <Code>POST</Code> or <Code>DELETE</Code>{" "}
+          never leaves the browser.{" "}
+          <HL>This is the one case where CORS blocks the wire, not just the read.</HL>{" "}
+          Browsers cache the <Code>OPTIONS</Code> result briefly via{" "}
           <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t
-          repeat every time.
+          repeat on every call.
         </P>
 
         {/* §4.5 — credentials (folded in) */}
@@ -297,8 +267,7 @@ await fetch('https://api.other.com/me', {
         </Callout>
         <P>
           The browser isn&apos;t being rude. It&apos;s doing the thing that keeps
-          every other site you&apos;re logged into — your bank, your email, your
-          account settings — from being read by whatever tab you just opened.{" "}
+          every other tab from reading what you&apos;re logged into.{" "}
           <HL>The <Code>TypeError</Code> is that protection, showing up for you too.</HL>
         </P>
         <p

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -205,43 +205,6 @@ export default function WhyFetchFailsOnlyInBrowser() {
           <Code>Access-Control-Max-Age</Code> so the handshake doesn&apos;t
           repeat on every call.
         </P>
-
-        {/* §4.5 — credentials (folded in) */}
-        <H3Like>…and when credentials are in play, both sides opt in.</H3Like>
-        <P>
-          <Code>fetch</Code> to a cross-origin URL does <Em>not</Em>{" "}send cookies
-          or HTTP auth unless you ask. You opt in; the server opts in separately.
-          Both sides have to agree.
-        </P>
-      </div>
-
-      <FullBleed>
-        <CodeBlock
-          lang="javascript"
-          filename="client"
-          code={`// client opt-in
-await fetch('https://api.other.com/me', {
-  credentials: 'include',
-});
-
-// server must respond with, exactly:
-//   Access-Control-Allow-Origin: https://app.example.com
-//   Access-Control-Allow-Credentials: true
-//
-// not '*' — wildcard + credentials is an error.`}
-        />
-      </FullBleed>
-
-      <div>
-        <P>
-          Notice what&apos;s missing: the wildcard.{" "}
-          <Code>{"Access-Control-Allow-Origin: *"}</Code>{" "}
-          is illegal once credentials are in play, and the browser will reject
-          the response even if the server sends it. The origin has to be{" "}
-          <Em>named</Em>{" "}— because a wildcard would mean &ldquo;any site can
-          read this response using this user&apos;s cookies,&rdquo; which is the
-          thing CORS exists to prevent.
-        </P>
         <Callout tone="warn">
           If your server reflects the request&apos;s <Code>Origin</Code> header
           back in <Code>Access-Control-Allow-Origin</Code> to support many
@@ -285,24 +248,5 @@ await fetch('https://api.other.com/me', {
         </p>
       </div>
     </Prose>
-  );
-}
-
-/** Inline sub-head used for the folded credentials beat inside §4. */
-function H3Like({ children }: { children: React.ReactNode }) {
-  return (
-    <h3
-      className="font-sans"
-      style={{
-        marginBlockStart: "2em",
-        marginBlockEnd: "0.5em",
-        fontSize: "var(--text-h3)",
-        fontWeight: 600,
-        letterSpacing: "-0.005em",
-        color: "var(--color-text)",
-      }}
-    >
-      {children}
-    </h3>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -100,13 +100,9 @@ export default function WhyFetchFailsOnlyInBrowser() {
         <Dots />
         <H2>Same origin is three things, not one.</H2>
         <P>
-          Before the mechanism makes sense, the vocabulary has to. An <Term>origin</Term>{" "}
-          is the triple <Code>(scheme, host, port)</Code>. Two URLs are the same origin
-          only if all three match.{" "}
-          <HL>Path doesn&apos;t count. Subdomains don&apos;t match.</HL>{" "}
-          And yes, <Code>http</Code> vs <Code>https</Code> on the exact same hostname
-          is cross-origin — TLS changes the trust boundary. Tap (or tab to) any row
-          below to see which part differs.
+          An <Term>origin</Term>{" "}is the triple{" "}
+          <Code>(scheme, host, port)</Code>. Two URLs are the same origin only if
+          all three match.
         </P>
       </div>
 
@@ -114,20 +110,15 @@ export default function WhyFetchFailsOnlyInBrowser() {
 
       <div>
         <P>
-          The <Em>same-origin policy</Em>{" "}is{" "}
-          <HL>the browser&apos;s default</HL>. JS running in one origin can&apos;t
-          read a response from another. Loading assets across origins — an{" "}
-          <Code>&lt;img&gt;</Code>, a <Code>&lt;script&gt;</Code>, a stylesheet —
-          has always been allowed, which is why the restriction feels arbitrary
-          until you notice what <Em>is</Em>{" "}forbidden:{" "}
-          <HL>reading a response from JS</HL>. CORS is the opt-in mechanism for
-          punching holes in that wall.
+          That triple is what the browser checks before it lets one page read
+          another&apos;s response. CORS is the opt-in mechanism for relaxing
+          that rule, narrowly.
         </P>
-        <Callout tone="note">
+        <Aside>
           Your dev setup on <Code>localhost:3000</Code> and your API on{" "}
           <Code>localhost:4000</Code> are cross-origin. CORS is a localhost
           problem before it&apos;s a production one.
-        </Callout>
+        </Aside>
       </div>
 
       {/* §3 — THE reveal */}
@@ -228,9 +219,9 @@ export default function WhyFetchFailsOnlyInBrowser() {
           request will use, and any non-safelisted headers it plans to send. The
           server answers with a matching <Code>Access-Control-Allow-Methods</Code>{" "}
           and <Code>Access-Control-Allow-Headers</Code>, and <Em>only then</Em>{" "}does
-          the browser let the real request go. If any of those don&apos;t line up,{" "}
-          <HL>the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code> never reaches your backend</HL>
-          . This is{" "}
+          the browser let the real request go. If any of those don&apos;t line up,
+          the real <Code>POST</Code>, <Code>DELETE</Code>, or <Code>PATCH</Code> never
+          reaches your backend. This is{" "}
           <HL>the one case where CORS genuinely blocks the wire, not just the read</HL>
           .
         </P>
@@ -301,8 +292,8 @@ await fetch('https://api.other.com/me', {
           that origin <Em>exactly</Em>? And if there&apos;s an{" "}
           <Code>OPTIONS</Code> row before your real request, does{" "}
           <Em>that</Em>{" "}response approve the method and headers you&apos;re
-          about to send?{" "}
-          <HL>Almost every CORS failure is one of those three, in that order.</HL>
+          about to send? Almost every CORS failure is one of those three, in that
+          order.
         </Callout>
         <P>
           The browser isn&apos;t being rude. It&apos;s doing the thing that keeps

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { HScroll } from "@/components/viz/HScroll";
 import { WidgetShell } from "./WidgetShell";
 
 type Row = {
@@ -11,6 +10,9 @@ type Row = {
   port: string;
   path: string;
   sameOrigin: boolean;
+  /** Which component differs from BASE — drives the terracotta highlight in the
+   *  stacked-list view. `null` for the same-origin row. */
+  differs: ColKey | null;
   caption: string;
 };
 
@@ -30,8 +32,9 @@ const ROWS: Row[] = [
     port: "(80)",
     path: "/",
     sameOrigin: false,
+    differs: "scheme",
     caption:
-      "Scheme differs. `http` and `https` are separate origins even on the same host — TLS changes the trust boundary.",
+      "Scheme differs. http and https are separate origins even on the same host — TLS changes the trust boundary.",
   },
   {
     url: "https://app.example.com:8080",
@@ -40,6 +43,7 @@ const ROWS: Row[] = [
     port: "8080",
     path: "/",
     sameOrigin: false,
+    differs: "port",
     caption:
       "Port differs. Browsers include the port in the origin tuple — so your API on :8080 is cross-origin from your site on :443.",
   },
@@ -50,6 +54,7 @@ const ROWS: Row[] = [
     port: "(443)",
     path: "/",
     sameOrigin: false,
+    differs: "host",
     caption:
       "Host differs. Subdomains are cross-origin. api.example.com and app.example.com are as foreign as example.com and evil.com under this rule.",
   },
@@ -60,6 +65,7 @@ const ROWS: Row[] = [
     port: "(443)",
     path: "/",
     sameOrigin: false,
+    differs: "host",
     caption:
       "Host differs. The parent domain is its own origin. Strip a subdomain and you've left the origin.",
   },
@@ -70,6 +76,7 @@ const ROWS: Row[] = [
     port: "(443)",
     path: "/admin",
     sameOrigin: true,
+    differs: null,
     caption:
       "Same origin. Path is not part of the tuple — /admin and / share an origin, which is why cookies and JS access work across routes.",
   },
@@ -77,11 +84,11 @@ const ROWS: Row[] = [
 
 type ColKey = "scheme" | "host" | "port" | "path";
 
-const COLS: { key: ColKey; label: string; weight: number }[] = [
-  { key: "scheme", label: "scheme", weight: 1 },
-  { key: "host", label: "host", weight: 1 },
-  { key: "port", label: "port", weight: 1 },
-  { key: "path", label: "path", weight: 1 },
+const COLS: { key: ColKey; label: string }[] = [
+  { key: "scheme", label: "scheme" },
+  { key: "host", label: "host" },
+  { key: "port", label: "port" },
+  { key: "path", label: "path" },
 ];
 
 function cellDiffers(row: Row, col: ColKey): boolean {
@@ -103,138 +110,261 @@ export function OriginMatrix() {
     <WidgetShell
       title="origin · scheme · host · port"
       measurements={`base · ${BASE.url}`}
+      captionTone="prominent"
       caption={
         row ? (
-          <span>
+          <span aria-live="off">
             <span style={{ color: tone, fontWeight: 500 }}>{decision}</span>
             {" — "}
             {row.caption}
           </span>
         ) : (
           <span>
-            Tap any row. Terracotta marks the component that moves it
-            cross-origin.
+            Tap any row. Terracotta marks the part that shifts the URL out of
+            your origin.
           </span>
         )
       }
     >
-      <HScroll ariaLabel="origin comparison matrix, 5 rows, scrollable">
+      {/* Mobile-first: stacked list of cards. Each card = url on its own line,
+          a one-line scheme/host/port/path diff string with the differing piece
+          in terracotta, and a verdict pill on the right. The full caption
+          surfaces in WidgetShell's caption slot when the row is focused/tapped.
+          At @container widget (min-width: 640px) the list flips to a table. */}
 
-        <table
-          className="w-full font-mono tabular-nums"
-          style={{
-            fontSize: "var(--text-small)",
-            borderCollapse: "collapse",
-            minWidth: "520px",
-          }}
-        >
-          <thead>
-            <tr style={{ color: "var(--color-text-muted)" }}>
-              <th className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal">
-                url
-              </th>
-              {COLS.map((c) => (
-                <th
-                  key={c.key}
-                  className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal"
+      {/* Base row (mobile). At desktop the thead carries the "base" row instead. */}
+      <div
+        className="bs-om-base flex flex-wrap items-baseline gap-x-[var(--spacing-sm)] gap-y-[var(--spacing-2xs)] pb-[var(--spacing-sm)] font-mono"
+        style={{
+          fontSize: "var(--text-small)",
+          color: "var(--color-text-muted)",
+          borderBottom: "1px dashed var(--color-rule)",
+        }}
+      >
+        <span style={{ minWidth: "4ch" }}>base</span>
+        <span>{BASE.url}</span>
+      </div>
+
+      {/* Stacked-list view (mobile / narrow). */}
+      <ul
+        className="bs-om-stack flex flex-col"
+        role="list"
+        aria-label="origin comparison, 5 rows"
+      >
+        {ROWS.map((r, i) => {
+          const active = i === focused;
+          return (
+            <li
+              key={`stack-${r.url}`}
+              role="button"
+              tabIndex={0}
+              onClick={() => setFocused(i)}
+              onFocus={() => setFocused(i)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setFocused(i);
+                }
+              }}
+              aria-label={`${r.url}: ${r.sameOrigin ? "same origin" : "cross-origin"}`}
+              className="cursor-pointer py-[var(--spacing-sm)] px-[var(--spacing-2xs)]"
+              style={{
+                background: active
+                  ? "color-mix(in oklab, var(--color-accent) 5%, transparent)"
+                  : "transparent",
+                transition: "background 160ms",
+                borderTop: "1px dashed var(--color-rule)",
+              }}
+            >
+              <div className="flex items-baseline justify-between gap-[var(--spacing-sm)]">
+                <span
+                  className="font-mono break-all"
+                  style={{ fontSize: "var(--text-small)" }}
                 >
-                  {c.label}
-                </th>
-              ))}
-              <th className="text-right py-[var(--spacing-xs)] font-normal">verdict</th>
-            </tr>
-            <tr aria-hidden>
-              <td
-                colSpan={6}
+                  {r.url}
+                </span>
+                <span
+                  className="font-mono shrink-0"
+                  style={{
+                    fontSize: "var(--text-small)",
+                    color: r.sameOrigin
+                      ? "var(--color-text)"
+                      : "var(--color-accent)",
+                    fontWeight: 500,
+                  }}
+                >
+                  {r.sameOrigin ? "same" : "cross"}
+                </span>
+              </div>
+              <div
+                className="mt-[var(--spacing-2xs)] font-mono flex flex-wrap gap-x-[var(--spacing-sm)]"
                 style={{
-                  borderTop: "1px dashed var(--color-rule)",
-                  paddingTop: 0,
-                  height: 1,
+                  fontSize: "var(--text-small)",
+                  color: "var(--color-text-muted)",
                 }}
-              />
-            </tr>
-            <tr>
+              >
+                {COLS.map((c) => {
+                  const differs = cellDiffers(r, c.key);
+                  return (
+                    <span
+                      key={c.key}
+                      style={{
+                        color: differs
+                          ? "var(--color-accent)"
+                          : "var(--color-text-muted)",
+                        fontWeight: differs ? 500 : 400,
+                      }}
+                    >
+                      <span
+                        style={{
+                          color: "var(--color-text-muted)",
+                          fontWeight: 400,
+                        }}
+                      >
+                        {c.label}:
+                      </span>{" "}
+                      {r[c.key]}
+                    </span>
+                  );
+                })}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Table view (desktop / wide). Same data, denser. */}
+      <table
+        className="bs-om-table w-full font-mono tabular-nums"
+        style={{
+          fontSize: "var(--text-small)",
+          borderCollapse: "collapse",
+        }}
+      >
+        <thead>
+          <tr style={{ color: "var(--color-text-muted)" }}>
+            <th className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal">
+              url
+            </th>
+            {COLS.map((c) => (
+              <th
+                key={c.key}
+                className="text-left py-[var(--spacing-xs)] pr-[var(--spacing-sm)] font-normal"
+              >
+                {c.label}
+              </th>
+            ))}
+            <th className="text-right py-[var(--spacing-xs)] font-normal">
+              verdict
+            </th>
+          </tr>
+          <tr aria-hidden>
+            <td
+              colSpan={6}
+              style={{
+                borderTop: "1px dashed var(--color-rule)",
+                paddingTop: 0,
+                height: 1,
+              }}
+            />
+          </tr>
+          <tr>
+            <td
+              className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              base
+            </td>
+            {COLS.map((c) => (
               <td
+                key={c.key}
                 className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
                 style={{ color: "var(--color-text-muted)" }}
               >
-                base
+                {BASE[c.key]}
               </td>
-              {COLS.map((c) => (
-                <td
-                  key={c.key}
-                  className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
-                  style={{ color: "var(--color-text-muted)" }}
-                >
-                  {BASE[c.key]}
-                </td>
-              ))}
-              <td
-                className="py-[var(--spacing-xs)] text-right"
-                style={{ color: "var(--color-text-muted)" }}
+            ))}
+            <td
+              className="py-[var(--spacing-xs)] text-right"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              —
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map((r, i) => {
+            const active = i === focused;
+            return (
+              <tr
+                key={`table-${r.url}`}
+                role="button"
+                onClick={() => setFocused(i)}
+                onFocus={() => setFocused(i)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setFocused(i);
+                  }
+                }}
+                tabIndex={0}
+                aria-label={`${r.url}: ${r.sameOrigin ? "same origin" : "cross-origin"}`}
+                style={{
+                  cursor: "pointer",
+                  background: active
+                    ? "color-mix(in oklab, var(--color-accent) 5%, transparent)"
+                    : "transparent",
+                  transition: "background 160ms",
+                  borderTop: "1px dashed var(--color-rule)",
+                }}
               >
-                —
-              </td>
-            </tr>
-          </thead>
-          <tbody>
-            {ROWS.map((r, i) => {
-              const active = i === focused;
-              return (
-                <tr
-                  key={r.url}
-                  onMouseEnter={() => setFocused(i)}
-                  onFocus={() => setFocused(i)}
-                  tabIndex={0}
-                  aria-label={`${r.url}: ${r.sameOrigin ? "same origin" : "cross-origin"}`}
+                <td className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]">
+                  {r.url}
+                </td>
+                {COLS.map((c) => {
+                  const differs = cellDiffers(r, c.key);
+                  return (
+                    <td
+                      key={c.key}
+                      className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
+                      style={{
+                        color: differs
+                          ? "var(--color-accent)"
+                          : "var(--color-text-muted)",
+                        fontWeight: differs ? 500 : 400,
+                      }}
+                    >
+                      {r[c.key]}
+                      {differs ? (
+                        <span
+                          aria-hidden
+                          style={{
+                            marginLeft: 4,
+                            color: "var(--color-accent)",
+                          }}
+                        >
+                          ✗
+                        </span>
+                      ) : null}
+                    </td>
+                  );
+                })}
+                <td
+                  className="py-[var(--spacing-xs)] text-right"
                   style={{
-                    cursor: "pointer",
-                    background: active
-                      ? "color-mix(in oklab, var(--color-accent) 5%, transparent)"
-                      : "transparent",
-                    transition: "background 160ms",
-                    borderTop: "1px dashed var(--color-rule)",
+                    color: r.sameOrigin
+                      ? "var(--color-text)"
+                      : "var(--color-accent)",
+                    fontWeight: 500,
                   }}
                 >
-                  <td className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]">{r.url}</td>
-                  {COLS.map((c) => {
-                    const differs = cellDiffers(r, c.key);
-                    return (
-                      <td
-                        key={c.key}
-                        className="py-[var(--spacing-xs)] pr-[var(--spacing-sm)]"
-                        style={{
-                          color: differs ? "var(--color-accent)" : "var(--color-text-muted)",
-                          fontWeight: differs ? 500 : 400,
-                        }}
-                      >
-                        {r[c.key]}
-                        {differs ? (
-                          <span
-                            aria-hidden
-                            style={{ marginLeft: 4, color: "var(--color-accent)" }}
-                          >
-                            ✗
-                          </span>
-                        ) : null}
-                      </td>
-                    );
-                  })}
-                  <td
-                    className="py-[var(--spacing-xs)] text-right"
-                    style={{
-                      color: r.sameOrigin ? "var(--color-text)" : "var(--color-accent)",
-                      fontWeight: 500,
-                    }}
-                  >
-                    {r.sameOrigin ? "same" : "cross"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </HScroll>
+                  {r.sameOrigin ? "same" : "cross"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </WidgetShell>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -76,6 +76,8 @@ export function RequestClassifier({
   const [contentType, setContentType] = useState<ContentType>(initialContentType);
   const [auth, setAuth] = useState(initialAuth);
   const [custom, setCustom] = useState(initialCustom);
+  const [touched, setTouched] = useState(false);
+  const touch = () => setTouched(true);
 
   const verdict = useMemo(
     () => classify(method, contentType, auth, custom),
@@ -86,12 +88,15 @@ export function RequestClassifier({
 
   return (
     <WidgetShell
-      title="preflight classifier · does this OPTIONS first?"
+      title="preflight classifier · request shape decides"
       measurements={verdict.preflight ? "OPTIONS first" : "sends directly"}
+      captionTone="prominent"
       caption={
-        verdict.preflight
-          ? "OPTIONS goes first. If the server doesn't approve it, the real request never leaves your browser."
-          : "Safelisted. The request goes straight out; only the response is gated."
+        !touched
+          ? "Toggle a method, a content-type, or a header. Watch the verdict — and the OPTIONS handshake when one fires."
+          : verdict.preflight
+            ? "OPTIONS goes first. If the server doesn't approve it, the real request never leaves your browser."
+            : "Safelisted. The request goes straight out; only the response is gated."
       }
     >
       <div className="flex flex-col gap-[var(--spacing-md)]">
@@ -101,13 +106,19 @@ export function RequestClassifier({
             label="method"
             options={METHODS}
             value={method}
-            onChange={setMethod}
+            onChange={(v) => {
+              touch();
+              setMethod(v);
+            }}
           />
           <SegmentedRow
             label="Content-Type"
             options={CONTENT_TYPES}
             value={contentType}
-            onChange={setContentType}
+            onChange={(v) => {
+              touch();
+              setContentType(v);
+            }}
             disabled={ctDisabled}
             disabledHint={ctDisabled ? "(no body on this method)" : undefined}
           />
@@ -122,18 +133,24 @@ export function RequestClassifier({
                 minWidth: "12ch",
               }}
             >
-              headers
+              extra headers
             </span>
             <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
               <Toggle
                 label="Authorization"
                 pressed={auth}
-                onToggle={() => setAuth((v) => !v)}
+                onToggle={() => {
+                  touch();
+                  setAuth((v) => !v);
+                }}
               />
               <Toggle
                 label="X-Custom"
                 pressed={custom}
-                onToggle={() => setCustom((v) => !v)}
+                onToggle={() => {
+                  touch();
+                  setCustom((v) => !v);
+                }}
               />
             </div>
           </div>

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
+import { motion } from "motion/react";
 import { PRESS, SPRING } from "@/lib/motion";
 import { WidgetShell } from "./WidgetShell";
 
@@ -20,14 +20,23 @@ const CONTENT_TYPES: ContentType[] = [
 
 const SAFE_METHODS = new Set<Method>(["GET", "POST"]);
 
-type Reason = { text: string; key: string };
+type Reason = { text: string; key: string; tone?: "default" | "credentials" };
+
+type Verdict = {
+  preflight: boolean;
+  /** True iff a cookie / credentialed request would itself be rejected
+   *  (e.g. the server's `*` allow-origin is illegal once credentials ride). */
+  credentialsBlock: boolean;
+  reasons: Reason[];
+};
 
 function classify(
   method: Method,
   contentType: ContentType,
   auth: boolean,
   custom: boolean,
-): { preflight: boolean; reasons: Reason[] } {
+  credentials: boolean,
+): Verdict {
   const reasons: Reason[] = [];
   if (!SAFE_METHODS.has(method)) {
     reasons.push({
@@ -56,7 +65,18 @@ function classify(
       text: `Custom headers (X-*, anything non-standard) force a preflight.`,
     });
   }
-  return { preflight: reasons.length > 0, reasons };
+  if (credentials) {
+    reasons.push({
+      key: "creds",
+      tone: "credentials",
+      text: `credentials: 'include' — the response must carry Access-Control-Allow-Credentials: true, and Allow-Origin can't be the wildcard *.`,
+    });
+  }
+  return {
+    preflight: reasons.some((r) => r.tone !== "credentials"),
+    credentialsBlock: credentials,
+    reasons,
+  };
 }
 
 type Props = {
@@ -64,6 +84,7 @@ type Props = {
   initialContentType?: ContentType;
   initialAuth?: boolean;
   initialCustom?: boolean;
+  initialCredentials?: boolean;
 };
 
 export function RequestClassifier({
@@ -71,36 +92,60 @@ export function RequestClassifier({
   initialContentType = "text/plain",
   initialAuth = false,
   initialCustom = false,
+  initialCredentials = false,
 }: Props) {
   const [method, setMethod] = useState<Method>(initialMethod);
   const [contentType, setContentType] = useState<ContentType>(initialContentType);
   const [auth, setAuth] = useState(initialAuth);
   const [custom, setCustom] = useState(initialCustom);
+  const [credentials, setCredentials] = useState(initialCredentials);
   const [touched, setTouched] = useState(false);
   const touch = () => setTouched(true);
 
   const verdict = useMemo(
-    () => classify(method, contentType, auth, custom),
-    [method, contentType, auth, custom],
+    () => classify(method, contentType, auth, custom, credentials),
+    [method, contentType, auth, custom, credentials],
   );
 
   const ctDisabled = method === "GET" || method === "DELETE";
 
+  const measurements = verdict.preflight
+    ? credentials
+      ? "OPTIONS first · creds gated"
+      : "OPTIONS first"
+    : credentials
+      ? "sends directly · creds gated"
+      : "sends directly";
+
+  const caption = !touched
+    ? "Watch the request shape decide. Toggle a method, a content-type, or a header — flip credentials to add the cookie constraint."
+    : verdict.preflight
+      ? credentials
+        ? "OPTIONS goes first AND the response must opt into credentials. Either step failing keeps the body out of JS."
+        : "OPTIONS goes first. If the server doesn't approve it, the real request never leaves your browser."
+      : credentials
+        ? "Sent directly — but cookies only ride if the response carries Allow-Credentials: true and a named origin (no wildcard)."
+        : "Safelisted. The request goes straight out; only the response is gated.";
+
   return (
     <WidgetShell
       title="preflight classifier · request shape decides"
-      measurements={verdict.preflight ? "OPTIONS first" : "sends directly"}
+      measurements={measurements}
       captionTone="prominent"
-      caption={
-        !touched
-          ? "Toggle a method, a content-type, or a header. Watch the verdict — and the OPTIONS handshake when one fires."
-          : verdict.preflight
-            ? "OPTIONS goes first. If the server doesn't approve it, the real request never leaves your browser."
-            : "Safelisted. The request goes straight out; only the response is gated."
-      }
+      caption={caption}
     >
-      <div className="flex flex-col gap-[var(--spacing-md)]">
-        {/* Controls */}
+      {/* Fixed-frame grid: every row reserves its maximum height upfront so the
+          container never resizes when verdict / reasons / preflight panel
+          change. All transitions are color-, opacity-, or transform-only.
+          R6 hard-rule compliance. */}
+      <div
+        className="grid"
+        style={{
+          gap: "var(--spacing-md)",
+          gridTemplateRows: "auto auto auto",
+        }}
+      >
+        {/* Row A — controls */}
         <div className="grid gap-[var(--spacing-sm)]" style={{ gridTemplateColumns: "minmax(0, 1fr)" }}>
           <SegmentedRow
             label="method"
@@ -128,10 +173,7 @@ export function RequestClassifier({
           >
             <span
               className="bs-classifier-label font-mono"
-              style={{
-                color: "var(--color-text-muted)",
-                minWidth: "12ch",
-              }}
+              style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
             >
               extra headers
             </span>
@@ -154,9 +196,30 @@ export function RequestClassifier({
               />
             </div>
           </div>
+          <div
+            className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+            style={{ fontSize: "var(--text-ui)" }}
+          >
+            <span
+              className="bs-classifier-label font-mono"
+              style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
+            >
+              credentials
+            </span>
+            <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
+              <CredentialsSwitch
+                value={credentials}
+                onChange={(v) => {
+                  touch();
+                  setCredentials(v);
+                }}
+              />
+            </div>
+          </div>
         </div>
 
-        {/* Verdict pill + reasons */}
+        {/* Row B — verdict pill + reasons.
+            Reserves space for up-to-five reasons so list growth is opacity-only. */}
         <div
           className="rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
           style={{
@@ -164,6 +227,11 @@ export function RequestClassifier({
               ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
               : "color-mix(in oklab, var(--color-surface) 60%, transparent)",
             border: `1px solid ${verdict.preflight ? "var(--color-accent)" : "var(--color-rule)"}`,
+            transition: "background 220ms ease, border-color 220ms ease",
+            // Reserve enough vertical space for the verdict line + up to 5
+            // reason lines so the frame never reflows. Calibrated to the worst
+            // case (PUT + json + Authorization + X-Custom + credentials).
+            minHeight: "11.5em",
           }}
         >
           <div
@@ -179,111 +247,79 @@ export function RequestClassifier({
               ? "preflighted · OPTIONS sent first"
               : "simple request · no preflight"}
           </div>
-          <AnimatePresence initial={false}>
-            {verdict.reasons.length > 0 ? (
-              <motion.ul
-                className="mt-[var(--spacing-sm)] flex flex-col gap-[var(--spacing-2xs)] font-sans"
-                style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)" }}
+          <ul
+            className="mt-[var(--spacing-sm)] flex flex-col gap-[var(--spacing-2xs)] font-sans"
+            style={{
+              fontSize: "var(--text-small)",
+              color: "var(--color-text-muted)",
+              listStyle: "none",
+            }}
+          >
+            {verdict.reasons.map((r) => (
+              <motion.li
+                key={r.key}
+                className="flex gap-[var(--spacing-xs)]"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={SPRING.smooth}
+                layout={false}
               >
-                {verdict.reasons.map((r) => (
-                  <li key={r.key} className="flex gap-[var(--spacing-xs)]">
-                    <span style={{ color: "var(--color-accent)" }} aria-hidden>
-                      ·
-                    </span>
-                    <span>{r.text}</span>
-                  </li>
-                ))}
-              </motion.ul>
-            ) : null}
-          </AnimatePresence>
+                <span
+                  style={{
+                    color:
+                      r.tone === "credentials"
+                        ? "var(--color-accent)"
+                        : "var(--color-accent)",
+                  }}
+                  aria-hidden
+                >
+                  {r.tone === "credentials" ? "▴" : "·"}
+                </span>
+                <span>{r.text}</span>
+              </motion.li>
+            ))}
+          </ul>
         </div>
 
-        {/* Preflight exchange reveal */}
-        <AnimatePresence initial={false}>
-          {verdict.preflight ? (
-            <motion.div
-              key="preflight"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 8 }}
-              transition={SPRING.smooth}
-              className="rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-md)] font-mono"
-              style={{
-                background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
-                border: "1px dashed var(--color-rule)",
-                fontSize: "var(--text-small)",
-                lineHeight: 1.7,
-              }}
-            >
-              <div style={{ color: "var(--color-text-muted)" }}>
-                <span className="sr-only">step 1 of 3: </span>
-                <span aria-hidden>①</span> browser → server
-              </div>
-              <div>
-                OPTIONS /me HTTP/1.1
-                <br />
-                Origin: https://app.example.com
-                <br />
-                Access-Control-Request-Method: {method}
-                {(auth || custom || contentType === "application/json") && (
-                  <>
-                    <br />
-                    Access-Control-Request-Headers:{" "}
-                    {[
-                      contentType === "application/json" ? "content-type" : null,
-                      auth ? "authorization" : null,
-                      custom ? "x-custom" : null,
-                    ]
-                      .filter(Boolean)
-                      .join(", ")}
-                  </>
-                )}
-              </div>
-              <div
-                className="mt-[var(--spacing-sm)]"
-                style={{ color: "var(--color-text-muted)" }}
-              >
-                <span className="sr-only">step 2 of 3: </span>
-                <span aria-hidden>②</span> server → browser
-              </div>
-              <div>
-                HTTP/1.1 204 No Content
-                <br />
-                Access-Control-Allow-Origin: https://app.example.com
-                <br />
-                Access-Control-Allow-Methods: {method}
-                {(auth || custom || contentType === "application/json") && (
-                  <>
-                    <br />
-                    Access-Control-Allow-Headers:{" "}
-                    {[
-                      contentType === "application/json" ? "Content-Type" : null,
-                      auth ? "Authorization" : null,
-                      custom ? "X-Custom" : null,
-                    ]
-                      .filter(Boolean)
-                      .join(", ")}
-                  </>
-                )}
-              </div>
-              <div
-                className="mt-[var(--spacing-sm)]"
-                style={{ color: "var(--color-text-muted)" }}
-              >
-                <span className="sr-only">step 3 of 3: </span>
-                <span aria-hidden>③</span> real {method} request proceeds
-              </div>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
+        {/* Row C — fixed-height detail panel.
+            Always rendered at the SAME height. Content swaps via opacity-only
+            cross-fade so the frame can't shift. Three states:
+              · default (no preflight, no creds): a quiet "no handshake" stub
+              · preflight on, creds off: the OPTIONS↔200 handshake
+              · creds on (with or without preflight): the same handshake but
+                with Allow-Credentials lines added; if no preflight, the
+                "what creds add to the response headers" annotation. */}
+        <div
+          className="relative rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-md)] font-mono"
+          style={{
+            background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+            border: "1px dashed var(--color-rule)",
+            fontSize: "var(--text-small)",
+            lineHeight: 1.7,
+            // Reserve enough space for the longest possible exchange (preflight
+            // with both credentials + json + auth + x-custom). Pinned so
+            // cross-fades don't reflow surrounding prose.
+            minHeight: "16em",
+          }}
+        >
+          <PreflightExchange
+            method={method}
+            auth={auth}
+            custom={custom}
+            credentials={credentials}
+            contentType={contentType}
+            preflight={verdict.preflight}
+          />
+        </div>
       </div>
     </WidgetShell>
   );
 }
+
+/* -------------------------------------------------------------------------- */
+/*  Sub-components                                                            */
+/* -------------------------------------------------------------------------- */
 
 function SegmentedRow<T extends string>({
   label,
@@ -307,10 +343,7 @@ function SegmentedRow<T extends string>({
     >
       <span
         className="bs-classifier-label font-mono"
-        style={{
-          color: "var(--color-text-muted)",
-          minWidth: "12ch",
-        }}
+        style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
       >
         {label}
       </span>
@@ -388,5 +421,220 @@ function Toggle({
       </span>
       {label}
     </motion.button>
+  );
+}
+
+/** Two-state switch: include / omit. Sized to match the segmented controls
+ *  above so the row doesn't visually rebalance when toggled. */
+function CredentialsSwitch({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  const opts: { label: string; v: boolean }[] = [
+    { label: "omit", v: false },
+    { label: "include", v: true },
+  ];
+  return (
+    <div role="radiogroup" aria-label="credentials" className="flex items-center gap-[var(--spacing-2xs)]">
+      {opts.map((o) => {
+        const active = o.v === value;
+        return (
+          <motion.button
+            key={o.label}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(o.v)}
+            className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] min-h-[44px] inline-flex items-center font-mono transition-colors hover:text-[color:var(--color-accent)]"
+            style={{
+              fontSize: "var(--text-small)",
+              color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+              background: active
+                ? "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                : "transparent",
+              border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+            }}
+            {...PRESS}
+          >
+            {o.label}
+          </motion.button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Renders the OPTIONS↔200 exchange when preflight fires; renders the cookies-
+ *  ride-along annotation when only credentials are on; renders the quiet
+ *  "no handshake" stub otherwise. All three swap inside the SAME fixed-height
+ *  frame via opacity-only cross-fade. */
+function PreflightExchange({
+  method,
+  auth,
+  custom,
+  credentials,
+  contentType,
+  preflight,
+}: {
+  method: Method;
+  auth: boolean;
+  custom: boolean;
+  credentials: boolean;
+  contentType: ContentType;
+  preflight: boolean;
+}) {
+  const requestHeaders = [
+    contentType === "application/json" ? "content-type" : null,
+    auth ? "authorization" : null,
+    custom ? "x-custom" : null,
+  ].filter(Boolean) as string[];
+  const responseHeaders = [
+    contentType === "application/json" ? "Content-Type" : null,
+    auth ? "Authorization" : null,
+    custom ? "X-Custom" : null,
+  ].filter(Boolean) as string[];
+
+  // We render all three states on top of each other (absolutely positioned)
+  // and animate opacity. This guarantees zero layout shift across states.
+  const showPreflight = preflight;
+  const showCredsOnly = !preflight && credentials;
+  const showQuiet = !preflight && !credentials;
+
+  return (
+    <>
+      {/* Preflight exchange */}
+      <motion.div
+        className="absolute inset-0 px-[var(--spacing-md)] py-[var(--spacing-md)]"
+        initial={false}
+        animate={{ opacity: showPreflight ? 1 : 0 }}
+        transition={SPRING.smooth}
+        style={{ pointerEvents: showPreflight ? "auto" : "none" }}
+        aria-hidden={!showPreflight}
+      >
+        <div style={{ color: "var(--color-text-muted)" }}>
+          <span className="sr-only">step 1 of 3: </span>
+          <span aria-hidden>①</span> browser → server
+        </div>
+        <div>
+          OPTIONS /me HTTP/1.1
+          <br />
+          Origin: https://app.example.com
+          <br />
+          Access-Control-Request-Method: {method}
+          {requestHeaders.length > 0 && (
+            <>
+              <br />
+              Access-Control-Request-Headers: {requestHeaders.join(", ")}
+            </>
+          )}
+        </div>
+        <div className="mt-[var(--spacing-sm)]" style={{ color: "var(--color-text-muted)" }}>
+          <span className="sr-only">step 2 of 3: </span>
+          <span aria-hidden>②</span> server → browser
+        </div>
+        <div>
+          HTTP/1.1 204 No Content
+          <br />
+          Access-Control-Allow-Origin:{" "}
+          {credentials ? (
+            <span style={{ color: "var(--color-accent)" }}>https://app.example.com</span>
+          ) : (
+            "https://app.example.com"
+          )}
+          <br />
+          Access-Control-Allow-Methods: {method}
+          {responseHeaders.length > 0 && (
+            <>
+              <br />
+              Access-Control-Allow-Headers: {responseHeaders.join(", ")}
+            </>
+          )}
+          {credentials && (
+            <>
+              <br />
+              <span style={{ color: "var(--color-accent)" }}>
+                Access-Control-Allow-Credentials: true
+              </span>
+            </>
+          )}
+        </div>
+        <div className="mt-[var(--spacing-sm)]" style={{ color: "var(--color-text-muted)" }}>
+          <span className="sr-only">step 3 of 3: </span>
+          <span aria-hidden>③</span> real {method} request proceeds
+          {credentials && (
+            <span style={{ color: "var(--color-accent)" }}> · with cookies</span>
+          )}
+        </div>
+      </motion.div>
+
+      {/* Credentials-only annotation (no preflight, but cookies ride) */}
+      <motion.div
+        className="absolute inset-0 px-[var(--spacing-md)] py-[var(--spacing-md)]"
+        initial={false}
+        animate={{ opacity: showCredsOnly ? 1 : 0 }}
+        transition={SPRING.smooth}
+        style={{ pointerEvents: showCredsOnly ? "auto" : "none" }}
+        aria-hidden={!showCredsOnly}
+      >
+        <div style={{ color: "var(--color-text-muted)" }}>
+          <span aria-hidden>·</span> request goes directly with cookies attached
+        </div>
+        <div className="mt-[var(--spacing-sm)]">
+          {method} /me HTTP/1.1
+          <br />
+          Origin: https://app.example.com
+          <br />
+          Cookie: session=abc123
+        </div>
+        <div className="mt-[var(--spacing-sm)]" style={{ color: "var(--color-text-muted)" }}>
+          <span aria-hidden>·</span> response must carry, exactly:
+        </div>
+        <div>
+          HTTP/1.1 200 OK
+          <br />
+          <span style={{ color: "var(--color-accent)" }}>
+            Access-Control-Allow-Origin: https://app.example.com
+          </span>
+          <br />
+          <span style={{ color: "var(--color-accent)" }}>
+            Access-Control-Allow-Credentials: true
+          </span>
+        </div>
+        <div
+          className="mt-[var(--spacing-sm)] font-sans"
+          style={{ fontSize: "var(--text-small)", color: "var(--color-text-muted)", lineHeight: 1.5 }}
+        >
+          Wildcard <code>*</code> origin is illegal once credentials ride. Both sides have to opt in by name.
+        </div>
+      </motion.div>
+
+      {/* Quiet stub — no preflight, no credentials */}
+      <motion.div
+        className="absolute inset-0 px-[var(--spacing-md)] py-[var(--spacing-md)] flex items-center"
+        initial={false}
+        animate={{ opacity: showQuiet ? 1 : 0 }}
+        transition={SPRING.smooth}
+        style={{ pointerEvents: showQuiet ? "auto" : "none" }}
+        aria-hidden={!showQuiet}
+      >
+          <div style={{ color: "var(--color-text-muted)" }}>
+            <span aria-hidden>·</span> no handshake — request leaves directly. Only the response is gated.
+            <br />
+            <br />
+            {method} /me HTTP/1.1
+            <br />
+            Origin: https://app.example.com
+            {contentType !== "text/plain" && method !== "GET" && method !== "DELETE" && (
+              <>
+                <br />
+                Content-Type: {contentType}
+              </>
+            )}
+          </div>
+      </motion.div>
+    </>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -60,7 +60,7 @@ const STEPS: Step[] = [
  */
 type Beat = {
   /** Arrow direction: which lane the connector points TO. */
-  dir: "right" | "left" | "self-server";
+  dir: "right" | "left" | "self-server" | "self-browser";
   /** Compact token displayed on the connector. */
   token: string;
   /** Tone for color treatment. */
@@ -72,7 +72,10 @@ const BEATS: Beat[] = [
   { dir: "right", token: "GET /me · Origin" }, // step 2: request on the wire
   { dir: "self-server", token: "handler runs", tone: "muted" }, // step 3
   { dir: "left", token: "200 OK · body" }, // step 4: response back
-  { dir: "left", token: "verdict", tone: "accent" }, // step 5: gatekeeper
+  // step 5: the verdict is browser-internal — no wire transmission.
+  // Self-loop on the BROWSER lane mirrors beat 3's self-loop on the server,
+  // and reinforces the post's thesis: the browser is the enforcer.
+  { dir: "self-browser", token: "ACAO match?", tone: "accent" },
 ];
 
 type Props = {
@@ -329,7 +332,7 @@ function Journey({
               markerEnd={arrowMarker}
             />
           );
-        } else {
+        } else if (beat.dir === "self-server") {
           // self-loop on the server lane: small horizontal arc to the right of
           // LANE_RIGHT_X and back, terminating on the lane.
           const xs = LANE_RIGHT_X - CONNECTOR_INSET;
@@ -338,6 +341,22 @@ function Journey({
               d={`M ${xs} ${y - 8}
                   q 22 0 22 8
                   q 0 8 -22 8`}
+              fill="none"
+              stroke={tone}
+              strokeWidth={isCurrent ? 1.8 : 1.2}
+              markerEnd={arrowMarker}
+            />
+          );
+        } else {
+          // self-loop on the browser lane: mirror of self-server, on the left.
+          // Used for the verdict beat — encodes "browser decides internally,
+          // no wire transmission" — supports the post's thesis.
+          const xs = LANE_LEFT_X + CONNECTOR_INSET;
+          connector = (
+            <path
+              d={`M ${xs} ${y - 8}
+                  q -22 0 -22 8
+                  q 0 8 22 8`}
               fill="none"
               stroke={tone}
               strokeWidth={isCurrent ? 1.8 : 1.2}

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -53,59 +53,26 @@ const STEPS: Step[] = [
   },
 ];
 
-const LANE_LABELS = ["JS", "browser", "network", "server"] as const;
-
-type Actor = 0 | 1 | 2 | 3;
-
-type Message = {
-  /** Earliest step at which this message is visible. */
-  from: number;
-  /** Lifelines: 0 = JS, 1 = browser, 2 = network, 3 = server */
-  fromCol: Actor;
-  toCol: Actor;
-  label: string;
-  shortLabel?: string;
+/* Beats 1..5 each correspond to STEPS[1..5]. Each beat is one horizontal
+ * connector between the two lanes (browser-lane on the left, server-lane on
+ * the right) — direction is encoded in `dir`, which determines arrow head
+ * placement. Beat 3 is a self-loop on the server lane (handler runs locally).
+ */
+type Beat = {
+  /** Arrow direction: which lane the connector points TO. */
+  dir: "right" | "left" | "self-server";
+  /** Compact token displayed on the connector. */
+  token: string;
+  /** Tone for color treatment. */
   tone?: "default" | "accent" | "muted";
 };
 
-const MESSAGES: Message[] = [
-  {
-    from: 1,
-    fromCol: 0,
-    toCol: 1,
-    label: "fetch(url)",
-    shortLabel: "fetch",
-  },
-  {
-    from: 2,
-    fromCol: 1,
-    toCol: 3,
-    label: "GET /me · Origin: app.example.com",
-    shortLabel: "GET /me",
-  },
-  {
-    from: 3,
-    fromCol: 3,
-    toCol: 3,
-    label: "handler runs",
-    shortLabel: "handler",
-    tone: "muted",
-  },
-  {
-    from: 4,
-    fromCol: 3,
-    toCol: 1,
-    label: "200 OK · body",
-    shortLabel: "200 OK",
-  },
-  {
-    from: 5,
-    fromCol: 1,
-    toCol: 0,
-    label: "verdict (allow-origin?)",
-    shortLabel: "verdict",
-    tone: "accent",
-  },
+const BEATS: Beat[] = [
+  { dir: "right", token: "fetch(url)" }, // step 1: JS in browser → server-bound
+  { dir: "right", token: "GET /me · Origin" }, // step 2: request on the wire
+  { dir: "self-server", token: "handler runs", tone: "muted" }, // step 3
+  { dir: "left", token: "200 OK · body" }, // step 4: response back
+  { dir: "left", token: "verdict", tone: "accent" }, // step 5: gatekeeper
 ];
 
 type Props = {
@@ -156,9 +123,10 @@ export function RequestJourney({
 }
 
 /* -------------------------------------------------------------------------- */
-/*  Single mobile-first canvas — horizontal lifelines, time flows L→R.        */
-/*  Authoring viewport is ~340 units wide; SVG scales up via width:100% +     */
-/*  viewBox. Replaces the prior wide/narrow dual-render trick.                */
+/*  Mobile-first numbered lane-pair. Two short vertical lanes (browser left,  */
+/*  server right). Each beat is a horizontal connector between them — arrow   */
+/*  direction is unambiguous because connectors are strictly horizontal.      */
+/*  Time flows top-to-bottom. Authored at 320 viewport units; SVG scales up.  */
 /* -------------------------------------------------------------------------- */
 
 function Journey({
@@ -170,25 +138,20 @@ function Journey({
   allow: boolean;
   current: Step;
 }) {
-  const WIDTH = 340;
-  const LEFT_PAD = 52;
-  const RIGHT_PAD = 14;
-  const TOP_PAD = 22;
-  const ROW_H = 38;
-  const ROWS = 4;
-  const LIFELINE_BOT = TOP_PAD + ROWS * ROW_H;
-  const LABEL_BAND = 48;
-  const DEVTOOLS_H = 60;
-  const HEIGHT = LIFELINE_BOT + LABEL_BAND + DEVTOOLS_H + 14;
-  const rowY = (i: number) => TOP_PAD + i * ROW_H + ROW_H / 2;
+  const WIDTH = 320;
+  const TOP_PAD = 28;
+  const BEAT_H = 46;
+  const BEATS_COUNT = BEATS.length;
+  const LANES_BOT = TOP_PAD + BEATS_COUNT * BEAT_H + 8;
+  const DEVTOOLS_GAP = 16;
+  const DEVTOOLS_H = 64;
+  const HEIGHT = LANES_BOT + DEVTOOLS_GAP + DEVTOOLS_H + 12;
 
-  const timelineW = WIDTH - LEFT_PAD - RIGHT_PAD;
-  const msgX = (i: number) =>
-    LEFT_PAD +
-    20 +
-    (i * (timelineW - 32)) / Math.max(MESSAGES.length - 1, 1);
+  const LANE_LEFT_X = 56; // browser lane center
+  const LANE_RIGHT_X = WIDTH - 56; // server lane center
+  const CONNECTOR_INSET = 12; // gap between lane glyph and connector tip
 
-  const lastX = msgX(MESSAGES.length - 1);
+  const beatY = (i: number) => TOP_PAD + i * BEAT_H + BEAT_H / 2;
   const showDiscard = step >= 5 && !allow;
 
   return (
@@ -205,9 +168,9 @@ function Journey({
           viewBox="0 0 10 10"
           refX="9"
           refY="5"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto"
         >
           <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
         </marker>
@@ -216,178 +179,233 @@ function Journey({
           viewBox="0 0 10 10"
           refX="9"
           refY="5"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto"
         >
           <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
         </marker>
+        <marker
+          id="arrow-muted-rj"
+          viewBox="0 0 10 10"
+          refX="9"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto"
+        >
+          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
+        </marker>
       </defs>
 
-      {/* Actor rows: label on left + horizontal dashed lifeline */}
-      {LANE_LABELS.map((lane, i) => (
-        <g key={lane}>
-          <text
-            x={LEFT_PAD - 8}
-            y={rowY(i)}
-            textAnchor="end"
-            dominantBaseline="central"
-            fontFamily="var(--font-sans)"
-            fontSize={11}
-            fontWeight={500}
-            fill="var(--color-text-muted)"
-          >
-            {lane}
-          </text>
-          <line
-            x1={LEFT_PAD}
-            x2={WIDTH - RIGHT_PAD}
-            y1={rowY(i)}
-            y2={rowY(i)}
-            stroke="var(--color-rule)"
-            strokeWidth={1}
-            strokeDasharray="3 4"
-          />
-        </g>
-      ))}
-
-      {/* Time axis label */}
+      {/* Lane headers */}
       <text
-        x={LEFT_PAD}
-        y={TOP_PAD - 8}
+        x={LANE_LEFT_X}
+        y={TOP_PAD - 12}
+        textAnchor="middle"
         fontFamily="var(--font-sans)"
-        fontSize={10}
-        fill="var(--color-text-muted)"
+        fontSize={11}
+        fontWeight={600}
+        fill="var(--color-text)"
       >
-        time →
+        browser
+      </text>
+      <text
+        x={LANE_RIGHT_X}
+        y={TOP_PAD - 12}
+        textAnchor="middle"
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fontWeight={600}
+        fill="var(--color-text)"
+      >
+        server
       </text>
 
-      {/* Browser ↔ JS boundary band — at the last message column when the
-          request reaches the verdict step. */}
+      {/* Vertical lanes — dashed rules indicate "time" in each actor's frame */}
+      <line
+        x1={LANE_LEFT_X}
+        x2={LANE_LEFT_X}
+        y1={TOP_PAD - 4}
+        y2={LANES_BOT}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+      <line
+        x1={LANE_RIGHT_X}
+        x2={LANE_RIGHT_X}
+        y1={TOP_PAD - 4}
+        y2={LANES_BOT}
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+        strokeDasharray="3 4"
+      />
+
+      {/* Gatekeeper highlight — wraps the LEFT (browser) lane at the verdict
+          row. Reinforces the pedagogy: the gate lives on the browser side. */}
       {(() => {
         const gateActive = step >= 5;
-        const y0 = rowY(0);
-        const y1 = rowY(1);
+        const verdictY = beatY(BEATS_COUNT - 1);
         return (
           <motion.g
             initial={false}
-            animate={{ opacity: step >= 4 ? 1 : 0.3 }}
+            animate={{ opacity: step >= 4 ? 1 : 0 }}
             transition={SPRING.smooth}
           >
             <rect
-              x={lastX - 20}
-              y={y0 - 8}
-              width={40}
-              height={y1 - y0 + 16}
-              rx={3}
+              x={LANE_LEFT_X - 14}
+              y={verdictY - 16}
+              width={28}
+              height={32}
+              rx={4}
               fill={
                 gateActive
                   ? allow
                     ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                    : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
+                    : "color-mix(in oklab, var(--color-accent) 12%, transparent)"
                   : "transparent"
               }
-              stroke={gateActive ? "var(--color-accent)" : "var(--color-rule)"}
+              stroke="var(--color-accent)"
               strokeWidth={gateActive ? 1.4 : 1}
-              strokeDasharray={gateActive ? undefined : "3 3"}
+              strokeDasharray={gateActive ? undefined : "2 3"}
             />
           </motion.g>
         );
       })()}
 
-      {/* Messages as vertical arrows at their time-step column */}
-      {MESSAGES.map((m, idx) => {
-        const x = msgX(idx);
-        const visible = step >= m.from;
-        const isCurrent = step === m.from;
-        const past = step > m.from;
+      {/* Beats — one horizontal connector per row */}
+      {BEATS.map((beat, idx) => {
+        const beatStep = idx + 1; // BEATS[0] corresponds to STEPS[1]
+        const visible = step >= beatStep;
+        const isCurrent = step === beatStep;
+        const past = step > beatStep;
+        const y = beatY(idx);
 
         const tone =
-          m.tone === "accent"
+          beat.tone === "accent"
             ? "var(--color-accent)"
-            : m.tone === "muted"
+            : beat.tone === "muted"
               ? "var(--color-text-muted)"
               : isCurrent
                 ? "var(--color-accent)"
                 : "var(--color-text-muted)";
         const arrowMarker =
-          m.tone === "accent"
+          beat.tone === "accent"
             ? "url(#arrow-accent-rj)"
-            : "url(#arrow-default-rj)";
-        const token = m.shortLabel ?? m.label;
-        const isSelf = m.fromCol === m.toCol;
+            : beat.tone === "muted"
+              ? "url(#arrow-muted-rj)"
+              : "url(#arrow-default-rj)";
+
+        // Numbered badge sits on the browser side of the row, just outside the lane.
+        const badgeX = 18;
+
+        let connector: React.ReactNode;
+        if (beat.dir === "right") {
+          const x1 = LANE_LEFT_X + CONNECTOR_INSET;
+          const x2 = LANE_RIGHT_X - CONNECTOR_INSET;
+          connector = (
+            <line
+              x1={x1}
+              x2={x2}
+              y1={y}
+              y2={y}
+              stroke={tone}
+              strokeWidth={isCurrent ? 1.8 : 1.2}
+              markerEnd={arrowMarker}
+            />
+          );
+        } else if (beat.dir === "left") {
+          const x1 = LANE_RIGHT_X - CONNECTOR_INSET;
+          const x2 = LANE_LEFT_X + CONNECTOR_INSET;
+          connector = (
+            <line
+              x1={x1}
+              x2={x2}
+              y1={y}
+              y2={y}
+              stroke={tone}
+              strokeWidth={isCurrent ? 1.8 : 1.2}
+              markerEnd={arrowMarker}
+            />
+          );
+        } else {
+          // self-loop on the server lane: small horizontal arc to the right of
+          // LANE_RIGHT_X and back, terminating on the lane.
+          const xs = LANE_RIGHT_X - CONNECTOR_INSET;
+          connector = (
+            <path
+              d={`M ${xs} ${y - 8}
+                  q 22 0 22 8
+                  q 0 8 -22 8`}
+              fill="none"
+              stroke={tone}
+              strokeWidth={isCurrent ? 1.8 : 1.2}
+              markerEnd={arrowMarker}
+            />
+          );
+        }
 
         return (
           <motion.g
-            key={`m-${idx}`}
+            key={`beat-${idx}`}
             initial={false}
             animate={{
-              opacity: visible ? (isCurrent ? 1 : past ? 0.6 : 0) : 0,
+              opacity: visible ? (isCurrent ? 1 : past ? 0.55 : 0) : 0.12,
             }}
             transition={SPRING.smooth}
           >
-            {isSelf ? (
-              <path
-                d={`M ${x - 2} ${rowY(m.fromCol) - 8}
-                    q -12 0 -12 8
-                    q 0 8 12 8`}
-                fill="none"
-                stroke={tone}
-                strokeWidth={isCurrent ? 1.6 : 1}
-                markerEnd={arrowMarker}
-              />
-            ) : (
-              <line
-                x1={x}
-                x2={x}
-                y1={rowY(m.fromCol)}
-                y2={rowY(m.toCol)}
-                stroke={tone}
-                strokeWidth={isCurrent ? 1.8 : 1}
-                markerEnd={arrowMarker}
-              />
-            )}
-            {/* Short token above the topmost point of the arrow */}
+            {/* Step badge — circled number outside the browser lane */}
+            <circle
+              cx={badgeX}
+              cy={y}
+              r={9}
+              fill={isCurrent ? "var(--color-accent)" : "transparent"}
+              stroke={
+                isCurrent
+                  ? "var(--color-accent)"
+                  : past
+                    ? "var(--color-text-muted)"
+                    : "var(--color-rule)"
+              }
+              strokeWidth={1}
+            />
             <text
-              x={x}
-              y={Math.min(rowY(m.fromCol), rowY(m.toCol)) - 6}
+              x={badgeX}
+              y={y}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fontWeight={600}
+              fill={isCurrent ? "var(--color-bg)" : "var(--color-text-muted)"}
+            >
+              {beatStep}
+            </text>
+
+            {connector}
+
+            {/* Connector token — sits above the line, centered between the lanes */}
+            <text
+              x={(LANE_LEFT_X + LANE_RIGHT_X) / 2}
+              y={y - 6}
               textAnchor="middle"
               fontFamily="var(--font-mono)"
               fontSize={10}
               fill={isCurrent ? "var(--color-text)" : "var(--color-text-muted)"}
             >
-              {token}
+              {beat.token}
             </text>
           </motion.g>
         );
       })}
 
-      {/* Full current-message label below the lifelines where it has room */}
-      <motion.text
-        key={`label-${step}-${allow ? "a" : "b"}`}
-        x={WIDTH / 2}
-        y={LIFELINE_BOT + 22}
-        textAnchor="middle"
-        fontFamily="var(--font-mono)"
-        fontSize={11}
-        fill="var(--color-text)"
-        initial={{ opacity: 0, y: LIFELINE_BOT + 28 }}
-        animate={{ opacity: 1, y: LIFELINE_BOT + 22 }}
-        transition={SPRING.smooth}
-      >
-        {step === 5
-          ? allow
-            ? "resolve(Response)"
-            : "TypeError: Failed to fetch"
-          : MESSAGES[Math.min(step, MESSAGES.length - 1)]?.label ?? ""}
-      </motion.text>
-
-      {/* Compact DevTools panel */}
+      {/* Compact DevTools panel — preserves the discard-beat pedagogy */}
       <g>
         <rect
-          x={LEFT_PAD}
-          y={HEIGHT - DEVTOOLS_H - 4}
-          width={WIDTH - LEFT_PAD - RIGHT_PAD}
+          x={16}
+          y={LANES_BOT + DEVTOOLS_GAP}
+          width={WIDTH - 32}
           height={DEVTOOLS_H}
           rx={3}
           fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
@@ -395,8 +413,8 @@ function Journey({
           strokeWidth={1}
         />
         <text
-          x={LEFT_PAD + 8}
-          y={HEIGHT - DEVTOOLS_H + 14}
+          x={24}
+          y={LANES_BOT + DEVTOOLS_GAP + 16}
           fontFamily="var(--font-mono)"
           fontSize={10}
           fill="var(--color-text-muted)"
@@ -411,32 +429,32 @@ function Journey({
           transition={SPRING.smooth}
         >
           <text
-            x={LEFT_PAD + 8}
-            y={HEIGHT - DEVTOOLS_H + 30}
+            x={24}
+            y={LANES_BOT + DEVTOOLS_GAP + 32}
             fontFamily="var(--font-mono)"
             fontSize={10}
             fill="var(--color-text)"
           >
             Net · 200 OK · body
           </text>
-          {/* Discard beat — terracotta strikethrough across "body" when verdict is
-              fail. scaleX animates 0→1, transform-only per DESIGN §9. */}
           <motion.rect
-            x={LEFT_PAD + 8}
-            y={HEIGHT - DEVTOOLS_H + 26}
+            x={24}
+            y={LANES_BOT + DEVTOOLS_GAP + 28}
             width={120}
             height={1.5}
             fill="var(--color-accent)"
             initial={{ scaleX: 0 }}
             animate={{ scaleX: showDiscard ? 1 : 0 }}
             transition={SPRING.smooth}
-            style={{ transformOrigin: `${LEFT_PAD + 8}px ${HEIGHT - DEVTOOLS_H + 26}px` }}
+            style={{
+              transformOrigin: `24px ${LANES_BOT + DEVTOOLS_GAP + 28}px`,
+            }}
           />
         </motion.g>
 
         <motion.text
-          x={LEFT_PAD + 8}
-          y={HEIGHT - DEVTOOLS_H + 46}
+          x={24}
+          y={LANES_BOT + DEVTOOLS_GAP + 50}
           fontFamily="var(--font-mono)"
           fontSize={10}
           fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
@@ -444,7 +462,11 @@ function Journey({
           animate={{ opacity: step >= 5 ? 1 : 0.25 }}
           transition={SPRING.smooth}
         >
-          {allow ? "▸ Response {…}" : "✗ TypeError"}
+          {step >= 5
+            ? allow
+              ? "▸ Response {…}"
+              : "✗ TypeError: Failed to fetch"
+            : "▸ awaiting verdict"}
         </motion.text>
       </g>
     </svg>

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -17,7 +17,7 @@ const STEPS: Step[] = [
     id: "idle",
     label: "idle",
     caption: () =>
-      "Nothing has happened yet. JS is about to call fetch on a cross-origin URL.",
+      "Press ▸ to walk a cross-origin fetch from the browser to the server and back. Toggle the allow-origin header to compare verdicts.",
   },
   {
     id: "issue",
@@ -63,13 +63,50 @@ type Message = {
   /** Lifelines: 0 = JS, 1 = browser, 2 = network, 3 = server */
   fromCol: Actor;
   toCol: Actor;
-  /** Row offset (in wide layout). In narrow layout the message's x is
-   *  derived from its `from` step. */
-  y: number;
   label: string;
   shortLabel?: string;
   tone?: "default" | "accent" | "muted";
 };
+
+const MESSAGES: Message[] = [
+  {
+    from: 1,
+    fromCol: 0,
+    toCol: 1,
+    label: "fetch(url)",
+    shortLabel: "fetch",
+  },
+  {
+    from: 2,
+    fromCol: 1,
+    toCol: 3,
+    label: "GET /me · Origin: app.example.com",
+    shortLabel: "GET /me",
+  },
+  {
+    from: 3,
+    fromCol: 3,
+    toCol: 3,
+    label: "handler runs",
+    shortLabel: "handler",
+    tone: "muted",
+  },
+  {
+    from: 4,
+    fromCol: 3,
+    toCol: 1,
+    label: "200 OK · body",
+    shortLabel: "200 OK",
+  },
+  {
+    from: 5,
+    fromCol: 1,
+    toCol: 0,
+    label: "verdict (allow-origin?)",
+    shortLabel: "verdict",
+    tone: "accent",
+  },
+];
 
 type Props = {
   initialStep?: number;
@@ -77,7 +114,7 @@ type Props = {
 };
 
 export function RequestJourney({
-  initialStep = 5,
+  initialStep = 0,
   initialAllowOrigin = false,
 }: Props) {
   const [step, setStep] = useState(initialStep);
@@ -85,55 +122,11 @@ export function RequestJourney({
 
   const current = STEPS[Math.min(step, STEPS.length - 1)];
 
-  const buildMessages = (TOP: number): Message[] => [
-    {
-      from: 1,
-      fromCol: 0,
-      toCol: 1,
-      y: TOP + 22,
-      label: "fetch(url)",
-      shortLabel: "fetch",
-    },
-    {
-      from: 2,
-      fromCol: 1,
-      toCol: 3,
-      y: TOP + 62,
-      label: "GET /me · Origin: app.example.com",
-      shortLabel: "GET /me",
-    },
-    {
-      from: 3,
-      fromCol: 3,
-      toCol: 3,
-      y: TOP + 102,
-      label: "handler runs",
-      shortLabel: "handler",
-      tone: "muted",
-    },
-    {
-      from: 4,
-      fromCol: 3,
-      toCol: 1,
-      y: TOP + 142,
-      label: "200 OK · body",
-      shortLabel: "200 OK",
-    },
-    {
-      from: 5,
-      fromCol: 1,
-      toCol: 0,
-      y: TOP + 200,
-      label: allow ? "resolve(Response)" : "TypeError",
-      shortLabel: allow ? "resolve" : "TypeError",
-      tone: "accent",
-    },
-  ];
-
   return (
     <WidgetShell
-      title="request journey · same wire, different verdict"
+      title="request journey · the browser is the gatekeeper"
       measurements={`step ${step + 1}/${STEPS.length} · allow-origin ${allow ? "sent" : "missing"}`}
+      captionTone="prominent"
       caption={current.caption(allow)}
       controls={
         <div className="flex items-center gap-[var(--spacing-md)] flex-wrap">
@@ -142,7 +135,7 @@ export function RequestJourney({
             type="button"
             onClick={() => setAllow((v) => !v)}
             aria-pressed={allow}
-            aria-label={`Toggle Access-Control-Allow-Origin header — currently ${allow ? "sent" : "missing"}`}
+            aria-label="Toggle the Access-Control-Allow-Origin header"
             className="rounded-[var(--radius-sm)] px-[var(--spacing-sm)] py-[var(--spacing-2xs)] min-h-[44px] inline-flex items-center font-mono transition-colors"
             style={{
               fontSize: "var(--text-small)",
@@ -157,337 +150,46 @@ export function RequestJourney({
         </div>
       }
     >
-      {/* Two orientations rendered; CSS container query picks which shows.
-          Pure-CSS flip so there's no hydration mismatch and no JS work
-          beyond the existing state changes. */}
-      <div className="bs-rj-wide">
-        <WideJourney
-          step={step}
-          allow={allow}
-          current={current}
-          messages={buildMessages(40)}
-        />
-      </div>
-      <div className="bs-rj-narrow">
-        <NarrowJourney
-          step={step}
-          allow={allow}
-          current={current}
-          messages={buildMessages(40)}
-        />
-      </div>
+      <Journey step={step} allow={allow} current={current} />
     </WidgetShell>
   );
 }
 
 /* -------------------------------------------------------------------------- */
-/*                                 Wide layout                                */
+/*  Single mobile-first canvas — horizontal lifelines, time flows L→R.        */
+/*  Authoring viewport is ~340 units wide; SVG scales up via width:100% +     */
+/*  viewBox. Replaces the prior wide/narrow dual-render trick.                */
 /* -------------------------------------------------------------------------- */
 
-function WideJourney({
+function Journey({
   step,
   allow,
   current,
-  messages,
 }: {
   step: number;
   allow: boolean;
   current: Step;
-  messages: Message[];
 }) {
-  const WIDTH = 820;
-  const HEIGHT = 380;
-  const LEFT_PAD = 64;
-  const RIGHT_PAD = 32;
-  const TOP = 40;
-  const BOT = 260;
-  const COLS = 4;
-  const colX = (i: number) =>
-    LEFT_PAD + (i * (WIDTH - LEFT_PAD - RIGHT_PAD)) / (COLS - 1);
-
-  return (
-    <svg
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      width="100%"
-      style={{ maxWidth: WIDTH, height: "auto", display: "block" }}
-      role="img"
-      aria-label={`Request journey step ${step + 1}: ${current.label}`}
-    >
-      <defs>
-        <marker
-          id="arrow-default"
-          viewBox="0 0 10 10"
-          refX="9"
-          refY="5"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
-        >
-          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
-        </marker>
-        <marker
-          id="arrow-accent"
-          viewBox="0 0 10 10"
-          refX="9"
-          refY="5"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
-        >
-          <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-accent)" />
-        </marker>
-      </defs>
-
-      {/* Lifelines */}
-      {LANE_LABELS.map((lane, i) => (
-        <g key={lane}>
-          <text
-            x={colX(i)}
-            y={TOP - 12}
-            textAnchor="middle"
-            fontFamily="var(--font-sans)"
-            fontSize={13}
-            fill="var(--color-text-muted)"
-            fontWeight={500}
-          >
-            {lane}
-          </text>
-          <line
-            x1={colX(i)}
-            x2={colX(i)}
-            y1={TOP}
-            y2={BOT}
-            stroke="var(--color-rule)"
-            strokeWidth={1}
-            strokeDasharray="3 4"
-          />
-        </g>
-      ))}
-
-      {/* Gate */}
-      <motion.rect
-        x={colX(0) - 12}
-        y={TOP + 180}
-        width={colX(1) - colX(0) + 24}
-        height={36}
-        rx={3}
-        fill={
-          step >= 5
-            ? allow
-              ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-              : "color-mix(in oklab, var(--color-accent) 10%, transparent)"
-            : "transparent"
-        }
-        stroke={step >= 5 ? "var(--color-accent)" : "var(--color-rule)"}
-        strokeWidth={step >= 5 ? 1.5 : 1}
-        strokeDasharray={step >= 5 ? undefined : "4 3"}
-        initial={false}
-        animate={{ opacity: step >= 4 ? 1 : 0.35 }}
-        transition={SPRING.smooth}
-      />
-      <text
-        x={(colX(0) + colX(1)) / 2}
-        y={TOP + 176}
-        textAnchor="middle"
-        fontFamily="var(--font-mono)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
-      >
-        browser ↔ JS boundary
-      </text>
-
-      {/* Messages */}
-      {messages.map((m, idx) => {
-        const visible = step >= m.from;
-        const isCurrent = step === m.from;
-        const past = step > m.from;
-        const x1 = colX(m.fromCol);
-        const x2 = colX(m.toCol);
-        const isSelf = m.fromCol === m.toCol;
-
-        const tone =
-          m.tone === "accent"
-            ? "var(--color-accent)"
-            : m.tone === "muted"
-              ? "var(--color-text-muted)"
-              : isCurrent
-                ? "var(--color-accent)"
-                : "var(--color-text-muted)";
-        const stroke = tone;
-        const textFill =
-          m.tone === "accent"
-            ? "var(--color-accent)"
-            : isCurrent
-              ? "var(--color-text)"
-              : "var(--color-text-muted)";
-
-        const arrowMarker =
-          m.tone === "accent" ? "url(#arrow-accent)" : "url(#arrow-default)";
-
-        return (
-          <motion.g
-            key={`m-${idx}`}
-            initial={false}
-            animate={{ opacity: visible ? (isCurrent ? 1 : past ? 0.55 : 0) : 0 }}
-            transition={SPRING.smooth}
-          >
-            {isSelf ? (
-              <>
-                <path
-                  d={`M ${x1 + 4} ${m.y} q 28 0 28 16 q 0 16 -28 16`}
-                  fill="none"
-                  stroke={stroke}
-                  strokeWidth={isCurrent ? 1.6 : 1}
-                  markerEnd={arrowMarker}
-                />
-                <text
-                  x={x1 + 40}
-                  y={m.y + 20}
-                  fontFamily="var(--font-mono)"
-                  fontSize={12}
-                  fill={textFill}
-                >
-                  {m.label}
-                </text>
-              </>
-            ) : (
-              <>
-                <line
-                  x1={x1}
-                  x2={x2}
-                  y1={m.y}
-                  y2={m.y}
-                  stroke={stroke}
-                  strokeWidth={isCurrent ? 1.8 : 1}
-                  markerEnd={arrowMarker}
-                />
-                <text
-                  x={(x1 + x2) / 2}
-                  y={m.y - 6}
-                  textAnchor="middle"
-                  fontFamily="var(--font-mono)"
-                  fontSize={12}
-                  fill={textFill}
-                >
-                  {m.label}
-                </text>
-              </>
-            )}
-          </motion.g>
-        );
-      })}
-
-      {/* DevTools panel */}
-      <g>
-        <rect
-          x={LEFT_PAD}
-          y={BOT + 20}
-          width={WIDTH - LEFT_PAD - RIGHT_PAD}
-          height={76}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-        <text
-          x={LEFT_PAD + 12}
-          y={BOT + 36}
-          fontFamily="var(--font-mono)"
-          fontSize={11}
-          fill="var(--color-text-muted)"
-        >
-          DevTools
-        </text>
-        <text
-          x={LEFT_PAD + 12}
-          y={BOT + 58}
-          fontFamily="var(--font-mono)"
-          fontSize={12}
-          fill="var(--color-text)"
-        >
-          Network
-        </text>
-        <motion.text
-          x={LEFT_PAD + 100}
-          y={BOT + 58}
-          fontFamily="var(--font-mono)"
-          fontSize={12}
-          fill="var(--color-text)"
-          initial={false}
-          animate={{ opacity: step >= 4 ? 1 : 0.25 }}
-          transition={SPRING.smooth}
-        >
-          GET /me · 200 OK · 142 B
-        </motion.text>
-
-        <text
-          x={LEFT_PAD + 12}
-          y={BOT + 82}
-          fontFamily="var(--font-mono)"
-          fontSize={12}
-          fill="var(--color-text)"
-        >
-          Console
-        </text>
-        <motion.text
-          x={LEFT_PAD + 100}
-          y={BOT + 82}
-          fontFamily="var(--font-mono)"
-          fontSize={12}
-          fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
-          initial={false}
-          animate={{ opacity: step >= 5 ? 1 : 0.25 }}
-          transition={SPRING.smooth}
-        >
-          {allow ? "▸ Response { ok: true, … }" : "✗ TypeError: Failed to fetch"}
-        </motion.text>
-      </g>
-    </svg>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/*                               Narrow layout                                */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Horizontal-lifelines layout for narrow containers. Actors become rows
- * stacked vertically, time flows left-to-right, and each message is a
- * vertical connector at its own time-step column. Long message labels —
- * which would collide at narrow widths — are replaced by short tokens on
- * past / future messages; the full label only shows on the current step,
- * rendered below the timeline where it has room to breathe.
- */
-function NarrowJourney({
-  step,
-  allow,
-  current,
-  messages,
-}: {
-  step: number;
-  allow: boolean;
-  current: Step;
-  messages: Message[];
-}) {
-  // ViewBox widened from 380→420 and font-sizes bumped (10→12, 9→11) so that
-  // at the narrowest mobile widget canvas (~300 px), SVG text still renders
-  // above the --text-small floor. Per `interactive-components.md §3`.
-  const WIDTH = 420;
-  const LEFT_PAD = 76;
-  const RIGHT_PAD = 18;
-  const TOP_PAD = 24;
-  const ROW_H = 44;
+  const WIDTH = 340;
+  const LEFT_PAD = 52;
+  const RIGHT_PAD = 14;
+  const TOP_PAD = 22;
+  const ROW_H = 38;
   const ROWS = 4;
   const LIFELINE_BOT = TOP_PAD + ROWS * ROW_H;
-  const LABEL_BAND = 56;
-  const DEVTOOLS_H = 68;
-  const HEIGHT = LIFELINE_BOT + LABEL_BAND + DEVTOOLS_H + 16;
+  const LABEL_BAND = 48;
+  const DEVTOOLS_H = 60;
+  const HEIGHT = LIFELINE_BOT + LABEL_BAND + DEVTOOLS_H + 14;
   const rowY = (i: number) => TOP_PAD + i * ROW_H + ROW_H / 2;
 
   const timelineW = WIDTH - LEFT_PAD - RIGHT_PAD;
-  // One x-step per message.
   const msgX = (i: number) =>
-    LEFT_PAD + 24 + (i * (timelineW - 40)) / Math.max(messages.length - 1, 1);
+    LEFT_PAD +
+    20 +
+    (i * (timelineW - 32)) / Math.max(MESSAGES.length - 1, 1);
+
+  const lastX = msgX(MESSAGES.length - 1);
+  const showDiscard = step >= 5 && !allow;
 
   return (
     <svg
@@ -499,7 +201,7 @@ function NarrowJourney({
     >
       <defs>
         <marker
-          id="arrow-default-n"
+          id="arrow-default-rj"
           viewBox="0 0 10 10"
           refX="9"
           refY="5"
@@ -510,7 +212,7 @@ function NarrowJourney({
           <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-muted)" />
         </marker>
         <marker
-          id="arrow-accent-n"
+          id="arrow-accent-rj"
           viewBox="0 0 10 10"
           refX="9"
           refY="5"
@@ -526,12 +228,12 @@ function NarrowJourney({
       {LANE_LABELS.map((lane, i) => (
         <g key={lane}>
           <text
-            x={LEFT_PAD - 10}
+            x={LEFT_PAD - 8}
             y={rowY(i)}
             textAnchor="end"
             dominantBaseline="central"
             fontFamily="var(--font-sans)"
-            fontSize={12}
+            fontSize={11}
             fontWeight={500}
             fill="var(--color-text-muted)"
           >
@@ -554,16 +256,15 @@ function NarrowJourney({
         x={LEFT_PAD}
         y={TOP_PAD - 8}
         fontFamily="var(--font-sans)"
-        fontSize={12}
+        fontSize={10}
         fill="var(--color-text-muted)"
       >
         time →
       </text>
 
-      {/* Browser ↔ JS boundary: highlighted band between rows 0 and 1 at the
-          last message's x position when the request reaches the decide step. */}
+      {/* Browser ↔ JS boundary band — at the last message column when the
+          request reaches the verdict step. */}
       {(() => {
-        const lastX = msgX(messages.length - 1);
         const gateActive = step >= 5;
         const y0 = rowY(0);
         const y1 = rowY(1);
@@ -574,9 +275,9 @@ function NarrowJourney({
             transition={SPRING.smooth}
           >
             <rect
-              x={lastX - 22}
+              x={lastX - 20}
               y={y0 - 8}
-              width={44}
+              width={40}
               height={y1 - y0 + 16}
               rx={3}
               fill={
@@ -595,7 +296,7 @@ function NarrowJourney({
       })()}
 
       {/* Messages as vertical arrows at their time-step column */}
-      {messages.map((m, idx) => {
+      {MESSAGES.map((m, idx) => {
         const x = msgX(idx);
         const visible = step >= m.from;
         const isCurrent = step === m.from;
@@ -610,22 +311,26 @@ function NarrowJourney({
                 ? "var(--color-accent)"
                 : "var(--color-text-muted)";
         const arrowMarker =
-          m.tone === "accent" ? "url(#arrow-accent-n)" : "url(#arrow-default-n)";
+          m.tone === "accent"
+            ? "url(#arrow-accent-rj)"
+            : "url(#arrow-default-rj)";
         const token = m.shortLabel ?? m.label;
         const isSelf = m.fromCol === m.toCol;
 
         return (
           <motion.g
-            key={`nm-${idx}`}
+            key={`m-${idx}`}
             initial={false}
-            animate={{ opacity: visible ? (isCurrent ? 1 : past ? 0.6 : 0) : 0 }}
+            animate={{
+              opacity: visible ? (isCurrent ? 1 : past ? 0.6 : 0) : 0,
+            }}
             transition={SPRING.smooth}
           >
             {isSelf ? (
               <path
-                d={`M ${x - 2} ${rowY(m.fromCol) - 10}
-                    q -14 0 -14 10
-                    q 0 10 14 10`}
+                d={`M ${x - 2} ${rowY(m.fromCol) - 8}
+                    q -12 0 -12 8
+                    q 0 8 12 8`}
                 fill="none"
                 stroke={tone}
                 strokeWidth={isCurrent ? 1.6 : 1}
@@ -648,7 +353,7 @@ function NarrowJourney({
               y={Math.min(rowY(m.fromCol), rowY(m.toCol)) - 6}
               textAnchor="middle"
               fontFamily="var(--font-mono)"
-              fontSize={11}
+              fontSize={10}
               fill={isCurrent ? "var(--color-text)" : "var(--color-text-muted)"}
             >
               {token}
@@ -657,20 +362,24 @@ function NarrowJourney({
         );
       })}
 
-      {/* Full current-message label — below the lifelines where it has room */}
+      {/* Full current-message label below the lifelines where it has room */}
       <motion.text
-        key={`narrow-label-${step}-${allow ? "a" : "b"}`}
+        key={`label-${step}-${allow ? "a" : "b"}`}
         x={WIDTH / 2}
         y={LIFELINE_BOT + 22}
         textAnchor="middle"
         fontFamily="var(--font-mono)"
-        fontSize={12}
+        fontSize={11}
         fill="var(--color-text)"
         initial={{ opacity: 0, y: LIFELINE_BOT + 28 }}
         animate={{ opacity: 1, y: LIFELINE_BOT + 22 }}
         transition={SPRING.smooth}
       >
-        {messages[Math.min(step, messages.length - 1)]?.label ?? ""}
+        {step === 5
+          ? allow
+            ? "resolve(Response)"
+            : "TypeError: Failed to fetch"
+          : MESSAGES[Math.min(step, MESSAGES.length - 1)]?.label ?? ""}
       </motion.text>
 
       {/* Compact DevTools panel */}
@@ -689,28 +398,47 @@ function NarrowJourney({
           x={LEFT_PAD + 8}
           y={HEIGHT - DEVTOOLS_H + 14}
           fontFamily="var(--font-mono)"
-          fontSize={12}
+          fontSize={10}
           fill="var(--color-text-muted)"
         >
           DevTools
         </text>
-        <motion.text
-          x={LEFT_PAD + 8}
-          y={HEIGHT - DEVTOOLS_H + 30}
-          fontFamily="var(--font-mono)"
-          fontSize={11}
-          fill="var(--color-text)"
+
+        {/* Network row — `body` is what gets discarded on allow=false */}
+        <motion.g
           initial={false}
           animate={{ opacity: step >= 4 ? 1 : 0.25 }}
           transition={SPRING.smooth}
         >
-          Net · 200 OK · 142 B
-        </motion.text>
+          <text
+            x={LEFT_PAD + 8}
+            y={HEIGHT - DEVTOOLS_H + 30}
+            fontFamily="var(--font-mono)"
+            fontSize={10}
+            fill="var(--color-text)"
+          >
+            Net · 200 OK · body
+          </text>
+          {/* Discard beat — terracotta strikethrough across "body" when verdict is
+              fail. scaleX animates 0→1, transform-only per DESIGN §9. */}
+          <motion.rect
+            x={LEFT_PAD + 8}
+            y={HEIGHT - DEVTOOLS_H + 26}
+            width={120}
+            height={1.5}
+            fill="var(--color-accent)"
+            initial={{ scaleX: 0 }}
+            animate={{ scaleX: showDiscard ? 1 : 0 }}
+            transition={SPRING.smooth}
+            style={{ transformOrigin: `${LEFT_PAD + 8}px ${HEIGHT - DEVTOOLS_H + 26}px` }}
+          />
+        </motion.g>
+
         <motion.text
           x={LEFT_PAD + 8}
-          y={HEIGHT - DEVTOOLS_H + 48}
+          y={HEIGHT - DEVTOOLS_H + 46}
           fontFamily="var(--font-mono)"
-          fontSize={11}
+          fontSize={10}
           fill={allow ? "var(--color-text-muted)" : "var(--color-accent)"}
           initial={false}
           animate={{ opacity: step >= 5 ? 1 : 0.25 }}


### PR DESCRIPTION
## Summary

Second polish pass on `why-fetch-fails-only-in-browser`. **Scope: MAJOR**, executed against five user directives — pedagogy-first rephrasing (D1), interactive components do the teaching (D2), Fancy primitives sparingly (D3), interaction-rules.md fixed-frame discipline (D4), mobile-first everywhere (D5) — calibrated to the gmail polish PR #29 quality bar (D6). Three iteration commits; net ~250 words of prose cut, three widgets rebuilt mobile-first, the credentials beat folded into RequestClassifier, RequestClassifier wrapped in a fixed-height frame so verdict/reasons/handshake never reflow the card.

## What changed structurally

- **`32b502a` — mech batch + OriginMatrix + RequestJourney + §2 reframe.** Microcopy fixes (item 12), `captionTone="prominent"` across all three widgets (item 7), HL count 9 → 6 (item 6), §2 reframe to three-sentences-before/after (item 9). OriginMatrix rebuilt as a stacked-list at narrow widths with terracotta-marked diff strings, table layout returning at `@container widget (min-width: 640px)` (item 1). RequestJourney rebuilt as a single ~340-unit-wide canvas with horizontal lifelines, dropping the dual-render `bs-rj-wide` / `bs-rj-narrow` trick (item 2); state-0 set to step 1 with prominent caption (item 4); discard beat added — terracotta strikethrough on response-body label at final step when `allow=false` (item 13).
- **`fb8440a` — post-widget cuts + closer compression.** Cut the prose that re-narrates each widget (items 5a/5b/5c, ~250 words). Closer compressed to three sentences with a single trailing HL (item 10).
- **`675ff99` — RequestClassifier fixed-frame + credentials toggle.** Verdict pill + reasons-list + preflight panel wrapped in a fixed-height container (item 3): worst-case `min-height` reserved on Row B, three-state Row C cross-fades on opacity only — no layout shift. Credentials toggle added as a third row with its own `radiogroup`; toggling it adds Allow-Credentials lines to the OPTIONS exchange and (in the no-preflight path) annotates the response-header requirement (item 8a). H3Like helper + standalone CodeBlock + the wildcard explainer paragraph removed from §4.5 since the widget now teaches the credentials path; Vary: Origin warn callout retained as engineering wisdom not covered by the widget.

## P0s resolved

All seven from `action-items.md`:

1. OriginMatrix mobile-first stacked-list (drop `min-width: 520px` table-scroll) — `32b502a`.
2. RequestJourney single mobile-first canvas (drop 820-wide WideJourney) — `32b502a`.
3. RequestClassifier fixed-frame container (verdict + reasons + preflight panel) — `675ff99`.
4. RequestJourney state-0 = step 1 — `32b502a`.
5. Post-widget prose cuts (5a/5b/5c) — `fb8440a`.
6. HL count 9 → 6 — `32b502a`.
7. All widgets `captionTone="prominent"` — `32b502a`.

## P1s resolved

- 8a Credentials toggle folded into RequestClassifier — `675ff99`.
- 9 §2 reframe — `32b502a`.
- 10 Closer paragraph compression — `fb8440a`.
- 11 Caption rewrites (prominent tone) — covered by 7 + new captions in `32b502a` / `675ff99`.
- 12 Microcopy fixes (titles, aria-labels, headers row label) — `32b502a`.
- 13 RequestJourney discard beat — `32b502a`.

## DESIGN.md ban enforcement (rejected suggestions)

Per `action-items.md` "Rejected (with bans cited)" section, the following review proposals were declined with explicit ban citations:

- ScrambleIn on `Access-Control-Allow-Origin: app.example.com` — `interactive-components.md §2.5` (must teach decoding/normalisation).
- Drop-shadow on verdict pill — `DESIGN.md §12` (no decorative shadows).
- Second accent (cool blue) for the "simple" verdict — `DESIGN.md §3 + §10` (one accent).
- Bouncy ease on row tap — `DESIGN.md §9` (no bounce/elastic).
- Animated gradient on H1 — `DESIGN.md §12` (no gradient text).
- Confetti on success state — `voice-profile.md §7` (no decorative animation).
- `Float` primitive on closer dot — `interactive-components.md §2.5` (Float decorative; closer dot still).
- `Underline Animation` on `<A>` — `interactive-components.md §2.5` (already-shipped underline vocabulary).
- `Letter Swap` on `<Term>` — `interactive-components.md §2.5` (hover-only; mobile-first directive).

## Validation results

Per `research/why-fetch-fails-only-in-browser-polish-2/validation.md`:

- `pnpm exec tsc --noEmit` → **clean**.
- `pnpm build` → **green** (Next 16.2.4 turbopack, all 13 static pages generated, route static-rendered).
- `node scripts/audit-prose.mjs` → **0 errors / 0 warnings / 14 info** (info-level: intentional short technical strings).
- A11y: keyboard nav verified across all three widgets (`role="button"` + `tabIndex` + `onKeyDown` for Enter/Space on OriginMatrix rows; native button keyboard model for RequestJourney toggle + Stepper; `radiogroup` + `radio` for RequestClassifier method/content-type/credentials pickers).
- `prefers-reduced-motion`: `globals.css` has 4 reduce-motion blocks; VerticalCutReveal defaults to `bounce: 0` (no spring tail); RequestClassifier Row C is opacity-only inside a fixed frame.
- Color-only-information: verdicts always carry text labels (`same`/`cross`, `preflighted · OPTIONS sent first`, etc.) alongside the accent color.
- Lighthouse perf/a11y: deferred to Vercel preview comment (script can't run pre-PR).

## Test plan

- [ ] Open the Vercel preview on iPhone SE viewport (375 × 667). Verify all three widgets fit without horizontal scroll.
- [ ] OriginMatrix: tap each row, confirm verdict + caption update; Tab through with keyboard, confirm focus rings + Enter/Space activation.
- [ ] RequestJourney: press play / step controls; toggle the allow-origin header; verify the discard beat (terracotta strikethrough on response body) fires only at the final step with `allow=false`.
- [ ] RequestClassifier: toggle methods, content-types, headers, credentials; confirm verdict + reasons + handshake panel update *without* shifting the card frame; confirm the credentials path produces `Access-Control-Allow-Credentials: true` in the response header lines.
- [ ] Read end-to-end on mobile and desktop; check voice cohesion and HL pacing (6 HLs total).
- [ ] Confirm preview Lighthouse perf ≥ 95, a11y ≥ 95.
- [ ] Compare against gmail polish PR #29 calibration bar.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>