### PR TITLE
fix: home post list renders instantly on back-navigation

### DIFF
--- a/components/nav/PostList.tsx
+++ b/components/nav/PostList.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 import { motion } from "motion/react";
 import type { PostMeta } from "@/content/posts-manifest";
 import { PRESS } from "@/lib/motion";
-import { useFirstVisit } from "@/lib/hooks/use-first-visit";
 import { MotionItem, MotionList } from "./PostListMotion";
 
 const MotionLink = motion.create(Link);
@@ -33,12 +32,6 @@ function coverSrc(p: PostMeta): string {
  * Year headings are rendered as small muted caps above their groups.
  */
 export function PostList({ posts }: { posts: PostMeta[] }) {
-  const { ready, firstVisit } = useFirstVisit();
-  // On first visit, hold the list until the hero choreography finishes
-  // (~1.2s). Return visits — and pre-hydration SSR — use the default tight
-  // stagger start. Keeping the SSR default matches the static render.
-  const delayChildren = ready && firstVisit ? 1.2 : 0.05;
-
   const groups = new Map<string, PostMeta[]>();
   for (const p of posts) {
     const year = p.date.slice(0, 4);
@@ -64,7 +57,7 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
           >
             {year}
           </h2>
-          <MotionList className="mt-[var(--spacing-sm)]" delayChildren={delayChildren}>
+          <MotionList className="mt-[var(--spacing-sm)]">
             {entries.map((p, i) => (
               <MotionItem
                 key={p.slug}

--- a/components/nav/PostListMotion.tsx
+++ b/components/nav/PostListMotion.tsx
@@ -1,62 +1,27 @@
-"use client";
-
-import { motion } from "motion/react";
-import { TIMING } from "@/lib/motion";
 import type { ReactNode } from "react";
 
 /**
- * PostListMotion — client-only wrapper around each <li> in PostList.
- * Each child fades in (opacity-only, no displacement) on TIMING.fast,
- * with a tiny inter-row stagger. Reveal is intentionally lightning-fast
- * on back-navigation; the only "slow" part is the optional first-visit
- * delayChildren that holds the cascade until the hero choreography
- * settles (set in PostList.tsx, not here).
+ * PostList wrappers — plain semantic <ul>/<li> with no entrance animation.
  *
- * Respects prefers-reduced-motion via the global MotionConfigProvider.
+ * Earlier revisions used motion/react to fade rows in on mount. That fired
+ * on every back-navigation to home, which read as a "page reload" even at
+ * 260ms. The hero choreography in AboutColumn (wordmark, paragraph) carries
+ * first-visit branding; the article list is content and renders instantly.
+ *
+ * Kept as named exports (MotionList / MotionItem) so the PostList import
+ * stays stable; the names are now historical. delayChildren is accepted
+ * and ignored to preserve the call-site signature.
  */
-
-const ITEM_STAGGER = 0.02; // 20ms — perceptible texture, no visible build-up
-
-const makeListVariants = (delayChildren: number) => ({
-  hidden: { opacity: 1 }, // keep the list itself visible; stagger drives children
-  show: {
-    opacity: 1,
-    transition: {
-      staggerChildren: ITEM_STAGGER,
-      delayChildren,
-    },
-  },
-});
-
-const itemVariants = {
-  hidden: { opacity: 0 },
-  show: {
-    opacity: 1,
-    transition: TIMING.fast,
-  },
-};
 
 export function MotionList({
   children,
   className,
-  delayChildren = 0.05,
 }: {
   children: ReactNode;
   className?: string;
-  /** Seconds to wait before the first child fires. First-visit home
-   *  choreography passes ~1.2s so the list arrives after the hero beat. */
   delayChildren?: number;
 }) {
-  return (
-    <motion.ul
-      className={className}
-      variants={makeListVariants(delayChildren)}
-      initial="hidden"
-      animate="show"
-    >
-      {children}
-    </motion.ul>
-  );
+  return <ul className={className}>{children}</ul>;
 }
 
 export function MotionItem({
@@ -66,9 +31,5 @@ export function MotionItem({
   children: ReactNode;
   className?: string;
 }) {
-  return (
-    <motion.li className={className} variants={itemVariants}>
-      {children}
-    </motion.li>
-  );
+  return <li className={className}>{children}</li>;
 }


### PR DESCRIPTION
## Summary

User reported: navigating from a post back to the home page felt like the list "reloads and reappears" every time. The browser-back transition itself was fast, but the article list animation re-fired on every navigation.

## Root cause

The home page's `PostList` is a client component. Next.js App Router on browser-back restores the page, which re-mounts the client tree. `motion/react`'s `initial="hidden"` → `animate="show"` cycle re-fires every mount. PR #31 reduced the duration to ~260ms but didn't address the re-fire problem.

`useFirstVisit` was supposed to differentiate first-visit from return-visit — but its effect resolves *after* motion has committed its initial value, so toggling `initial` based on the hook doesn't work for the first paint.

## Fix

Remove the entrance animation from `PostList` entirely. `AboutColumn`'s hero choreography (wordmark scale/y + paragraph mask sweep) already does the first-visit branding work. The article list is content — it should render instantly.

- `components/nav/PostListMotion.tsx` — drop motion variants; render plain `<ul>` / `<li>`. Kept `MotionList` / `MotionItem` named exports so the call site doesn't change.
- `components/nav/PostList.tsx` — drop `useFirstVisit` import and `delayChildren` computation.

## Test plan

- [ ] Open the site fresh — `AboutColumn` choreography still plays; list appears instantly (no fade).
- [ ] Click a post → back-nav to home → list is just there. No fade. No "reload" feel.
- [ ] Mobile back-button → same.
- [ ] `prefers-reduced-motion: reduce` → unchanged (already had no animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)