### PR TITLE
fix: home page card titles match the new descriptive H1s

### DIFF
--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -24,7 +24,7 @@ export type PostMeta = {
 export const POSTS: PostMeta[] = [
   {
     slug: "the-webpage-that-reads-the-agent",
-    title: "The webpage that reads the agent",
+    title: "AI agent traps & prompt injection on the open web",
     date: "2026-04-24",
     hook: "you don't break the model — you break the page it reads. six ways the open web learned to trap an AI agent.",
     readingMinutes: 18,
@@ -32,7 +32,7 @@ export const POSTS: PostMeta[] = [
   },
   {
     slug: "the-function-that-remembered",
-    title: "The function that remembered",
+    title: "JavaScript closures, var vs let, and the loop bug",
     date: "2026-04-19",
     hook: "how a function outlives the scope it was born in — and why half of your JS bugs start there.",
     readingMinutes: 10,
@@ -40,7 +40,7 @@ export const POSTS: PostMeta[] = [
   },
   {
     slug: "the-browser-stopped-asking",
-    title: "The browser stopped asking",
+    title: "WebSockets, SSE, and long-polling: how real-time web works",
     date: "2026-04-20",
     hook: "real-time apps didn't teach the server to speak first — they taught the browser to stop hanging up.",
     readingMinutes: 9,
@@ -48,7 +48,7 @@ export const POSTS: PostMeta[] = [
   },
   {
     slug: "why-fetch-fails-only-in-browser",
-    title: "Why `fetch` works in curl but the browser blocks it",
+    title: "Why fetch fails in browser but works in curl (CORS)",
     date: "2026-04-20",
     hook: "the server did answer — your browser is just holding the response back from your JavaScript.",
     readingMinutes: 9,
@@ -56,7 +56,7 @@ export const POSTS: PostMeta[] = [
   },
   {
     slug: "how-gmail-knows-your-email-is-taken",
-    title: "How Gmail knows your email is taken, instantly",
+    title: "How instant email-availability checks work",
     date: "2026-04-19",
     hook: "the pipeline that tells you 'already taken' before your finger lifts.",
     readingMinutes: 12,


### PR DESCRIPTION
## Summary

PR #35 swapped post-page H1s to descriptive form but explicitly did NOT touch `content/posts-manifest.ts` (the agent's reasoning at the time: "manifest's hook already does its job for cards"). After merge, this turned out to be wrong: home-page article cards still showed the old lyrical titles, while clicking through landed on a page with a different (descriptive) H1. Inconsistent and exactly the SEO problem PR #35 set out to fix.

## Fix

`content/posts-manifest.ts` — update each post's `title` to the new descriptive H1.

| slug | new title |
|---|---|
| the-webpage-that-reads-the-agent | "AI agent traps & prompt injection on the open web" |
| the-function-that-remembered | "JavaScript closures, var vs let, and the loop bug" |
| the-browser-stopped-asking | "WebSockets, SSE, and long-polling: how real-time web works" |
| why-fetch-fails-only-in-browser | "Why fetch fails in browser but works in curl (CORS)" |
| how-gmail-knows-your-email-is-taken | "How instant email-availability checks work" |

Hooks left unchanged — already lyrical, already crafted for cards. Pairs descriptive title + lyrical hook = mirrors the post-page structure (descriptive H1 + lyrical subtitle).

## Test plan

- [ ] Home page → each card shows the new descriptive title
- [ ] Click any card → post page H1 matches the card title
- [ ] No widget / post-body changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)