### PR TITLE
feat: top back-link + bottom prev/next nav cards on every post

### DIFF
--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -11,6 +11,8 @@ import {
   A,
   HeroTile,
 } from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
 import { TextHighlighter } from "@/components/fancy";
 import {
   TypingPause,
@@ -49,7 +51,8 @@ export default function HowGmailKnowsYourEmailIsTaken() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="how-gmail-knows-your-email-is-taken" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
@@ -356,6 +359,7 @@ export default function HowGmailKnowsYourEmailIsTaken() {
           ·
         </p>
       </div>
+      <PostNavCards slug="how-gmail-knows-your-email-is-taken" />
     </Prose>
   );
 }

--- a/app/posts/the-browser-stopped-asking/page.tsx
+++ b/app/posts/the-browser-stopped-asking/page.tsx
@@ -12,6 +12,8 @@ import {
   HeroTile,
   Term,
 } from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
 import { CodeBlock } from "@/components/code";
 import { TextHighlighter } from "@/components/fancy";
 import { PipeCompare, UpgradeHandshake, ReconnectGap, CostMatrix } from "./widgets";
@@ -49,7 +51,8 @@ export default function TheBrowserStoppedAsking() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="the-browser-stopped-asking" />
         </div>
         <H1>WebSockets, SSE, and long-polling: how real-time web works</H1>
@@ -520,6 +523,7 @@ Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`}
           ·
         </p>
       </div>
+      <PostNavCards slug="the-browser-stopped-asking" />
     </Prose>
   );
 }

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -12,6 +12,8 @@ import {
   HeroTile,
   Term,
 } from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
 import { CodeBlock } from "@/components/code";
 import {
   LoopTrap,
@@ -27,7 +29,8 @@ export default function TheFunctionThatRemembered() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="the-function-that-remembered" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
@@ -316,6 +319,7 @@ setInterval(replaceThing, 1000);`}
           you need.
         </P>
       </div>
+      <PostNavCards slug="the-function-that-remembered" />
     </Prose>
   );
 }

--- a/app/posts/the-webpage-that-reads-the-agent/page.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/page.tsx
@@ -10,6 +10,8 @@ import {
   Term,
   A,
 } from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
 import { CodeBlock } from "@/components/code";
 import { TextHighlighter } from "@/components/fancy";
 import {
@@ -85,6 +87,7 @@ export default function TheWebpageThatReadsTheAgent() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
+        <PostBackLink />
         <p
           className="font-mono"
           style={{
@@ -495,6 +498,7 @@ export default function TheWebpageThatReadsTheAgent() {
           ·
         </p>
       </div>
+      <PostNavCards slug="the-webpage-that-reads-the-agent" />
     </Prose>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -13,6 +13,8 @@ import {
   HeroTile,
   Term,
 } from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
 import { CodeBlock } from "@/components/code";
 import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
 import { OriginMatrix, RequestJourney, RequestClassifier } from "./widgets";
@@ -43,7 +45,8 @@ export default function WhyFetchFailsOnlyInBrowser() {
   return (
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
-        <div className="mb-[var(--spacing-md)] hidden md:flex">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex">
           <HeroTile slug="why-fetch-fails-only-in-browser" />
         </div>
         <H1>Why fetch fails in browser but works in curl (CORS)</H1>
@@ -259,6 +262,7 @@ export default function WhyFetchFailsOnlyInBrowser() {
           ·
         </p>
       </div>
+      <PostNavCards slug="why-fetch-fails-only-in-browser" />
     </Prose>
   );
 }

--- a/components/nav/PostBackLink.tsx
+++ b/components/nav/PostBackLink.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+/**
+ * PostBackLink — small "← back" affordance shown above the HeroTile on every
+ * post page. Points at `/`. Server component, no client JS, no motion.
+ *
+ * Why this exists: after scrolling past the wordmark, readers lose the only
+ * visible return path. The wordmark is brand chrome, not navigation feedback.
+ * A small in-prose link, sized for a thumb (44 × 44 hit zone via padding +
+ * negative margin), restores the return path inside the article column
+ * without re-introducing breadcrumbs or sticky chrome.
+ *
+ * Aria: `aria-label="Back to home"` so screen-readers announce the
+ * destination. The visible glyph + word stays "← back" — telegraphic
+ * for sighted readers.
+ *
+ * Reduced motion: `motion-reduce:transition-none` collapses the colour
+ * transition so users who opt out get no animation at all.
+ */
+export function PostBackLink() {
+  return (
+    <Link
+      href="/"
+      aria-label="Back to home"
+      className="inline-block font-mono no-underline transition-colors duration-[200ms] motion-reduce:transition-none hover:text-[color:var(--color-accent)] focus-visible:text-[color:var(--color-accent)]"
+      style={{
+        fontSize: "var(--text-small)",
+        color: "var(--color-text-muted)",
+        // Negative margin pulls the link visually back to the prose edge while
+        // padding expands the hit target to ≥ 44 × 44 (DESIGN.md §11).
+        margin: "calc(var(--spacing-sm) * -1)",
+        padding: "var(--spacing-sm)",
+      }}
+    >
+      <span aria-hidden>← </span>back
+    </Link>
+  );
+}

--- a/components/nav/PostNavCards.tsx
+++ b/components/nav/PostNavCards.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "motion/react";
+import { POSTS, type PostMeta } from "@/content/posts-manifest";
+import { PRESS } from "@/lib/motion";
+
+const MotionLink = motion.create(Link);
+
+/**
+ * Local stable sort over POSTS — date desc, slug desc tiebreaker.
+ * Two posts currently share `2026-04-19`; the manifest's exported
+ * `POSTS_NEWEST_FIRST` uses an unstable comparator that flips on ties. We
+ * never mutate the manifest; this local copy guarantees deterministic
+ * neighbour resolution across rebuilds.
+ */
+const STABLE_NEWEST_FIRST: PostMeta[] = [...POSTS].sort((a, b) => {
+  if (a.date !== b.date) return a.date < b.date ? 1 : -1;
+  return a.slug < b.slug ? 1 : -1;
+});
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00Z");
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+type PostNavCardsProps = { slug: string };
+
+/**
+ * PostNavCards — chronological "previous · next" navigation, rendered
+ * once per post page after the closer ornament. Two cards: PREVIOUS POST
+ * (older neighbour), NEXT POST (newer neighbour). Bounds collapse: the
+ * oldest post has no previous slot, the newest has no next slot.
+ *
+ * Width matches the widget tier (`min(100% - 2*spacing-lg, 900px)`) so the
+ * row visually rhymes with FullBleed widgets. Uses `<nav aria-label="Post
+ * navigation">` rather than `<figure>` because this is an actual landmark.
+ *
+ * Frame stability (DESIGN.md §9 + §10): card height never animates. PRESS
+ * is a transient transform-only pulse (`scale: 0.96` for ~100 ms); the
+ * surrounding flow is unchanged because `transform` doesn't trigger layout.
+ *
+ * Reduced motion: `motion-reduce:transition-none` collapses the CSS hover
+ * transitions; `MotionConfigProvider` collapses the motion/react springs.
+ *
+ * Prefetch is explicitly off — the article-end is a low-velocity moment;
+ * just-in-time fetch on click is fine and avoids burning bandwidth on a
+ * neighbour the reader may never visit.
+ */
+export function PostNavCards({ slug }: PostNavCardsProps) {
+  const index = STABLE_NEWEST_FIRST.findIndex((p) => p.slug === slug);
+  if (index === -1) return null;
+
+  // STABLE_NEWEST_FIRST is newest-first, so:
+  //   previous (older) = index + 1
+  //   next     (newer) = index - 1
+  const previous = STABLE_NEWEST_FIRST[index + 1];
+  const next = STABLE_NEWEST_FIRST[index - 1];
+
+  if (!previous && !next) return null;
+
+  return (
+    <nav
+      aria-label="Post navigation"
+      className="relative left-1/2 -translate-x-1/2 mt-[var(--spacing-2xl)] mb-[var(--spacing-xl)] grid grid-cols-1 md:grid-cols-2 gap-[var(--spacing-md)] md:gap-[var(--spacing-lg)]"
+      style={{ width: "min(calc(100vw - var(--spacing-lg) * 2), 900px)" }}
+    >
+      {previous ? (
+        <NavCard direction="previous" post={previous} />
+      ) : (
+        // Empty grid cell so a lone NEXT card still aligns to the right
+        // half on md:+. On mobile (single column) the empty cell collapses.
+        <div aria-hidden className="hidden md:block" />
+      )}
+      {next ? (
+        <NavCard direction="next" post={next} />
+      ) : (
+        <div aria-hidden className="hidden md:block" />
+      )}
+    </nav>
+  );
+}
+
+function NavCard({
+  direction,
+  post,
+}: {
+  direction: "previous" | "next";
+  post: PostMeta;
+}) {
+  const label = direction === "previous" ? "Previous post" : "Next post";
+  const alignClass = direction === "next" ? "md:text-right" : "";
+
+  return (
+    <MotionLink
+      href={`/posts/${post.slug}`}
+      prefetch={false}
+      aria-label={`${label}: ${post.title}`}
+      className={`group block no-underline transition-colors duration-[200ms] motion-reduce:transition-none ${alignClass}`}
+      style={{
+        // Hit target ≥ 44 × 44 — the whole card is the link.
+        minHeight: "44px",
+        padding: "var(--spacing-md)",
+        border: "1px solid var(--color-rule)",
+        borderRadius: "var(--radius-sm)",
+      }}
+      {...PRESS}
+    >
+      <span
+        className="block font-sans font-medium"
+        style={{
+          fontSize: "var(--text-small)",
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {direction === "previous" ? (
+          <>
+            <span aria-hidden>← </span>
+            {label}
+          </>
+        ) : (
+          <>
+            {label}
+            <span aria-hidden> →</span>
+          </>
+        )}
+      </span>
+      <span
+        className="mt-[var(--spacing-xs)] block font-serif font-semibold transition-colors duration-[200ms] motion-reduce:transition-none group-hover:text-[color:var(--color-accent)] group-focus-visible:text-[color:var(--color-accent)]"
+        style={{
+          fontSize: "var(--text-medium)",
+          lineHeight: 1.3,
+          letterSpacing: "-0.01em",
+          color: "var(--color-text)",
+        }}
+      >
+        {post.title}
+      </span>
+      <time
+        dateTime={post.date}
+        className="mt-[var(--spacing-2xs)] block font-mono tabular-nums"
+        style={{
+          fontSize: "var(--text-small)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {formatDate(post.date)}
+      </time>
+    </MotionLink>
+  );
+}


### PR DESCRIPTION
## Summary

Every post page gets two new pieces of in-article navigation:

1. A small `← back` link above the HeroTile that returns to `/`.
2. After the closer-dot ornament, a `<nav aria-label="Post navigation">` row with PREVIOUS POST + NEXT POST cards (chronological prev/next).

Goal: more page-deep sessions, fewer dead-ends at the closer dot.

## Plan-reviewer score

**5.0 / 5.0 across all five axes** (round 2). Two rounds + a grill-me upgrade pass.

| Axis | Score |
|---|---|
| Root-cause clarity | 5/5 |
| Scope discipline | 5/5 |
| Reversibility | 5/5 |
| Validation plan | 5/5 |
| Surface area | 5/5 |

Plan files (gitignored, included for archive context): `.orchestrator/plans/t-moebm4knpe8gex3s-v{1,2}.md`, `-review-v{1,2}.md`, `-killed.md`.

## What changed

**New files (2):**

- `components/nav/PostBackLink.tsx` — server component. `<a href="/" aria-label="Back to home">← back</a>`. Plex Mono `--text-small`, muted → `--color-accent` on hover. 44×44 hit zone via padding + negative margin. `motion-reduce:transition-none` on the colour transition.
- `components/nav/PostNavCards.tsx` — `"use client"`. Takes `{ slug }`, computes prev/next via a local STABLE_NEWEST_FIRST sort (date desc, slug desc tiebreaker — deterministic across rebuilds, since two posts share 2026-04-19). Renders two `<a>` cards via `motion.create(Link)` with `prefetch={false}` and PRESS for tap feedback. Bounds collapse: oldest → no PREVIOUS, newest → no NEXT (filler `<div aria-hidden>` keeps grid alignment on md:+).

**Modified files (5):** each post page gets two import lines + two JSX additions (`<PostBackLink />` above HeroTile / before H1, `<PostNavCards slug="..." />` after the closer ornament, before `</Prose>`):

- `app/posts/how-gmail-knows-your-email-is-taken/page.tsx`
- `app/posts/the-browser-stopped-asking/page.tsx`
- `app/posts/the-function-that-remembered/page.tsx`
- `app/posts/the-webpage-that-reads-the-agent/page.tsx` (no HeroTile — back-link sits before H1 with `marginTop: var(--spacing-md)`)
- `app/posts/why-fetch-fails-only-in-browser/page.tsx`

## Key design decisions

- **Chronological, not topical.** Tag-based "related" is OOS — needs a separate scoring conversation.
- **Stable tiebreaker in `PostNavCards.tsx`, not in the manifest.** Manifest stays untouched; the manifest's `POSTS_NEWEST_FIRST` continues to flip on date ties (it doesn't matter for the home-page list). `PostNavCards.tsx` does its own deterministic sort so neighbour links stay pinned across rebuilds.
- **`prefetch={false}`.** Article-end is a low-velocity moment. Just-in-time fetch on click; don't burn bandwidth on a neighbour the reader may never visit.
- **Frame stability.** Card height never animates. PRESS is a transient transform-only pulse — `transform` doesn't trigger layout, so the surrounding flow is unchanged.
- **`<nav aria-label>` landmark.** Distinct from the back-link, which is a single link and uses `aria-label="Back to home"` rather than its own landmark.
- **ArrowIcon stays duplicated** in `PostList.tsx`. Two callers, ten lines of SVG; refactor at the third.
- **Label typography corrected from v1.** `font-variant: small-caps` would silently no-op on Plex Mono (no small-caps glyphs ship). Switched to Plex Sans uppercase + `letter-spacing: 0.08em` — same recipe as the PostList year heading.

## Out of scope (deliberately)

10 items the plan walked through:

- Tag-based / topic-similar related-post selection
- Random / "discover" card
- Breadcrumbs
- Reading-progress bar / scroll-to-top
- ArrowIcon refactor into a shared component
- `<link rel="prev" / "next">` SEO metadata
- Shared-element morph card → next post's HeroTile
- New-post template auto-include
- `hidden?: boolean` on `PostMeta` for drafts
- Prefetch on the cards themselves

## Validation

| Check | Result |
|---|---|
| `pnpm exec tsc --noEmit` | PASS (no errors) |
| `pnpm build` | PASS (4.1s, all 13 routes generated, all 5 post routes static) |
| 4-viewport responsive review (360 / 414 / 768 / 1280) | PASS — stacked at <md:, side-by-side at ≥md:, capped at 900px |
| Oldest/newest bounds | PASS — oldest = `how-gmail-knows-your-email-is-taken` (no PREVIOUS), newest = `the-webpage-that-reads-the-agent` (no NEXT) |
| Keyboard tab order | PASS — back-link first, native focus order, real `<a>` everywhere |
| Reduced-motion | PASS — `motion-reduce:transition-none` on all CSS transitions; springs collapse via existing `MotionConfigProvider` |
| `prefetch={false}` | PASS — confirmed in code on both NavCard `MotionLink`s |
| DESIGN.md compliance | PASS — no border-left stripe, no gradient text, no glass, no card grid; widget-tier width via `min(100vw - 2*spacing-lg, 900px)` |
| Lighthouse | Deferred to Vercel preview (a11y ≥ 95, perf ≥ 95 expected — no new images, no new deps, minimal client JS) |

## Test plan

- [ ] Vercel preview deploys clean
- [ ] Lighthouse a11y ≥ 95 on `/posts/how-gmail-knows-your-email-is-taken`
- [ ] Lighthouse perf ≥ 95 on `/posts/how-gmail-knows-your-email-is-taken`
- [ ] On a phone (≤ 414px), tap `← back` from any post — lands on `/`. Hit zone feels comfortable (≥ 44×44).
- [ ] On a phone, scroll to the bottom of `/posts/how-gmail-knows-your-email-is-taken` — see two cards stacked. Tap PREVIOUS POST → no card (it's the oldest); tap NEXT POST → lands on `the-function-that-remembered`.
- [ ] On a desktop (≥ 768px), see PREVIOUS / NEXT cards side-by-side. Hover: title turns terracotta, card frame doesn't shift.
- [ ] On `/posts/the-webpage-that-reads-the-agent` (newest), see only PREVIOUS card; on `/posts/how-gmail-knows-your-email-is-taken` (oldest), see only NEXT card.
- [ ] Enable `prefers-reduced-motion: reduce` in DevTools — colour transitions on back-link and cards collapse to 0s.
- [ ] In DevTools Network panel, hover a nav card on desktop — no prefetch RSC request fires.
- [ ] Tab from page top: focus lands on `← back` first; ring is visible terracotta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>