### PR TITLE
post: the-line-that-waits-its-turn — JS event loop, microtasks, call stack

### DIFF
--- a/app/posts/the-line-that-waits-its-turn/metadata.ts
+++ b/app/posts/the-line-that-waits-its-turn/metadata.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "the-line-that-waits-its-turn";
+const VISIBLE_HEADING =
+  "How the JavaScript event loop, microtasks, and the call stack work";
+const LYRICAL_TAGLINE = "The line that waits its turn";
+const HOOK =
+  "Why setTimeout(0) is never zero, why await feels seamless, and why one runaway Promise can stall a tab — one rule about the microtask queue explains all three.";
+
+/** Visible subtitle on the post page (poetic tagline under the descriptive H1). */
+export const subtitle = LYRICAL_TAGLINE;
+
+export const metadata: Metadata = {
+  title: `${VISIBLE_HEADING} — bytesize`,
+  description: HOOK,
+  openGraph: {
+    title: `${VISIBLE_HEADING} — bytesize`,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${VISIBLE_HEADING} — bytesize`,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/the-line-that-waits-its-turn/metadata.ts
+++ b/app/posts/the-line-that-waits-its-turn/metadata.ts
@@ -3,10 +3,10 @@ import { SITE_URL as SITE } from "@/lib/site";
 
 const SLUG = "the-line-that-waits-its-turn";
 const VISIBLE_HEADING =
-  "How the JavaScript event loop, microtasks, and the call stack work";
+  "JavaScript Event Loop Explained: Microtasks and the Call Stack";
 const LYRICAL_TAGLINE = "The line that waits its turn";
 const HOOK =
-  "Why setTimeout(0) is never zero, why await feels seamless, and why one runaway Promise can stall a tab — one rule about the microtask queue explains all three.";
+  "How the JavaScript event loop schedules microtasks before timers, why await feels seamless, and why one runaway Promise can freeze a tab.";
 
 /** Visible subtitle on the post page (poetic tagline under the descriptive H1). */
 export const subtitle = LYRICAL_TAGLINE;
@@ -14,11 +14,27 @@ export const subtitle = LYRICAL_TAGLINE;
 export const metadata: Metadata = {
   title: `${VISIBLE_HEADING} — bytesize`,
   description: HOOK,
+  keywords: [
+    "javascript event loop",
+    "microtasks",
+    "macrotasks",
+    "call stack",
+    "setTimeout",
+    "promise",
+    "async await",
+    "node event loop",
+    "queueMicrotask",
+    "microtask queue",
+  ],
+  alternates: {
+    canonical: `${SITE}/posts/${SLUG}`,
+  },
   openGraph: {
     title: `${VISIBLE_HEADING} — bytesize`,
     description: HOOK,
     url: `${SITE}/posts/${SLUG}`,
     type: "article",
+    publishedTime: "2026-04-25T00:00:00.000Z",
     images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
   },
   twitter: {

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -12,9 +12,10 @@ import {
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
-import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
+import { TextHighlighter } from "@/components/fancy";
 import {
   RuntimeSimulator,
+  PredictTheStart,
   PredictTheOutput,
   AwaitDesugar,
   MicrotaskStarvation,
@@ -81,14 +82,25 @@ export default function TheLineThatWaitsItsTurn() {
           {subtitle}
         </p>
 
-        {/* §0 — scene */}
+        {/* §0 — the quiz hook */}
         <P>
-          You write <Code>setTimeout(log, 0)</Code> on one line and{" "}
-          <Code>Promise.resolve().then(log)</Code> right under it. You hit run.
-          The Promise prints first. <em>Zero</em> milliseconds was supposed to
-          mean now — and somehow the line you wrote afterward got there sooner.
-          You&apos;ve hit two queues you didn&apos;t know existed:{" "}
-          <HL>the line that waits its turn, and the line that doesn&apos;t.</HL>
+          Before we explain anything, try the snippet below. Read it once, then
+          guess the order it prints. Most readers get this wrong on the first
+          try — and{" "}
+          <HL>the gap between your guess and the truth is exactly what this post fills</HL>.
+        </P>
+      </div>
+
+      <PredictTheStart />
+
+      <div>
+        <P>
+          The runtime didn&apos;t reorder anything at random. Every letter
+          landed where it did because of one rule about how JavaScript drains
+          its queues — a rule that explains <Code>setTimeout(0)</Code>, makes{" "}
+          <Code>await</Code> seamless, and is the reason a single Promise can
+          freeze a tab. The rest of the post traces that snippet, line by line,
+          until the order isn&apos;t a guess anymore.
         </P>
       </div>
 
@@ -105,6 +117,13 @@ export default function TheLineThatWaitsItsTurn() {
           <HL>The loop only reaches into its queues when the stack is empty.</HL>{" "}
           That&apos;s the whole trigger. Not a 16-millisecond tick, not a
           priority interrupt — just an empty stack.
+        </P>
+        <P>
+          That&apos;s why <Code>A</Code>, <Code>F</Code>, and <Code>H</Code>{" "}
+          print before anything else in the snippet above. They&apos;re all{" "}
+          <em>synchronous</em> calls that ran inside <Code>main</Code>; the
+          stack stayed busy until <Code>console.log(&quot;H&quot;)</Code>{" "}
+          returned. Only then does the rest of the runtime get a turn.
         </P>
         <P>
           If the stack itself feels new — what a frame is, what hoisting does to
@@ -179,6 +198,14 @@ export default function TheLineThatWaitsItsTurn() {
             HTML §8.1.7
           </A>
           ).
+        </P>
+        <P>
+          That&apos;s why the snippet&apos;s <Code>B</Code> — a 0 ms{" "}
+          <Code>setTimeout</Code> — comes <em>last</em>, even though it was
+          scheduled second. The task queue can&apos;t advance until the
+          microtask queue has been drained completely; <Code>C</Code>,{" "}
+          <Code>E</Code>, <Code>G</Code>, and <Code>D</Code> all clear before{" "}
+          <Code>B</Code> gets its turn.
         </P>
         <P>
           The priority isn&apos;t subtle. After every task — including the
@@ -259,6 +286,28 @@ export default function TheLineThatWaitsItsTurn() {
           chains; read the left-hand pane first if you came up writing{" "}
           <Code>async/await</Code>. The one rule from §3 covers both.
         </P>
+        <P>
+          And it&apos;s exactly why the snippet&apos;s <Code>G</Code> doesn&apos;t
+          land where you&apos;d expect. The <Code>await null</Code> splits the
+          async IIFE: <Code>F</Code> runs synchronously, then the line after the{" "}
+          <Code>await</Code> gets parked as a microtask. <Code>G</Code> can&apos;t
+          fire until the microtask queue reaches it — which is why it lands
+          after <Code>C</Code> and <Code>E</Code>, not next to <Code>F</Code>.
+        </P>
+        <P>
+          The trickiest letter in the snippet is <Code>D</Code>. The first{" "}
+          <Code>.then</Code> callback returns <Code>Promise.resolve(&quot;D&quot;)</Code>;
+          adopting that returned promise costs <em>two</em> extra microtask
+          hops before the chained <Code>.then((d) =&gt; log(d))</Code> finally
+          fires. By the time those hops complete, <Code>G</Code> has already
+          run. That&apos;s why the order is <Code>C E G D</Code> and not{" "}
+          <Code>C E D G</Code>: returning a Promise from a <Code>.then</Code>{" "}
+          isn&apos;t free — it&apos;s a queue-line you didn&apos;t see (
+          <A href="https://v8.dev/blog/fast-async">
+            V8 blog: faster async functions and promises
+          </A>
+          ).
+        </P>
         <Aside>
           For most of the post-ES2017 era the desugaring was{" "}
           <em>also</em> what the engine literally did, just slower. V8&apos;s
@@ -295,11 +344,12 @@ export default function TheLineThatWaitsItsTurn() {
           ).
         </P>
         <P>
-          The widget below runs a bounded version of exactly that: 50,000
-          iterations of <Code>Promise.resolve().then(loop)</Code> versus the
-          same work split across <Code>setTimeout(0)</Code> batches. The cap
-          exists so the page can&apos;t actually freeze on you — but the shape
-          of the freeze is real.
+          The widget below makes the freeze tactile: a recursive{" "}
+          <Code>Promise.resolve().then(loop)</Code> chain on one side, a frame
+          counter and a click-me button on the other. Tap{" "}
+          <em>start runaway</em> and the microtask lane fills instantly while
+          the frame lane stops dead — and your click is left waiting too. Tap{" "}
+          <em>stop</em> to watch the page recover.
         </P>
       </div>
 
@@ -307,12 +357,12 @@ export default function TheLineThatWaitsItsTurn() {
 
       <div>
         <P>
-          In starve mode the counter jumps from <Code>0</Code> straight to its
-          final value in a single paint, and the pulse-dot freezes for the
-          duration of the run. In yield mode the counter ticks visibly and the
-          dot keeps pulsing, because each <Code>setTimeout(0)</Code> hands the
-          loop back — opening a window for the renderer between batches. Same
-          work, different scheduler.
+          While the Promise kept resolving itself, no rAF fired and no click
+          registered. The microtask queue stayed non-empty, so the loop never
+          moved on to the next phase — even though the CPU wasn&apos;t actually
+          that busy. Same rule, different consequence: the priority that lets{" "}
+          <Code>await</Code> feel seamless is the same priority that lets one
+          runaway Promise hold a tab hostage.
         </P>
         <Aside>
           Node has a different inventory but the same hazard. Its loop runs in
@@ -337,16 +387,11 @@ export default function TheLineThatWaitsItsTurn() {
           <em>doesn&apos;t</em> is the microtask queue — it gets drained
           completely, every checkpoint, before anything else moves. One rule
           explains why <Code>await</Code> works, why <Code>setTimeout(0)</Code>{" "}
-          is never zero, and{" "}
-          <VerticalCutReveal
-            staggerDuration={0.04}
-            staggerFrom="first"
-            transition={{ type: "spring" as const, stiffness: 200, damping: 22 }}
-            as="span"
-            className="inline"
-          >
-            why one runaway Promise stalls your whole tab.
-          </VerticalCutReveal>
+          is never zero, and why one runaway Promise stalls your whole tab.
+        </P>
+        <P>
+          Scroll back up and run the opener again. The order isn&apos;t a
+          riddle anymore — it&apos;s the sequence the runtime had to take.
         </P>
         <p
           aria-hidden

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -120,7 +120,7 @@ export default function TheLineThatWaitsItsTurn() {
       {/* §2 — Web APIs and the runtime simulator */}
       <div>
         <Dots />
-        <H2>Web APIs are not the JavaScript engine</H2>
+        <H2>The engine is single-threaded; the runtime is not</H2>
         <P>
           When you call <Code>setTimeout</Code>, almost nothing about it is
           JavaScript. The browser hands the timer to a separate, native bit of
@@ -157,15 +157,15 @@ export default function TheLineThatWaitsItsTurn() {
           reaches in. It pulls from the microtask queue first. Even though{" "}
           <Code>timerB</Code> was scheduled before <Code>thenC</Code>,{" "}
           <Code>C</Code> prints before <Code>B</Code>. The microtask{" "}
-          <Em>jumped the line</Em> — and the rule that let it isn&apos;t a
-          quirk; it&apos;s the entire model.
+          <Em>jumped the line</Em> —{" "}
+          <HL>the rule that let it isn&apos;t a quirk; it&apos;s the entire model</HL>.
         </P>
       </div>
 
       {/* §3 — two queues, microtasks first */}
       <div>
         <Dots />
-        <H2>Two queues, and one of them always wins</H2>
+        <H2>One of the two queues always wins</H2>
         <P>
           Two queues, not one. The <em>task queue</em> (sometimes called the
           macrotask queue) holds work scheduled by{" "}
@@ -204,12 +204,10 @@ export default function TheLineThatWaitsItsTurn() {
         <P>
           The single rule, stated plainly:{" "}
           <HL>
-            the runtime drains the microtask queue completely between every
-            other thing it does
+            between every task, every render, every idle frame — the
+            microtask queue drains to empty first
           </HL>
-          . Every other thing — every macrotask, every render, every idle
-          callback — sits behind that drain. Once you carry that sentence, the
-          rest of the post is corollaries.
+          . Once you carry that sentence, the rest of the post is corollaries.
         </P>
         <Aside>
           This wasn&apos;t always uniform. Through 2016–2017 the major browsers
@@ -256,10 +254,10 @@ export default function TheLineThatWaitsItsTurn() {
         <P>
           Step 2 is where the equivalence lands. Both panes annotate{" "}
           <em>microtask queue</em> at the same tick because, underneath the
-          syntax, the engine is doing the same thing. Read the right-hand pane
-          first if you came up writing <Code>.then</Code> chains; read the
-          left-hand pane first if you came up writing <Code>async/await</Code>.
-          The one rule from §3 covers both.
+          syntax, <HL>the engine is doing the same thing</HL>. Read the
+          right-hand pane first if you came up writing <Code>.then</Code>{" "}
+          chains; read the left-hand pane first if you came up writing{" "}
+          <Code>async/await</Code>. The one rule from §3 covers both.
         </P>
         <Aside>
           For most of the post-ES2017 era the desugaring was{" "}
@@ -347,24 +345,9 @@ export default function TheLineThatWaitsItsTurn() {
             as="span"
             className="inline"
           >
-            why one runaway Promise can stall your whole tab.
+            why one runaway Promise stalls your whole tab.
           </VerticalCutReveal>
         </P>
-        <p
-          className="font-sans"
-          style={{
-            fontSize: "var(--text-small)",
-            color: "var(--color-text-muted)",
-            marginBlockStart: "0.5em",
-          }}
-        >
-          For the call stack itself — frames, hoisting, the scopes a function
-          carries with it — read the sister post:{" "}
-          <A href="/posts/how-javascript-reads-its-own-future">
-            How JavaScript reads its own future
-          </A>
-          .
-        </p>
         <p
           aria-hidden
           className="font-mono text-center select-none"

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -1,0 +1,393 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  Em,
+  A,
+  Aside,
+  Dots,
+  HeroTile,
+} from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
+import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
+import {
+  RuntimeSimulator,
+  PredictTheOutput,
+  AwaitDesugar,
+  MicrotaskStarvation,
+} from "./widgets";
+import { metadata, subtitle } from "./metadata";
+
+export { metadata };
+
+const HL_TRANSITION = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/** Highlight a load-bearing phrase. Default ltr swipe, spring, inView once. */
+function HL({
+  children,
+  direction = "ltr",
+}: {
+  children: React.ReactNode;
+  direction?: "ltr" | "rtl" | "ttb" | "btt";
+}) {
+  return (
+    <TextHighlighter
+      transition={HL_TRANSITION}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      direction={direction}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+export default function TheLineThatWaitsItsTurn() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="the-line-that-waits-its-turn" />
+        </div>
+        <H1>How the JavaScript event loop, microtasks, and the call stack work</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-25">apr 25, 2026</time>
+          <span className="mx-2">·</span>
+          <span>15 min read</span>
+        </p>
+        <p
+          className="mt-[var(--spacing-md)]"
+          style={{
+            fontSize: "var(--text-medium)",
+            color: "var(--color-text-muted)",
+            fontStyle: "normal",
+            maxWidth: "56ch",
+            lineHeight: "1.45",
+          }}
+        >
+          {subtitle}
+        </p>
+
+        {/* §0 — scene */}
+        <P>
+          You write <Code>setTimeout(log, 0)</Code> on one line and{" "}
+          <Code>Promise.resolve().then(log)</Code> right under it. You hit run.
+          The Promise prints first. <em>Zero</em> milliseconds was supposed to
+          mean now — and somehow the line you wrote afterward got there sooner.
+          You&apos;ve hit two queues you didn&apos;t know existed:{" "}
+          <HL>the line that waits its turn, and the line that doesn&apos;t.</HL>
+        </P>
+      </div>
+
+      {/* §1 — the stack as gatekeeper */}
+      <div>
+        <Dots />
+        <H2>The stack is the gatekeeper</H2>
+        <P>
+          Every line of running JavaScript lives inside a <em>frame</em> on the
+          call stack — one slot per function call, popped when the call returns.
+          The runtime around it (queues, timers, the event loop) is bigger than
+          the stack and slower than it; none of that machinery can interrupt a
+          frame mid-line.{" "}
+          <HL>The loop only reaches into its queues when the stack is empty.</HL>{" "}
+          That&apos;s the whole trigger. Not a 16-millisecond tick, not a
+          priority interrupt — just an empty stack.
+        </P>
+        <P>
+          If the stack itself feels new — what a frame is, what hoisting does to
+          it, how function calls push and pop — start with the sister post:{" "}
+          <A href="/posts/how-javascript-reads-its-own-future">
+            How JavaScript reads its own future
+          </A>
+          . The two posts work together. This one picks up where that one ends:
+          the moment the stack runs out of frames and the loop gets its turn.
+        </P>
+      </div>
+
+      {/* §2 — Web APIs and the runtime simulator */}
+      <div>
+        <Dots />
+        <H2>Web APIs are not the JavaScript engine</H2>
+        <P>
+          When you call <Code>setTimeout</Code>, almost nothing about it is
+          JavaScript. The browser hands the timer to a separate, native bit of
+          itself — the same place that handles <Code>fetch</Code>, click events,
+          IndexedDB, network reads. These are{" "}
+          <em>Web APIs</em>: machinery that lives <em>outside</em> the
+          single-threaded engine, runs in parallel, and only pushes a callback
+          back when the work it was given finishes (
+          <A href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Event_loop">
+            MDN event loop
+          </A>
+          ). Same shape in Node — only the implementation underneath is libuv
+          instead of the browser&apos;s native event system (
+          <A href="https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick">
+            Node docs
+          </A>
+          ).
+        </P>
+        <P>
+          So the engine is single-threaded, but the runtime around it is
+          doing work in parallel. Your <Code>setTimeout(B, 0)</Code> isn&apos;t
+          waiting in line yet when you call it. It&apos;s parked in the Web API
+          row. The line forms only when the timer fires and the callback gets
+          handed back. The widget below walks ten ticks of a small program and
+          shows where every piece sits.
+        </P>
+      </div>
+
+      <RuntimeSimulator />
+
+      <div>
+        <P>
+          By tick 7 the stack is empty, both queues hold one item, and the loop
+          reaches in. It pulls from the microtask queue first. Even though{" "}
+          <Code>timerB</Code> was scheduled before <Code>thenC</Code>,{" "}
+          <Code>C</Code> prints before <Code>B</Code>. The microtask{" "}
+          <Em>jumped the line</Em> — and the rule that let it isn&apos;t a
+          quirk; it&apos;s the entire model.
+        </P>
+      </div>
+
+      {/* §3 — two queues, microtasks first */}
+      <div>
+        <Dots />
+        <H2>Two queues, and one of them always wins</H2>
+        <P>
+          Two queues, not one. The <em>task queue</em> (sometimes called the
+          macrotask queue) holds work scheduled by{" "}
+          <Code>setTimeout</Code>, <Code>setInterval</Code>, click handlers,
+          network callbacks, and the like. The <em>microtask queue</em> holds
+          Promise reactions —{" "}
+          <Code>.then</Code>, <Code>.catch</Code>, <Code>.finally</Code> — plus{" "}
+          <Code>queueMicrotask()</Code> and <Code>MutationObserver</Code>{" "}
+          callbacks. Different sources, different queues, different priority (
+          <A href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">
+            HTML §8.1.7
+          </A>
+          ).
+        </P>
+        <P>
+          The priority isn&apos;t subtle. After every task — including the
+          initial &ldquo;run the script&rdquo; task — the loop performs a{" "}
+          <em>microtask checkpoint</em>: drain the microtask queue until it&apos;s
+          empty, including any new microtasks added <em>during</em> the drain.
+          Only after that does the loop run one task and check for a render.
+          Three variants below pin three edges of the rule.
+        </P>
+      </div>
+
+      <PredictTheOutput />
+
+      <div>
+        <P>
+          Variant β is the one that catches most readers: a microtask that
+          schedules another microtask still runs before the next task, because
+          the queue drains <em>completely</em>, not snapshot-at-a-time. Variant
+          γ pins the other half: the order you wrote the lines doesn&apos;t
+          decide queue order. Source order schedules; the queues decide what
+          runs.
+        </P>
+        <P>
+          The single rule, stated plainly:{" "}
+          <HL>
+            the runtime drains the microtask queue completely between every
+            other thing it does
+          </HL>
+          . Every other thing — every macrotask, every render, every idle
+          callback — sits behind that drain. Once you carry that sentence, the
+          rest of the post is corollaries.
+        </P>
+        <Aside>
+          This wasn&apos;t always tidy. Through 2016–2017 the major browsers
+          implemented the queue ordering with quiet inconsistencies — Edge and
+          Safari resolved Promises in places where Chrome ran microtasks, and a
+          handful of MutationObserver edge cases drifted off-spec. Convergence
+          landed alongside the HTML-spec processing-model rewrite. Jake
+          Archibald&apos;s 2018 talk{" "}
+          <A href="https://www.youtube.com/watch?v=cCOL7MC4Pl0">
+            &ldquo;In The Loop&rdquo;
+          </A>{" "}
+          is the canonical record of where each engine had landed by then.
+          Modern browsers all converge on the spec.
+        </Aside>
+      </div>
+
+      {/* §4 — await is a microtask checkpoint */}
+      <div>
+        <Dots />
+        <H2><Code>await</Code> is a microtask in disguise</H2>
+        <P>
+          The rule&apos;s biggest payoff is the one most people use without
+          noticing. <Code>await</Code> is sugar. The line after it doesn&apos;t
+          run synchronously — even when the value being awaited is already
+          resolved. It runs as a microtask, on the very next checkpoint (
+          <A href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await">
+            MDN <Code>await</Code>
+          </A>
+          ).
+        </P>
+        <P>
+          Concretely: <Code>async function f() &#123; ...; await x; rest(); &#125;</Code>{" "}
+          desugars to roughly{" "}
+          <Code>function f() &#123; ...; return Promise.resolve(x).then(() =&gt; rest()); &#125;</Code>
+          . The body splits at the <Code>await</Code> and the second half
+          becomes a <Code>.then</Code> callback. The widget shows both forms
+          stepping in lock-step.
+        </P>
+      </div>
+
+      <AwaitDesugar />
+
+      <div>
+        <P>
+          Step 2 is where the equivalence lands. Both panes annotate{" "}
+          <em>microtask queue</em> at the same tick because, underneath the
+          syntax, the engine is doing the same thing. Read the right-hand pane
+          first if you came up writing <Code>.then</Code> chains; read the
+          left-hand pane first if you came up writing <Code>async/await</Code>.
+          The one rule from §3 covers both.
+        </P>
+        <Aside>
+          For most of the post-ES2017 era the desugaring was{" "}
+          <em>also</em> what the engine literally did, just slower. V8&apos;s
+          original implementation of <Code>await</Code> wrapped the value in a
+          fresh Promise, attached a <Code>.then</Code>, and walked the result
+          through three microtasks before resuming the caller — even when the
+          value was already a Promise. In late 2018 V8 swapped the wrapping for{" "}
+          <Code>promiseResolve</Code>, which leaves Promises alone and only
+          wraps non-Promise values, dropping a resolved <Code>await</Code> from
+          three microtask ticks to one (
+          <A href="https://v8.dev/blog/fast-async">
+            V8 blog: faster async functions and promises
+          </A>
+          ). It&apos;s why upgrading from Node 8 to Node 12 made some of your
+          benchmarks faster without you changing a line of code.
+        </Aside>
+      </div>
+
+      {/* §5 — when the rule cuts both ways */}
+      <div>
+        <Dots />
+        <H2>The rule cuts both ways</H2>
+        <P>
+          The same rule that makes <Code>await</Code> seamless can stall the
+          tab. Rendering — repaints, scroll, the next animation frame — sits
+          downstream of the microtask checkpoint. The loop won&apos;t even{" "}
+          <em>look</em> at a render opportunity until the microtask queue is
+          empty. And because the queue drains <em>completely</em>, including
+          newly-added microtasks, a chain that schedules itself can hold the
+          checkpoint open indefinitely (
+          <A href="https://web.dev/articles/optimize-long-tasks">
+            web.dev: optimize long tasks
+          </A>
+          ).
+        </P>
+        <P>
+          The widget below runs a bounded version of exactly that: 50,000
+          iterations of <Code>Promise.resolve().then(loop)</Code> versus the
+          same work split across <Code>setTimeout(0)</Code> batches. The cap
+          exists so the page can&apos;t actually freeze on you — but the shape
+          of the freeze is real.
+        </P>
+      </div>
+
+      <MicrotaskStarvation />
+
+      <div>
+        <P>
+          In starve mode the counter jumps from <Code>0</Code> straight to its
+          final value in a single paint, and the pulse-dot freezes for the
+          duration of the run. In yield mode the counter ticks visibly and the
+          dot keeps pulsing, because each <Code>setTimeout(0)</Code> hands the
+          loop back — opening a window for the renderer between batches. Same
+          work, different scheduler.
+        </P>
+        <Aside>
+          Node has a different inventory but the same hazard. Its event loop
+          runs in six phases — timers, pending callbacks, idle/prepare, poll,
+          check, close — with{" "}
+          <Code>process.nextTick</Code> and microtask drains <em>between</em>{" "}
+          phases (
+          <A href="https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick">
+            Node docs
+          </A>
+          ). <Code>process.nextTick</Code> outranks Promise microtasks; both
+          outrank anything in the next phase. The Node maintainers flag
+          recursive <Code>nextTick</Code> calls as a starvation hazard for the
+          same reason: a queue that drains to empty before yielding will hold
+          the loop forever if you keep refilling it.{" "}
+          <Code>setImmediate</Code> is what you reach for when you need to{" "}
+          <em>not</em> jump the line — it runs in the check phase, after I/O.
+          Browsers don&apos;t ship <Code>setImmediate</Code> or{" "}
+          <Code>process.nextTick</Code>; the equivalents are{" "}
+          <Code>queueMicrotask</Code> and <Code>setTimeout(fn, 0)</Code>.
+        </Aside>
+      </div>
+
+      {/* §6 — closer */}
+      <div>
+        <Dots />
+        <H2>The line that waits its turn</H2>
+        <P>
+          The line that waits its turn is the task queue. The line that{" "}
+          <em>doesn&apos;t</em> is the microtask queue — it gets drained
+          completely, every checkpoint, before anything else moves. One rule
+          explains why <Code>await</Code> works, why <Code>setTimeout(0)</Code>{" "}
+          is never zero, and{" "}
+          <VerticalCutReveal
+            staggerDuration={0.04}
+            staggerFrom="first"
+            transition={{ type: "spring" as const, stiffness: 200, damping: 22 }}
+            as="span"
+            className="inline"
+          >
+            why one runaway Promise can stall your whole tab.
+          </VerticalCutReveal>
+        </P>
+        <p
+          className="font-sans"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+            marginBlockStart: "0.5em",
+          }}
+        >
+          For the call stack itself — frames, hoisting, the scopes a function
+          carries with it — read the sister post:{" "}
+          <A href="/posts/how-javascript-reads-its-own-future">
+            How JavaScript reads its own future
+          </A>
+          .
+        </p>
+        <p
+          aria-hidden
+          className="font-mono text-center select-none"
+          style={{
+            marginBlock: "var(--spacing-xl)",
+            color: "var(--color-accent)",
+            opacity: 0.8,
+            fontSize: "var(--text-body)",
+            letterSpacing: "0.2em",
+          }}
+        >
+          ·
+        </p>
+      </div>
+      <PostNavCards slug="the-line-that-waits-its-turn" />
+    </Prose>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -57,7 +57,7 @@ export default function TheLineThatWaitsItsTurn() {
         <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
           <HeroTile slug="the-line-that-waits-its-turn" />
         </div>
-        <H1>How the JavaScript event loop, microtasks, and the call stack work</H1>
+        <H1>JavaScript Event Loop Explained: Microtasks and the Call Stack</H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"
           style={{
@@ -344,12 +344,13 @@ export default function TheLineThatWaitsItsTurn() {
           ).
         </P>
         <P>
-          The widget below makes the freeze tactile: a recursive{" "}
-          <Code>Promise.resolve().then(loop)</Code> chain on one side, a frame
-          counter and a click-me button on the other. Tap{" "}
-          <em>start runaway</em> and the microtask lane fills instantly while
-          the frame lane stops dead — and your click is left waiting too. Tap{" "}
-          <em>stop</em> to watch the page recover.
+          The widget below makes the priority rule playable. Build a queue:
+          tap <em>+ microtask</em> a few times, then <em>+ macrotask</em>, then{" "}
+          <em>Run</em> — the console writes the firing order so you can see
+          microtasks drain first. Then add a{" "}
+          <em>+ self-scheduling micro</em>: a microtask that schedules another
+          microtask. The macrotask never gets its turn — that&apos;s
+          starvation, made visible without freezing your tab.
         </P>
       </div>
 
@@ -357,12 +358,13 @@ export default function TheLineThatWaitsItsTurn() {
 
       <div>
         <P>
-          While the Promise kept resolving itself, no rAF fired and no click
-          registered. The microtask queue stayed non-empty, so the loop never
-          moved on to the next phase — even though the CPU wasn&apos;t actually
-          that busy. Same rule, different consequence: the priority that lets{" "}
-          <Code>await</Code> feel seamless is the same priority that lets one
-          runaway Promise hold a tab hostage.
+          Each loop tick, the engine drains every pending microtask before
+          touching macrotasks. With a self-scheduling microtask in flight, the
+          microtask queue keeps re-filling itself — the macrotask waits and
+          waits, even though the engine isn&apos;t doing real work, just
+          servicing the queue. Same rule, different consequence: the priority
+          that lets <Code>await</Code> feel seamless is the same priority that
+          lets one runaway Promise hold a tab hostage.
         </P>
         <Aside>
           Node has a different inventory but the same hazard. Its loop runs in

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -212,7 +212,7 @@ export default function TheLineThatWaitsItsTurn() {
           rest of the post is corollaries.
         </P>
         <Aside>
-          This wasn&apos;t always tidy. Through 2016–2017 the major browsers
+          This wasn&apos;t always uniform. Through 2016–2017 the major browsers
           implemented the queue ordering with quiet inconsistencies — Edge and
           Safari resolved Promises in places where Chrome ran microtasks, and a
           handful of MutationObserver edge cases drifted off-spec. Convergence
@@ -317,24 +317,16 @@ export default function TheLineThatWaitsItsTurn() {
           work, different scheduler.
         </P>
         <Aside>
-          Node has a different inventory but the same hazard. Its event loop
-          runs in six phases — timers, pending callbacks, idle/prepare, poll,
-          check, close — with{" "}
-          <Code>process.nextTick</Code> and microtask drains <em>between</em>{" "}
-          phases (
+          Node has a different inventory but the same hazard. Its loop runs in
+          six phases instead of one, with <Code>process.nextTick</Code> and
+          microtask drains <em>between</em> phases (
           <A href="https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick">
             Node docs
           </A>
           ). <Code>process.nextTick</Code> outranks Promise microtasks; both
-          outrank anything in the next phase. The Node maintainers flag
-          recursive <Code>nextTick</Code> calls as a starvation hazard for the
-          same reason: a queue that drains to empty before yielding will hold
-          the loop forever if you keep refilling it.{" "}
-          <Code>setImmediate</Code> is what you reach for when you need to{" "}
-          <em>not</em> jump the line — it runs in the check phase, after I/O.
-          Browsers don&apos;t ship <Code>setImmediate</Code> or{" "}
-          <Code>process.nextTick</Code>; the equivalents are{" "}
-          <Code>queueMicrotask</Code> and <Code>setTimeout(fn, 0)</Code>.
+          outrank anything in the next phase — and a recursive{" "}
+          <Code>nextTick</Code> chain starves the loop the same way a recursive{" "}
+          <Code>.then</Code> chain does in the browser.
         </Aside>
       </div>
 

--- a/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { memo, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * Two equivalent code panes. The async/await form on the left, the .then
+ * form on the right. The 4-step scrubber walks both in lock-step. Step 2 is
+ * the load-bearing tick: both panes annotate "→ microtask queue"
+ * simultaneously.
+ * --------------------------------------------------------------------------*/
+
+const ASYNC_LINES = [
+  `async function f() {`,
+  `  console.log("1");`,
+  `  await Promise.resolve();`,
+  `  console.log("2");`,
+  `}`,
+  `f();`,
+];
+
+const THEN_LINES = [
+  `function f() {`,
+  `  console.log("1");`,
+  `  return Promise.resolve()`,
+  `    .then(() => {`,
+  `      console.log("2");`,
+  `    });`,
+  `}`,
+  `f();`,
+];
+
+type Step = {
+  /** 0-indexed lines highlighted on the async pane. */
+  asyncActive: number[];
+  /** 0-indexed lines highlighted on the .then pane. */
+  thenActive: number[];
+  /** Annotation chip beside async pane (or null). */
+  asyncChip: string | null;
+  /** Annotation chip beside .then pane (or null). */
+  thenChip: string | null;
+  /** Caption text for this tick. */
+  caption: React.ReactNode;
+};
+
+const STEPS: Step[] = [
+  {
+    asyncActive: [1],
+    thenActive: [1],
+    asyncChip: "running",
+    thenChip: "running",
+    caption: (
+      <>
+        <CaptionCue>Tick 1.</CaptionCue> Both panes call{" "}
+        <code className="font-mono">console.log(&quot;1&quot;)</code> synchronously
+        inside the function body.
+      </>
+    ),
+  },
+  {
+    asyncActive: [2],
+    thenActive: [2, 3, 4, 5],
+    asyncChip: "→ microtask queue",
+    thenChip: "→ microtask queue",
+    caption: (
+      <>
+        <CaptionCue>Tick 2 — the load-bearing one.</CaptionCue> On the left,{" "}
+        <code className="font-mono">await</code> suspends the function. On the
+        right, the explicit <code className="font-mono">.then</code> attaches
+        its callback. <strong>Both lines park their continuation in the same
+        microtask queue.</strong>
+      </>
+    ),
+  },
+  {
+    asyncActive: [],
+    thenActive: [],
+    asyncChip: "queued",
+    thenChip: "queued",
+    caption: (
+      <>
+        <CaptionCue>Tick 3.</CaptionCue> The function frame pops. Stack empty
+        → the loop reaches into the microtask queue and pulls the
+        continuation back out.
+      </>
+    ),
+  },
+  {
+    asyncActive: [3],
+    thenActive: [4],
+    asyncChip: "running (continuation)",
+    thenChip: "running (callback)",
+    caption: (
+      <>
+        <CaptionCue>Tick 4.</CaptionCue> Both panes log{" "}
+        <code className="font-mono">&quot;2&quot;</code>. The continuation
+        and the <code className="font-mono">.then</code> callback are the
+        same kind of work — they ran on the same trip through the loop.
+      </>
+    ),
+  },
+];
+
+function CodePane({
+  title,
+  lines,
+  active,
+  chip,
+}: {
+  title: string;
+  lines: string[];
+  active: number[];
+  chip: string | null;
+}) {
+  const LINE_H = 22;
+  const PADDING = 12;
+  // Reserve the longest pane height so the card never grows. Both panes are
+  // capped to 8 lines of reserved height; the .then form is the longer one
+  // (8 lines) so we use that as the canonical reservation.
+  const reservedLines = Math.max(ASYNC_LINES.length, THEN_LINES.length);
+  const minH = reservedLines * LINE_H + PADDING * 2;
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-center justify-between"
+        style={{
+          fontSize: "var(--text-ui)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        <span className="font-sans">{title}</span>
+        <AnimatePresence mode="wait" initial={false}>
+          {chip ? (
+            <motion.span
+              key={chip}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.snappy}
+              className="font-mono"
+              style={{
+                fontSize: 11,
+                padding: "2px 8px",
+                borderRadius: 3,
+                background:
+                  chip.includes("microtask")
+                    ? "var(--color-accent)"
+                    : "transparent",
+                color:
+                  chip.includes("microtask")
+                    ? "var(--color-bg)"
+                    : "var(--color-text-muted)",
+                border:
+                  chip.includes("microtask")
+                    ? "none"
+                    : "1px solid var(--color-rule)",
+              }}
+            >
+              {chip}
+            </motion.span>
+          ) : (
+            <span style={{ visibility: "hidden", fontSize: 11 }}>·</span>
+          )}
+        </AnimatePresence>
+      </div>
+      <div
+        className="relative font-mono"
+        style={{
+          background:
+            "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          padding: PADDING,
+          borderRadius: "var(--radius-sm)",
+          minHeight: minH,
+          fontSize: 12,
+          lineHeight: `${LINE_H}px`,
+          color: "var(--color-text)",
+        }}
+      >
+        {lines.map((line, i) => {
+          const isActive = active.includes(i);
+          return (
+            <div
+              key={i}
+              style={{
+                position: "relative",
+                paddingLeft: 4,
+              }}
+            >
+              {isActive ? (
+                <motion.span
+                  layoutId={undefined}
+                  initial={false}
+                  animate={{ opacity: 1 }}
+                  transition={SPRING.snappy}
+                  style={{
+                    position: "absolute",
+                    inset: `0 -6px 0 -6px`,
+                    background:
+                      "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+                    borderLeft: `2px solid var(--color-accent)`,
+                    borderRadius: 2,
+                    pointerEvents: "none",
+                  }}
+                />
+              ) : null}
+              <span
+                style={{
+                  position: "relative",
+                  color: isActive
+                    ? "var(--color-text)"
+                    : "var(--color-text-muted)",
+                  whiteSpace: "pre",
+                }}
+              >
+                {line || " "}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const MemoCodePane = memo(CodePane);
+
+/**
+ * AwaitDesugar (W3) — two synchronised code panes show that{" "}
+ * `async/await` and `.then` produce the same scheduling. Step 2 — both
+ * panes annotate "→ microtask queue" simultaneously — is the load-bearing
+ * tick.
+ *
+ * One verb: step (via WidgetNav).
+ *
+ * Frame stability (R6): both panes have a fixed `min-height` set to the
+ * longest variant. Line highlight is an absolutely-positioned overlay;
+ * nothing reflows.
+ */
+export function AwaitDesugar() {
+  const [step, setStep] = useState(0);
+  const tick = STEPS[step];
+
+  return (
+    <WidgetShell
+      title="await · the .then in disguise"
+      measurements={`tick ${step + 1} / ${STEPS.length}`}
+      caption={tick.caption}
+      captionTone="prominent"
+      controls={
+        <div className="flex items-center justify-center w-full">
+          <WidgetNav
+            value={step}
+            total={STEPS.length}
+            onChange={setStep}
+            counterNoun="tick"
+          />
+        </div>
+      }
+    >
+      <div
+        className="grid gap-[var(--spacing-md)]"
+        style={{
+          gridTemplateColumns: "1fr",
+        }}
+      >
+        <div
+          className="grid gap-[var(--spacing-md)]"
+          style={{
+            gridTemplateColumns: "minmax(0, 1fr)",
+          }}
+        >
+          <div className="bs-await-grid">
+            <MemoCodePane
+              title="async/await form"
+              lines={ASYNC_LINES}
+              active={tick.asyncActive}
+              chip={tick.asyncChip}
+            />
+            <MemoCodePane
+              title=".then form (equivalent)"
+              lines={THEN_LINES}
+              active={tick.thenActive}
+              chip={tick.thenChip}
+            />
+          </div>
+          <style>{`
+            .bs-await-grid {
+              display: grid;
+              grid-template-columns: 1fr;
+              gap: var(--spacing-md);
+            }
+            @media (min-width: 640px) {
+              .bs-await-grid {
+                grid-template-columns: 1fr 1fr;
+              }
+            }
+          `}</style>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
@@ -71,7 +71,7 @@ const STEPS: Step[] = [
     thenChip: "running",
     caption: (
       <>
-        <CaptionCue>Tick 1.</CaptionCue> Both panes call{" "}
+        <CaptionCue>Step 1.</CaptionCue> Both panes call{" "}
         <code className="font-mono">console.log(&quot;1&quot;)</code> synchronously
         inside the function body.
       </>
@@ -84,7 +84,7 @@ const STEPS: Step[] = [
     thenChip: "→ microtask queue",
     caption: (
       <>
-        <CaptionCue>Tick 2 — the load-bearing one.</CaptionCue> On the left,{" "}
+        <CaptionCue>Step 2 — the load-bearing one.</CaptionCue> On the left,{" "}
         <code className="font-mono">await</code> suspends the function. On the
         right, the explicit <code className="font-mono">.then</code> attaches
         its callback. <strong>Both lines park their continuation in the same
@@ -99,7 +99,7 @@ const STEPS: Step[] = [
     thenChip: "queued",
     caption: (
       <>
-        <CaptionCue>Tick 3.</CaptionCue> The function frame pops. Stack empty
+        <CaptionCue>Step 3.</CaptionCue> The function frame pops. Stack empty
         → the loop reaches into the microtask queue and pulls the
         continuation back out.
       </>
@@ -108,11 +108,11 @@ const STEPS: Step[] = [
   {
     asyncActive: [3],
     thenActive: [4],
-    asyncChip: "running (continuation)",
-    thenChip: "running (callback)",
+    asyncChip: "running",
+    thenChip: "running",
     caption: (
       <>
-        <CaptionCue>Tick 4.</CaptionCue> Both panes log{" "}
+        <CaptionCue>Step 4.</CaptionCue> Both panes log{" "}
         <code className="font-mono">&quot;2&quot;</code>. The continuation
         and the <code className="font-mono">.then</code> callback are the
         same kind of work — they ran on the same trip through the loop.
@@ -194,6 +194,7 @@ function CodePane({
           fontSize: 12,
           lineHeight: `${LINE_H}px`,
           color: "var(--color-text)",
+          overflowX: "auto",
         }}
       >
         {lines.map((line, i) => {
@@ -216,8 +217,7 @@ function CodePane({
                     position: "absolute",
                     inset: `0 -6px 0 -6px`,
                     background:
-                      "color-mix(in oklab, var(--color-accent) 14%, transparent)",
-                    borderLeft: `2px solid var(--color-accent)`,
+                      "color-mix(in oklab, var(--color-accent) 18%, transparent)",
                     borderRadius: 2,
                     pointerEvents: "none",
                   }}
@@ -263,7 +263,7 @@ export function AwaitDesugar() {
   return (
     <WidgetShell
       title="await · the .then in disguise"
-      measurements={`tick ${step + 1} / ${STEPS.length}`}
+      measurements={`step ${step + 1} / ${STEPS.length}`}
       caption={tick.caption}
       captionTone="prominent"
       controls={
@@ -272,7 +272,7 @@ export function AwaitDesugar() {
             value={step}
             total={STEPS.length}
             onChange={setStep}
-            counterNoun="tick"
+            counterNoun="step"
           />
         </div>
       }

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -94,7 +94,7 @@ function PulseDot({ frozen }: { frozen: boolean }) {
   const reduce = useReducedMotion();
   return (
     <span
-      aria-label={frozen ? "render thread blocked" : "render thread alive"}
+      aria-label={frozen ? "paint loop frozen" : "paint loop alive"}
       className="inline-flex items-center gap-[var(--spacing-2xs)] font-sans"
       style={{
         fontSize: "var(--text-small)",
@@ -111,15 +111,15 @@ function PulseDot({ frozen }: { frozen: boolean }) {
           background: "var(--color-accent)",
         }}
         animate={
-          frozen || reduce ? { opacity: 0.25 } : { opacity: [0.3, 1, 0.3] }
+          frozen || reduce ? { opacity: 0.25 } : { opacity: [0.3, 1] }
         }
         transition={
           frozen || reduce
             ? { duration: 0 }
-            : { duration: 1.6, repeat: Infinity, ease: "linear" }
+            : { ...SPRING.gentle, repeat: Infinity, repeatType: "reverse" }
         }
       />
-      <span>{frozen ? "render frozen" : "render alive"}</span>
+      <span>{frozen ? "paint loop frozen" : "paint loop alive"}</span>
     </span>
   );
 }
@@ -190,7 +190,7 @@ export function MicrotaskStarvation() {
 
   return (
     <WidgetShell
-      title={`microtask starvation · mode: ${mode}`}
+      title="microtask starvation"
       measurements={`${count.toLocaleString()} / ${MAX_ITER.toLocaleString()}`}
       caption={
         running ? (
@@ -207,11 +207,11 @@ export function MicrotaskStarvation() {
           </>
         ) : (
           <>
-            <CaptionCue>Toggle the mode</CaptionCue> and tap <em>run</em>. In
-            starve mode, a recursive <code className="font-mono">.then</code>{" "}
-            chain runs to completion before the browser repaints. In yield
-            mode, <code className="font-mono">setTimeout(0)</code> between
-            batches gives the renderer a turn.
+            <CaptionCue>Pick a scheduler</CaptionCue> — starve or yield — and
+            tap <em>run</em>. Starve mode runs a recursive{" "}
+            <code className="font-mono">.then</code> chain to completion before
+            the browser can repaint. Yield mode breaks the work into batches
+            with <code className="font-mono">setTimeout(0)</code>.
           </>
         )
       }
@@ -304,7 +304,7 @@ export function MicrotaskStarvation() {
               border: "1px solid var(--color-rule)",
               transformOrigin: "left center",
             }}
-            aria-label="counter progress"
+            aria-label={`${mode} run progress, ${count} of ${MAX_ITER} iterations`}
             role="progressbar"
             aria-valuenow={Math.round(pct)}
             aria-valuemin={0}
@@ -324,24 +324,6 @@ export function MicrotaskStarvation() {
           </div>
         </div>
 
-        <div
-          className="font-mono"
-          style={{
-            fontSize: 11,
-            color: "var(--color-text-muted)",
-            background:
-              "color-mix(in oklab, var(--color-surface) 60%, transparent)",
-            padding: "var(--spacing-sm)",
-            borderRadius: "var(--radius-sm)",
-            lineHeight: 1.6,
-            whiteSpace: "pre",
-            overflowX: "auto",
-          }}
-        >
-          {mode === "starve"
-            ? `function step(i) {\n  if (i >= MAX) return;\n  Promise.resolve().then(() => step(i + 1));\n}\nstep(0); // microtask drains hold the loop`
-            : `function batch(i) {\n  if (i >= MAX) return;\n  for (let j = 0; j < 200; j++) i++;\n  setTimeout(() => batch(i), 0); // yield between batches\n}\nbatch(0);`}
-        </div>
       </div>
     </WidgetShell>
   );

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { motion, useReducedMotion } from "motion/react";
+import { useCallback, useRef, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING, PRESS } from "@/lib/motion";
 import { WidgetShell } from "@/components/viz/WidgetShell";
@@ -23,321 +23,280 @@ function CaptionCue({ children }: { children: React.ReactNode }) {
 }
 
 /* ---------------------------------------------------------------------------
- * MicrotaskStarvation — two-lane visualization that lets the reader feel
- * the freeze.
+ * MicrotaskStarvation — "Queue Race".
  *
- * IDLE  : a requestAnimationFrame ticks the "frame counter" lane visibly. A
- *         "click me" button increments a "clicks" counter normally. Both
- *         lanes drop a dot per tick to show the rhythm.
- * RUNAWAY: a recursive Promise chain — Promise.resolve().then(loop) —
- *         schedules itself forever (capped at MAX_ROUNDS to protect the
- *         page). The microtask lane fills with dots at high speed; the
- *         frame-counter stops; the click-me button stops responding.
- * STOP   : flips the loop off; rAF resumes; reader sees recovery.
+ * State-machine simulation of the event-loop priority rule:
+ *   On each tick:  drain ALL microtasks  →  run ONE macrotask  →  repeat.
  *
- * Hard caps:
- *   MAX_ROUNDS — 500 microtask hops before auto-bail
- *   MAX_MS     — 1000 ms wall-clock guard
+ * The reader builds the queues by tapping `+ microtask` and `+ macrotask`,
+ * then taps `Run` to drain one tick. The console pane records the firing
+ * order. A fourth button — `+ self-scheduling micro` — adds a microtask
+ * that, when fired, enqueues another microtask (capped at SELF_HOPS to
+ * keep the demo finite). With self-scheduling micros pending, the
+ * macrotask never gets a turn — that is microtask starvation, made
+ * visible without simulating a real freeze.
  *
- * Reduced-motion path: a static "before / after" diptych using the same
- * lane shapes — no live loop, no rAF, no Promise self-scheduling.
+ * No real Promise / setTimeout recursion. No rAF. Pure state machine.
  * --------------------------------------------------------------------------*/
 
-const MAX_ROUNDS = 500;
-const MAX_MS = 1000;
-const LANE_DOT_CAP = 80;
+const SELF_HOPS = 6;
+const STARVED_BADGE_AT = 4;
+const FIRE_DELAY_MS = 280; // visible per-step pacing for the Run animation
+const MAX_CONSOLE_LINES = 12;
 
-type Mode = "idle" | "runaway";
-
-function useFrameTicker(active: boolean, onFrame: () => void) {
-  const rafRef = useRef<number | null>(null);
-  const lastRef = useRef<number>(0);
-  const cbRef = useRef(onFrame);
-  cbRef.current = onFrame;
-
-  useEffect(() => {
-    if (!active) return;
-    let cancelled = false;
-    const loop = (t: number) => {
-      if (cancelled) return;
-      // Throttle to ~30 fps so dots are visible on slow screens.
-      if (t - lastRef.current >= 33) {
-        lastRef.current = t;
-        cbRef.current();
-      }
-      rafRef.current = requestAnimationFrame(loop);
-    };
-    rafRef.current = requestAnimationFrame(loop);
-    return () => {
-      cancelled = true;
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-    };
-  }, [active]);
-}
-
-function Lane({
-  label,
-  count,
-  dots,
-  filled,
-  frozen,
-}: {
+type Chip = {
+  id: string;
   label: string;
-  count: number;
-  dots: number;
-  filled: boolean;
-  frozen: boolean;
-}) {
-  return (
-    <div className="flex flex-col gap-[var(--spacing-2xs)]">
-      <div
-        className="flex items-baseline justify-between font-sans"
-        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
-      >
-        <span style={{ letterSpacing: "0.02em" }}>{label}</span>
-        <span
-          className="font-mono tabular-nums"
-          style={{
-            color: frozen ? "var(--color-text-muted)" : "var(--color-text)",
-            fontSize: 12,
-          }}
-        >
-          {count.toLocaleString()}
-        </span>
-      </div>
-      <div
-        style={{
-          border: "1px dashed var(--color-rule)",
-          borderRadius: "var(--radius-sm)",
-          padding: 8,
-          minHeight: 40,
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 4,
-          background: "color-mix(in oklab, var(--color-surface) 30%, transparent)",
-        }}
-      >
-        {Array.from({ length: Math.min(dots, LANE_DOT_CAP) }).map((_, i) => (
-          <span
-            key={i}
-            aria-hidden
-            style={{
-              display: "inline-block",
-              width: 6,
-              height: 6,
-              borderRadius: "50%",
-              background: filled
-                ? "var(--color-accent)"
-                : "color-mix(in oklab, var(--color-text-muted) 80%, transparent)",
-              opacity: filled ? 0.85 : 0.55,
-            }}
-          />
-        ))}
-        {dots > LANE_DOT_CAP ? (
-          <span
-            className="font-mono"
-            style={{
-              fontSize: 10,
-              color: "var(--color-text-muted)",
-              marginLeft: 4,
-            }}
-          >
-            +{dots - LANE_DOT_CAP}
-          </span>
-        ) : null}
-        {dots === 0 ? (
-          <span
-            className="font-sans"
-            style={{
-              fontSize: 11,
-              color: "var(--color-text-muted)",
-              opacity: 0.5,
-              fontStyle: "italic",
-            }}
-          >
-            empty
-          </span>
-        ) : null}
-      </div>
-    </div>
-  );
-}
+  /** kind === "self" → a micro that schedules another micro when fired. */
+  kind: "micro" | "macro" | "self";
+  /** Hops remaining before a self-scheduling chip stops re-spawning. */
+  hopsLeft?: number;
+};
 
-function ClickMeButton({
-  clicks,
-  onClick,
-  frozen,
-}: {
-  clicks: number;
-  onClick: () => void;
-  frozen: boolean;
-}) {
-  const reduce = useReducedMotion();
-  return (
-    <div className="flex flex-col gap-[var(--spacing-2xs)]">
-      <div
-        className="flex items-baseline justify-between font-sans"
-        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
-      >
-        <span style={{ letterSpacing: "0.02em" }}>UI thread</span>
-        <span
-          className="font-mono tabular-nums"
-          style={{ fontSize: 12, color: "var(--color-text)" }}
-        >
-          {clicks} click{clicks === 1 ? "" : "s"}
-        </span>
-      </div>
-      <motion.button
-        type="button"
-        onClick={onClick}
-        className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-        style={{
-          padding: "10px 14px",
-          fontSize: "var(--text-ui)",
-          background: frozen
-            ? "color-mix(in oklab, var(--color-surface) 80%, transparent)"
-            : "color-mix(in oklab, var(--color-accent) 14%, transparent)",
-          color: frozen ? "var(--color-text-muted)" : "var(--color-accent)",
-          border: `1px solid ${
-            frozen ? "var(--color-rule)" : "var(--color-accent)"
-          }`,
-          cursor: "pointer",
-          transition: reduce
-            ? "none"
-            : "background 200ms, color 200ms, border-color 200ms",
-        }}
-        whileTap={reduce ? undefined : { scale: 0.97 }}
-        transition={SPRING.snappy}
-      >
-        {frozen ? "click me (try it — nothing)" : "click me"}
-      </motion.button>
-    </div>
-  );
-}
+type ConsoleLine = {
+  id: string;
+  label: string;
+  kind: "micro" | "macro";
+};
 
-/**
- * MicrotaskStarvation (W4) — feel the freeze. Two lanes (microtask vs
- * rAF/render) plus a click-me button. Toggle Runaway to start a recursive
- * Promise chain; the rAF dots stop landing and the button stops responding
- * until you toggle Stop. Recovery is visible too — that's the point.
- *
- * One verb: toggle (start / stop the runaway loop).
- *
- * Hard cap: MAX_ROUNDS / MAX_MS. Reduced-motion path replaces the live
- * loop with a static before/after diptych.
- *
- * Frame stability (R6): all four panes have fixed min-heights; lane dots
- * cap at LANE_DOT_CAP and overflow into a "+N" indicator instead of
- * growing the container.
- */
+let __id = 0;
+const nextId = () => `c${++__id}`;
+
 export function MicrotaskStarvation() {
   const reduce = useReducedMotion();
 
-  const [mode, setMode] = useState<Mode>("idle");
-  const [microDots, setMicroDots] = useState(0);
-  const [microCount, setMicroCount] = useState(0);
-  const [frameDots, setFrameDots] = useState(0);
-  const [frameCount, setFrameCount] = useState(0);
-  const [clicks, setClicks] = useState(0);
+  const [micro, setMicro] = useState<Chip[]>([]);
+  const [macro, setMacro] = useState<Chip[]>([]);
+  const [output, setOutput] = useState<ConsoleLine[]>([]);
+  const [tick, setTick] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [starved, setStarved] = useState(false);
 
-  // The runaway loop is driven imperatively by Promise.then re-scheduling.
-  // We use a stop flag the loop checks each round. No setState during loop —
-  // we keep the live count in a ref, then commit it once when the loop bails.
-  const stopRef = useRef(false);
-  const microRef = useRef(0);
+  // Counters for label generation. Persist across resets via state, not refs,
+  // so the chip labels stay readable.
+  const [microSeq, setMicroSeq] = useState(0);
+  const [macroSeq, setMacroSeq] = useState(0);
 
-  const startRunaway = useCallback(() => {
-    stopRef.current = false;
-    microRef.current = 0;
-    const start = performance.now();
+  // Active-chip indicator: which chip is currently "firing" (highlighted).
+  const [activeId, setActiveId] = useState<string | null>(null);
 
-    function step() {
-      if (
-        stopRef.current ||
-        microRef.current >= MAX_ROUNDS ||
-        performance.now() - start > MAX_MS
-      ) {
-        // Bail. Commit final counts in one paint.
-        setMicroCount((c) => c + microRef.current);
-        setMicroDots((d) => Math.min(d + microRef.current, LANE_DOT_CAP));
-        setMode("idle");
-        return;
-      }
-      microRef.current++;
-      Promise.resolve().then(step);
-    }
-    Promise.resolve().then(step);
+  const cancelRef = useRef(false);
+
+  const addMicro = useCallback(() => {
+    if (running) return;
+    setMicroSeq((n) => {
+      const next = n + 1;
+      setMicro((q) => [...q, { id: nextId(), label: `m${next}`, kind: "micro" }]);
+      return next;
+    });
+  }, [running]);
+
+  const addSelf = useCallback(() => {
+    if (running) return;
+    setMicroSeq((n) => {
+      const next = n + 1;
+      setMicro((q) => [
+        ...q,
+        {
+          id: nextId(),
+          label: `m${next}*`,
+          kind: "self",
+          hopsLeft: SELF_HOPS,
+        },
+      ]);
+      return next;
+    });
+  }, [running]);
+
+  const addMacro = useCallback(() => {
+    if (running) return;
+    setMacroSeq((n) => {
+      const next = n + 1;
+      setMacro((q) => [...q, { id: nextId(), label: `M${next}`, kind: "macro" }]);
+      return next;
+    });
+  }, [running]);
+
+  const reset = useCallback(() => {
+    cancelRef.current = true;
+    setMicro([]);
+    setMacro([]);
+    setOutput([]);
+    setTick(0);
+    setMicroSeq(0);
+    setMacroSeq(0);
+    setStarved(false);
+    setRunning(false);
+    setActiveId(null);
   }, []);
 
-  const handleToggle = () => {
-    if (mode === "runaway") {
-      // Stop button — flag tells the loop to bail at its next check.
-      stopRef.current = true;
-      return;
+  // Read latest queue state via functional setters; UI updates each step.
+  const wait = (ms: number) =>
+    new Promise<void>((res) => {
+      const t = window.setTimeout(res, ms);
+      // best-effort cancel: we still resolve, but the run loop checks
+      // cancelRef.current to bail.
+      void t;
+    });
+
+  const fireOneFromQueue = useCallback(
+    async (
+      kind: "micro" | "macro",
+      step: number,
+    ): Promise<{ fired: boolean; spawnedSelf: boolean }> => {
+      // Snapshot top-of-queue.
+      let snapshot: Chip | undefined;
+      if (kind === "micro") {
+        setMicro((q) => {
+          snapshot = q[0];
+          return q;
+        });
+      } else {
+        setMacro((q) => {
+          snapshot = q[0];
+          return q;
+        });
+      }
+      // Allow setMicro/setMacro flush.
+      await wait(0);
+      if (!snapshot) return { fired: false, spawnedSelf: false };
+
+      // Highlight the head briefly.
+      setActiveId(snapshot.id);
+      await wait(reduce ? 0 : Math.round(FIRE_DELAY_MS * 0.45));
+
+      // Pop it + write to console + maybe spawn next self-scheduling micro.
+      const fired = snapshot;
+      let spawnedSelf = false;
+      if (kind === "micro") {
+        setMicro((q) => q.slice(1));
+        setOutput((o) =>
+          [
+            ...o,
+            { id: nextId(), label: fired.label, kind: "micro" as const },
+          ].slice(-MAX_CONSOLE_LINES),
+        );
+        if (fired.kind === "self" && (fired.hopsLeft ?? 0) > 1) {
+          const remaining = (fired.hopsLeft ?? 0) - 1;
+          spawnedSelf = true;
+          setMicro((q) => [
+            ...q,
+            {
+              id: nextId(),
+              label: `${fired.label.replace(/\*$/, "")}→${SELF_HOPS - remaining + 1}*`,
+              kind: "self",
+              hopsLeft: remaining,
+            },
+          ]);
+        }
+      } else {
+        setMacro((q) => q.slice(1));
+        setOutput((o) =>
+          [
+            ...o,
+            { id: nextId(), label: fired.label, kind: "macro" as const },
+          ].slice(-MAX_CONSOLE_LINES),
+        );
+      }
+
+      // Trigger starved badge once we've drained STARVED_BADGE_AT consecutive
+      // micros within the same Run with macros pending.
+      if (kind === "micro" && step >= STARVED_BADGE_AT) {
+        setStarved((prev) => {
+          if (prev) return prev;
+          // Only mark starved if there ARE macros waiting.
+          let hasMacro = false;
+          setMacro((q) => {
+            hasMacro = q.length > 0;
+            return q;
+          });
+          return hasMacro;
+        });
+      }
+
+      await wait(reduce ? 0 : Math.round(FIRE_DELAY_MS * 0.55));
+      setActiveId(null);
+      return { fired: true, spawnedSelf };
+    },
+    [reduce],
+  );
+
+  // Probe current queue lengths via setState callback — guarantees freshest
+  // values without subscribing to render cycles.
+  const peekMicroLen = () =>
+    new Promise<number>((res) => {
+      setMicro((q) => {
+        res(q.length);
+        return q;
+      });
+    });
+  const peekMacroLen = () =>
+    new Promise<number>((res) => {
+      setMacro((q) => {
+        res(q.length);
+        return q;
+      });
+    });
+
+  const run = useCallback(async () => {
+    if (running) return;
+    cancelRef.current = false;
+    setRunning(true);
+
+    // Hard cap on micro-drain steps in a single Run (handles self-scheduling
+    // chains). Visually matches "the macrotask never got its turn".
+    const MAX_MICRO_STEPS_PER_TICK = 32;
+
+    let microSteps = 0;
+    let microLen = await peekMicroLen();
+    while (microLen > 0 && microSteps < MAX_MICRO_STEPS_PER_TICK) {
+      if (cancelRef.current) break;
+      await fireOneFromQueue("micro", microSteps);
+      microSteps++;
+      microLen = await peekMicroLen();
     }
-    if (reduce) {
-      // Reduced-motion: simulate the freeze synthetically without actually
-      // blocking. Bump the counters to the same end state in one paint.
-      setMicroCount((c) => c + MAX_ROUNDS);
-      setMicroDots((d) => Math.min(d + MAX_ROUNDS, LANE_DOT_CAP));
-      return;
+
+    // ONE macrotask, only if we drained micros (else: starved).
+    if (!cancelRef.current && microSteps < MAX_MICRO_STEPS_PER_TICK) {
+      const macLen = await peekMacroLen();
+      if (macLen > 0) {
+        await fireOneFromQueue("macro", 0);
+      }
     }
-    setMode("runaway");
-    startRunaway();
-  };
 
-  const handleReset = () => {
-    stopRef.current = true;
-    setMode("idle");
-    setMicroDots(0);
-    setMicroCount(0);
-    setFrameDots(0);
-    setFrameCount(0);
-    setClicks(0);
-  };
+    setTick((t) => t + 1);
+    setRunning(false);
+  }, [running, fireOneFromQueue]);
 
-  // Drive the rAF lane only when we're not running the runaway loop. The
-  // whole point: when the microtask drain is in progress, this hook can't
-  // get its callbacks fired anyway — but we explicitly pause it on mode
-  // change so the post-runaway state shows the freeze cleanly.
-  useFrameTicker(mode === "idle" && !reduce, () => {
-    setFrameCount((c) => c + 1);
-    setFrameDots((d) => Math.min(d + 1, LANE_DOT_CAP));
-  });
-
-  // Reset only the lanes' dots on mode change so the reader can replay.
-  // (counters stay so they can compare totals across runs.)
-
-  const isFrozen = mode === "runaway";
+  // Derived
+  const outputStr = output.map((o) => o.label).join(" · ") || "—";
 
   return (
     <WidgetShell
-      title="microtask starvation · feel the freeze"
-      measurements={
-        isFrozen ? "runaway · frames stalled" : `${frameCount} frames · ${microCount} micro`
-      }
+      title="queue race · microtasks vs macrotasks"
+      measurements={`tick ${tick} · output ${output.length}`}
       caption={
-        isFrozen ? (
+        starved ? (
           <>
-            <CaptionCue>Loop running.</CaptionCue> The microtask queue keeps
-            re-filling itself. The render thread can&apos;t reach a frame, the
-            click-me button can&apos;t process input — the page is technically
-            alive but functionally frozen.
+            <CaptionCue>Microtask starvation.</CaptionCue> Each fired microtask
+            adds another microtask, so the queue never empties — and the
+            macrotask never gets its turn. One runaway Promise chain stalls
+            everything else, even though the engine isn&apos;t doing real work.
           </>
-        ) : microCount > 0 ? (
+        ) : output.length === 0 ? (
           <>
-            <CaptionCue>Runaway resolved.</CaptionCue> While the Promise kept
-            re-scheduling itself, no rAF fired and no click registered. The
-            microtask queue stayed non-empty, so the loop never moved on. That
-            is why one runaway Promise can stall a tab.
+            <CaptionCue>Build the queues, then Run.</CaptionCue> Add a few
+            microtasks and a macrotask. Tap <em>Run</em>: the loop drains{" "}
+            <em>every</em> microtask first, then runs <em>one</em> macrotask.
+            Try <em>+ self-scheduling micro</em> to feel the priority rule
+            bite.
           </>
         ) : (
           <>
-            <CaptionCue>Tap <em>start runaway</em>.</CaptionCue> The microtask
-            lane will fill instantly while the frame lane stops. Try clicking
-            the button mid-run — it won&apos;t respond. Hit <em>stop</em> to
-            see the page recover.
+            <CaptionCue>One tick complete.</CaptionCue> The microtask queue
+            drained fully before any macrotask ran. Add more, hit Run again —
+            or try a self-scheduling microtask to see what happens when the
+            queue refuses to empty.
           </>
         )
       }
@@ -346,25 +305,88 @@ export function MicrotaskStarvation() {
         <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] w-full">
           <motion.button
             type="button"
-            onClick={handleToggle}
-            className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+            onClick={addMicro}
+            disabled={running}
+            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
             style={{
-              padding: "8px 18px",
+              padding: "8px 14px",
               fontSize: "var(--text-ui)",
-              background: isFrozen ? "transparent" : "var(--color-accent)",
-              color: isFrozen ? "var(--color-accent)" : "var(--color-bg)",
-              border: isFrozen
-                ? "1px solid var(--color-accent)"
-                : "none",
+              background: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+              color: "var(--color-accent)",
+              border: "1px solid var(--color-accent)",
+              opacity: running ? 0.5 : 1,
+              cursor: running ? "not-allowed" : "pointer",
             }}
-            {...PRESS}
+            {...(running ? {} : PRESS)}
           >
-            {isFrozen ? "stop" : microCount > 0 ? "run again ▸" : "start runaway ▸"}
+            + microtask
           </motion.button>
           <motion.button
             type="button"
-            onClick={handleReset}
+            onClick={addMacro}
+            disabled={running}
+            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
+            style={{
+              padding: "8px 14px",
+              fontSize: "var(--text-ui)",
+              background: "transparent",
+              color: "var(--color-text)",
+              border: "1px solid var(--color-rule)",
+              opacity: running ? 0.5 : 1,
+              cursor: running ? "not-allowed" : "pointer",
+            }}
+            {...(running ? {} : PRESS)}
+          >
+            + macrotask
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={addSelf}
+            disabled={running}
+            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
+            style={{
+              padding: "8px 14px",
+              fontSize: "var(--text-ui)",
+              background: "color-mix(in oklab, var(--color-accent) 8%, transparent)",
+              color: "var(--color-accent)",
+              border: "1px dashed var(--color-accent)",
+              opacity: running ? 0.5 : 1,
+              cursor: running ? "not-allowed" : "pointer",
+            }}
+            {...(running ? {} : PRESS)}
+            aria-label="add a self-scheduling microtask (warning: starves the macrotask queue)"
+          >
+            + self-scheduling micro
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={run}
+            disabled={running || (micro.length === 0 && macro.length === 0)}
             className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+            style={{
+              padding: "8px 22px",
+              fontSize: "var(--text-ui)",
+              background: "var(--color-accent)",
+              color: "var(--color-bg)",
+              border: "none",
+              opacity:
+                running || (micro.length === 0 && macro.length === 0) ? 0.5 : 1,
+              cursor:
+                running || (micro.length === 0 && macro.length === 0)
+                  ? "not-allowed"
+                  : "pointer",
+              fontWeight: 600,
+            }}
+            {...(running || (micro.length === 0 && macro.length === 0)
+              ? {}
+              : PRESS)}
+          >
+            {running ? "running…" : "Run ▸"}
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={reset}
+            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
             style={{
               padding: "8px 14px",
               fontSize: "var(--text-ui)",
@@ -380,42 +402,295 @@ export function MicrotaskStarvation() {
       }
     >
       <div className="flex flex-col gap-[var(--spacing-md)]">
-        {/* Two columns on lg, stacked on mobile. Microtask lane on top so the
-            reader's eye lands there first when it suddenly fills. */}
-        <div className="bs-starvation-grid">
-          <Lane
+        <div className="bs-qrace-grid">
+          <QueueColumn
             label="microtask queue"
-            count={microCount}
-            dots={microDots}
-            filled
-            frozen={false}
+            chips={micro}
+            activeId={activeId}
+            accent
           />
-          <Lane
-            label="render frames (rAF)"
-            count={frameCount}
-            dots={frameDots}
-            filled={false}
-            frozen={isFrozen}
+          <QueueColumn
+            label="macrotask queue"
+            chips={macro}
+            activeId={activeId}
+            accent={false}
+            badge={starved ? "starved" : null}
           />
         </div>
-        <ClickMeButton
-          clicks={clicks}
-          onClick={() => setClicks((c) => c + 1)}
-          frozen={isFrozen}
-        />
+        <ConsolePane lines={output} />
+        <p
+          className="font-sans"
+          style={{
+            fontSize: 12,
+            color: "var(--color-text-muted)",
+            margin: 0,
+            textAlign: "center",
+            lineHeight: 1.5,
+          }}
+        >
+          Run = drain <em>all</em> microtasks, then <em>one</em> macrotask, then
+          repeat.
+        </p>
         <style>{`
-          .bs-starvation-grid {
+          .bs-qrace-grid {
             display: grid;
             grid-template-columns: 1fr;
             gap: var(--spacing-md);
           }
           @media (min-width: 640px) {
-            .bs-starvation-grid {
+            .bs-qrace-grid {
               grid-template-columns: 1fr 1fr;
             }
           }
         `}</style>
       </div>
     </WidgetShell>
+  );
+}
+
+function QueueColumn({
+  label,
+  chips,
+  activeId,
+  accent,
+  badge,
+}: {
+  label: string;
+  chips: Chip[];
+  activeId: string | null;
+  accent: boolean;
+  badge?: string | null;
+}) {
+  // Reserve at least 4 chip rows of vertical space (R6 frame stability).
+  const RESERVED = 4;
+  const ROW_H = 30;
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-center justify-between font-sans"
+        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
+      >
+        <span style={{ letterSpacing: "0.02em" }}>{label}</span>
+        <AnimatePresence initial={false}>
+          {badge ? (
+            <motion.span
+              key="badge"
+              initial={{ opacity: 0, scale: 0.7 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.7 }}
+              transition={SPRING.smooth}
+              className="font-mono"
+              style={{
+                fontSize: 10,
+                padding: "2px 8px",
+                borderRadius: 999,
+                color: "var(--color-bg)",
+                background: "var(--color-accent)",
+                letterSpacing: "0.04em",
+                textTransform: "uppercase",
+              }}
+            >
+              {badge}
+            </motion.span>
+          ) : (
+            <span
+              className="font-mono tabular-nums"
+              style={{ fontSize: 11, opacity: 0.7 }}
+            >
+              {chips.length}
+            </span>
+          )}
+        </AnimatePresence>
+      </div>
+      <div
+        style={{
+          border: `1px ${accent ? "solid" : "dashed"} var(--color-rule)`,
+          borderRadius: "var(--radius-sm)",
+          padding: 8,
+          minHeight: RESERVED * (ROW_H + 6) + 16,
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+          background: accent
+            ? "color-mix(in oklab, var(--color-accent) 4%, transparent)"
+            : "color-mix(in oklab, var(--color-surface) 30%, transparent)",
+          position: "relative",
+        }}
+      >
+        <AnimatePresence initial={false}>
+          {chips.length === 0 ? (
+            <motion.span
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-sans"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                opacity: 0.5,
+                fontStyle: "italic",
+                position: "absolute",
+                top: "50%",
+                left: 0,
+                right: 0,
+                textAlign: "center",
+                transform: "translateY(-50%)",
+                pointerEvents: "none",
+              }}
+            >
+              empty
+            </motion.span>
+          ) : (
+            chips.map((c) => {
+              const isActive = activeId === c.id;
+              return (
+                <motion.div
+                  key={c.id}
+                  layout
+                  layoutId={`chip-${c.id}`}
+                  initial={{ opacity: 0, scale: 0.8, y: 6 }}
+                  animate={{
+                    opacity: 1,
+                    scale: isActive ? 1.04 : 1,
+                    y: 0,
+                  }}
+                  exit={{ opacity: 0, scale: 0.7, x: 18 }}
+                  transition={SPRING.smooth}
+                  className="font-mono"
+                  style={{
+                    height: ROW_H,
+                    lineHeight: `${ROW_H}px`,
+                    paddingInline: 12,
+                    fontSize: 12,
+                    borderRadius: 4,
+                    background: accent
+                      ? isActive
+                        ? "var(--color-accent)"
+                        : "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                      : isActive
+                        ? "color-mix(in oklab, var(--color-text) 14%, transparent)"
+                        : "color-mix(in oklab, var(--color-surface) 80%, transparent)",
+                    color: accent
+                      ? isActive
+                        ? "var(--color-bg)"
+                        : "var(--color-accent)"
+                      : "var(--color-text)",
+                    border: `1px ${
+                      c.kind === "self" ? "dashed" : "solid"
+                    } ${
+                      accent ? "var(--color-accent)" : "var(--color-rule)"
+                    }`,
+                    textAlign: "left",
+                  }}
+                >
+                  {c.label}
+                  {c.kind === "self" ? (
+                    <span
+                      aria-hidden
+                      style={{
+                        marginLeft: 8,
+                        fontSize: 10,
+                        opacity: 0.7,
+                      }}
+                    >
+                      ↻
+                    </span>
+                  ) : null}
+                </motion.div>
+              );
+            })
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function ConsolePane({ lines }: { lines: ConsoleLine[] }) {
+  const RESERVED_LINES = 4;
+  const LINE_H = 22;
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-baseline justify-between font-sans"
+        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
+      >
+        <span style={{ letterSpacing: "0.02em" }}>console · firing order</span>
+        <span
+          className="font-mono tabular-nums"
+          style={{ fontSize: 11, opacity: 0.7 }}
+        >
+          {lines.length}
+        </span>
+      </div>
+      <div
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: "8px 12px",
+          minHeight: RESERVED_LINES * LINE_H + 16,
+          fontSize: 12,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        <AnimatePresence initial={false}>
+          {lines.length === 0 ? (
+            <motion.span
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-sans"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                opacity: 0.5,
+                fontStyle: "italic",
+                lineHeight: `${LINE_H}px`,
+              }}
+            >
+              waiting for Run…
+            </motion.span>
+          ) : (
+            lines.map((l, i) => (
+              <motion.div
+                key={l.id}
+                layout
+                initial={{ opacity: 0, x: -10 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.smooth}
+                className="font-mono"
+                style={{
+                  lineHeight: `${LINE_H}px`,
+                  color:
+                    l.kind === "micro"
+                      ? "var(--color-accent)"
+                      : "var(--color-text)",
+                  whiteSpace: "pre",
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--color-text-muted)",
+                    marginRight: 8,
+                    opacity: 0.7,
+                  }}
+                >
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span>
+                  {l.kind === "micro" ? "micro" : "macro"} → {l.label}
+                </span>
+              </motion.div>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
   );
 }

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -23,307 +23,398 @@ function CaptionCue({ children }: { children: React.ReactNode }) {
 }
 
 /* ---------------------------------------------------------------------------
- * Bounded microtask flood vs setTimeout(0)-yielded loop. Hard cap at 50_000
- * iterations OR 500 ms wall-clock so it can't brick the page even on slow
- * devices. The reduced-motion path skips the live loop and shows the same
- * outcome statically.
+ * MicrotaskStarvation — two-lane visualization that lets the reader feel
+ * the freeze.
+ *
+ * IDLE  : a requestAnimationFrame ticks the "frame counter" lane visibly. A
+ *         "click me" button increments a "clicks" counter normally. Both
+ *         lanes drop a dot per tick to show the rhythm.
+ * RUNAWAY: a recursive Promise chain — Promise.resolve().then(loop) —
+ *         schedules itself forever (capped at MAX_ROUNDS to protect the
+ *         page). The microtask lane fills with dots at high speed; the
+ *         frame-counter stops; the click-me button stops responding.
+ * STOP   : flips the loop off; rAF resumes; reader sees recovery.
+ *
+ * Hard caps:
+ *   MAX_ROUNDS — 500 microtask hops before auto-bail
+ *   MAX_MS     — 1000 ms wall-clock guard
+ *
+ * Reduced-motion path: a static "before / after" diptych using the same
+ * lane shapes — no live loop, no rAF, no Promise self-scheduling.
  * --------------------------------------------------------------------------*/
 
-const MAX_ITER = 50_000;
-const MAX_MS = 500;
-const TICK_BATCH = 200; // for yield mode, repaint between batches
+const MAX_ROUNDS = 500;
+const MAX_MS = 1000;
+const LANE_DOT_CAP = 80;
 
-type Mode = "starve" | "yield";
+type Mode = "idle" | "runaway";
 
-function startStarve(
-  setCount: (n: number) => void,
-  onDone: (final: number) => void,
-) {
-  const start = performance.now();
-  let i = 0;
-  // Recursive .then chain — each tick of the chain is a microtask, so the
-  // browser gets no chance to repaint until the chain ends.
-  function step() {
-    if (i >= MAX_ITER || performance.now() - start > MAX_MS) {
-      // We can update React state here, but the paint won't happen until
-      // the current microtask drain finishes.
-      setCount(i);
-      onDone(i);
-      return;
-    }
-    i++;
-    Promise.resolve().then(step);
-  }
-  Promise.resolve().then(step);
+function useFrameTicker(active: boolean, onFrame: () => void) {
+  const rafRef = useRef<number | null>(null);
+  const lastRef = useRef<number>(0);
+  const cbRef = useRef(onFrame);
+  cbRef.current = onFrame;
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    const loop = (t: number) => {
+      if (cancelled) return;
+      // Throttle to ~30 fps so dots are visible on slow screens.
+      if (t - lastRef.current >= 33) {
+        lastRef.current = t;
+        cbRef.current();
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      cancelled = true;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [active]);
 }
 
-function startYield(
-  setCount: (n: number) => void,
-  onDone: (final: number) => void,
-  shouldStop: () => boolean,
-) {
-  const start = performance.now();
-  let i = 0;
-  function batch() {
-    if (shouldStop()) {
-      onDone(i);
-      return;
-    }
-    if (i >= MAX_ITER || performance.now() - start > MAX_MS) {
-      setCount(i);
-      onDone(i);
-      return;
-    }
-    // Run a batch of work synchronously, then yield.
-    const end = Math.min(i + TICK_BATCH, MAX_ITER);
-    while (i < end) {
-      i++;
-    }
-    setCount(i);
-    setTimeout(batch, 0);
-  }
-  setTimeout(batch, 0);
+function Lane({
+  label,
+  count,
+  dots,
+  filled,
+  frozen,
+}: {
+  label: string;
+  count: number;
+  dots: number;
+  filled: boolean;
+  frozen: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-baseline justify-between font-sans"
+        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
+      >
+        <span style={{ letterSpacing: "0.02em" }}>{label}</span>
+        <span
+          className="font-mono tabular-nums"
+          style={{
+            color: frozen ? "var(--color-text-muted)" : "var(--color-text)",
+            fontSize: 12,
+          }}
+        >
+          {count.toLocaleString()}
+        </span>
+      </div>
+      <div
+        style={{
+          border: "1px dashed var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: 8,
+          minHeight: 40,
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 4,
+          background: "color-mix(in oklab, var(--color-surface) 30%, transparent)",
+        }}
+      >
+        {Array.from({ length: Math.min(dots, LANE_DOT_CAP) }).map((_, i) => (
+          <span
+            key={i}
+            aria-hidden
+            style={{
+              display: "inline-block",
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: filled
+                ? "var(--color-accent)"
+                : "color-mix(in oklab, var(--color-text-muted) 80%, transparent)",
+              opacity: filled ? 0.85 : 0.55,
+            }}
+          />
+        ))}
+        {dots > LANE_DOT_CAP ? (
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 10,
+              color: "var(--color-text-muted)",
+              marginLeft: 4,
+            }}
+          >
+            +{dots - LANE_DOT_CAP}
+          </span>
+        ) : null}
+        {dots === 0 ? (
+          <span
+            className="font-sans"
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              opacity: 0.5,
+              fontStyle: "italic",
+            }}
+          >
+            empty
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
 }
 
-/* Pulse-dot via rAF. Updates a ref-driven state so we can read it back to
- * see if frames landed during the last 200 ms window. In starve mode the
- * loop keeps ticking but `setCount` doesn't paint — so the dot freezes
- * because the render thread never runs. We add an explicit "frozen" flag
- * the parent flips while starve is in flight. */
-function PulseDot({ frozen }: { frozen: boolean }) {
+function ClickMeButton({
+  clicks,
+  onClick,
+  frozen,
+}: {
+  clicks: number;
+  onClick: () => void;
+  frozen: boolean;
+}) {
   const reduce = useReducedMotion();
   return (
-    <span
-      aria-label={frozen ? "paint loop frozen" : "paint loop alive"}
-      className="inline-flex items-center gap-[var(--spacing-2xs)] font-sans"
-      style={{
-        fontSize: "var(--text-small)",
-        color: "var(--color-text-muted)",
-      }}
-    >
-      <motion.span
-        aria-hidden
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-baseline justify-between font-sans"
+        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
+      >
+        <span style={{ letterSpacing: "0.02em" }}>UI thread</span>
+        <span
+          className="font-mono tabular-nums"
+          style={{ fontSize: 12, color: "var(--color-text)" }}
+        >
+          {clicks} click{clicks === 1 ? "" : "s"}
+        </span>
+      </div>
+      <motion.button
+        type="button"
+        onClick={onClick}
+        className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
         style={{
-          display: "inline-block",
-          width: 8,
-          height: 8,
-          borderRadius: "50%",
-          background: "var(--color-accent)",
+          padding: "10px 14px",
+          fontSize: "var(--text-ui)",
+          background: frozen
+            ? "color-mix(in oklab, var(--color-surface) 80%, transparent)"
+            : "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+          color: frozen ? "var(--color-text-muted)" : "var(--color-accent)",
+          border: `1px solid ${
+            frozen ? "var(--color-rule)" : "var(--color-accent)"
+          }`,
+          cursor: "pointer",
+          transition: reduce
+            ? "none"
+            : "background 200ms, color 200ms, border-color 200ms",
         }}
-        animate={
-          frozen || reduce ? { opacity: 0.25 } : { opacity: [0.3, 1] }
-        }
-        transition={
-          frozen || reduce
-            ? { duration: 0 }
-            : { ...SPRING.gentle, repeat: Infinity, repeatType: "reverse" }
-        }
-      />
-      <span>{frozen ? "paint loop frozen" : "paint loop alive"}</span>
-    </span>
+        whileTap={reduce ? undefined : { scale: 0.97 }}
+        transition={SPRING.snappy}
+      >
+        {frozen ? "click me (try it — nothing)" : "click me"}
+      </motion.button>
+    </div>
   );
 }
 
 /**
- * MicrotaskStarvation (W4) — bounded flood vs yielded loop. Toggle the
- * mode; the counter races the same MAX_ITER iterations either way. In
- * starve mode, the page can't repaint until the chain finishes; in yield
- * mode, the counter ticks visibly and the pulse-dot keeps pulsing.
+ * MicrotaskStarvation (W4) — feel the freeze. Two lanes (microtask vs
+ * rAF/render) plus a click-me button. Toggle Runaway to start a recursive
+ * Promise chain; the rAF dots stop landing and the button stops responding
+ * until you toggle Stop. Recovery is visible too — that's the point.
  *
- * One verb: toggle (mode segmented control). The "run" button is the
- * engagement; the segmented control is parameter selection.
+ * One verb: toggle (start / stop the runaway loop).
  *
- * Hard cap: 50_000 iterations OR 500 ms wall-clock — can't brick the page.
+ * Hard cap: MAX_ROUNDS / MAX_MS. Reduced-motion path replaces the live
+ * loop with a static before/after diptych.
  *
- * Reduced motion: pulse-dot uses opacity only (no infinite scale animation).
+ * Frame stability (R6): all four panes have fixed min-heights; lane dots
+ * cap at LANE_DOT_CAP and overflow into a "+N" indicator instead of
+ * growing the container.
  */
 export function MicrotaskStarvation() {
-  const [mode, setMode] = useState<Mode>("starve");
-  const [running, setRunning] = useState(false);
-  const [count, setCount] = useState(0);
-  const [final, setFinal] = useState<number | null>(null);
-  const stopRef = useRef(false);
+  const reduce = useReducedMotion();
 
-  const reset = useCallback(() => {
-    stopRef.current = true;
-    setRunning(false);
-    setCount(0);
-    setFinal(null);
+  const [mode, setMode] = useState<Mode>("idle");
+  const [microDots, setMicroDots] = useState(0);
+  const [microCount, setMicroCount] = useState(0);
+  const [frameDots, setFrameDots] = useState(0);
+  const [frameCount, setFrameCount] = useState(0);
+  const [clicks, setClicks] = useState(0);
+
+  // The runaway loop is driven imperatively by Promise.then re-scheduling.
+  // We use a stop flag the loop checks each round. No setState during loop —
+  // we keep the live count in a ref, then commit it once when the loop bails.
+  const stopRef = useRef(false);
+  const microRef = useRef(0);
+
+  const startRunaway = useCallback(() => {
+    stopRef.current = false;
+    microRef.current = 0;
+    const start = performance.now();
+
+    function step() {
+      if (
+        stopRef.current ||
+        microRef.current >= MAX_ROUNDS ||
+        performance.now() - start > MAX_MS
+      ) {
+        // Bail. Commit final counts in one paint.
+        setMicroCount((c) => c + microRef.current);
+        setMicroDots((d) => Math.min(d + microRef.current, LANE_DOT_CAP));
+        setMode("idle");
+        return;
+      }
+      microRef.current++;
+      Promise.resolve().then(step);
+    }
+    Promise.resolve().then(step);
   }, []);
 
-  function run() {
-    if (running) return;
-    stopRef.current = false;
-    setCount(0);
-    setFinal(null);
-    setRunning(true);
-
-    if (mode === "starve") {
-      startStarve(
-        (n) => setCount(n),
-        (n) => {
-          setFinal(n);
-          setRunning(false);
-        },
-      );
-    } else {
-      startYield(
-        (n) => setCount(n),
-        (n) => {
-          setFinal(n);
-          setRunning(false);
-        },
-        () => stopRef.current,
-      );
+  const handleToggle = () => {
+    if (mode === "runaway") {
+      // Stop button — flag tells the loop to bail at its next check.
+      stopRef.current = true;
+      return;
     }
-  }
+    if (reduce) {
+      // Reduced-motion: simulate the freeze synthetically without actually
+      // blocking. Bump the counters to the same end state in one paint.
+      setMicroCount((c) => c + MAX_ROUNDS);
+      setMicroDots((d) => Math.min(d + MAX_ROUNDS, LANE_DOT_CAP));
+      return;
+    }
+    setMode("runaway");
+    startRunaway();
+  };
 
-  // Reset on mode change.
-  useEffect(() => {
-    reset();
-  }, [mode, reset]);
+  const handleReset = () => {
+    stopRef.current = true;
+    setMode("idle");
+    setMicroDots(0);
+    setMicroCount(0);
+    setFrameDots(0);
+    setFrameCount(0);
+    setClicks(0);
+  };
 
-  const pct = Math.min(100, (count / MAX_ITER) * 100);
-  // Frozen dot only while a starve run is in flight (counter goes 0 → final
-  // in one paint). In yield mode the dot keeps pulsing even between batches.
-  const frozen = mode === "starve" && running;
+  // Drive the rAF lane only when we're not running the runaway loop. The
+  // whole point: when the microtask drain is in progress, this hook can't
+  // get its callbacks fired anyway — but we explicitly pause it on mode
+  // change so the post-runaway state shows the freeze cleanly.
+  useFrameTicker(mode === "idle" && !reduce, () => {
+    setFrameCount((c) => c + 1);
+    setFrameDots((d) => Math.min(d + 1, LANE_DOT_CAP));
+  });
+
+  // Reset only the lanes' dots on mode change so the reader can replay.
+  // (counters stay so they can compare totals across runs.)
+
+  const isFrozen = mode === "runaway";
 
   return (
     <WidgetShell
-      title="microtask starvation"
-      measurements={`${count.toLocaleString()} / ${MAX_ITER.toLocaleString()}`}
+      title="microtask starvation · feel the freeze"
+      measurements={
+        isFrozen ? "runaway · frames stalled" : `${frameCount} frames · ${microCount} micro`
+      }
       caption={
-        running ? (
+        isFrozen ? (
           <>
-            <CaptionCue>Running.</CaptionCue> {mode === "starve"
-              ? "The microtask drain holds the loop. The counter doesn't paint and the pulse-dot freezes until the chain finishes."
-              : "setTimeout(0) hands the loop back between batches. Rendering interleaves; the counter ticks visibly."}
+            <CaptionCue>Loop running.</CaptionCue> The microtask queue keeps
+            re-filling itself. The render thread can&apos;t reach a frame, the
+            click-me button can&apos;t process input — the page is technically
+            alive but functionally frozen.
           </>
-        ) : final !== null ? (
+        ) : microCount > 0 ? (
           <>
-            <CaptionCue>Done.</CaptionCue> {mode === "starve"
-              ? "Counter jumped from 0 straight to its final value in a single paint. The microtask checkpoint can't yield mid-drain."
-              : "Each batch yielded back to the loop. Rendering happened between every batch."}
+            <CaptionCue>Runaway resolved.</CaptionCue> While the Promise kept
+            re-scheduling itself, no rAF fired and no click registered. The
+            microtask queue stayed non-empty, so the loop never moved on. That
+            is why one runaway Promise can stall a tab.
           </>
         ) : (
           <>
-            <CaptionCue>Pick a scheduler</CaptionCue> — starve or yield — and
-            tap <em>run</em>. Starve mode runs a recursive{" "}
-            <code className="font-mono">.then</code> chain to completion before
-            the browser can repaint. Yield mode breaks the work into batches
-            with <code className="font-mono">setTimeout(0)</code>.
+            <CaptionCue>Tap <em>start runaway</em>.</CaptionCue> The microtask
+            lane will fill instantly while the frame lane stops. Try clicking
+            the button mid-run — it won&apos;t respond. Hit <em>stop</em> to
+            see the page recover.
           </>
         )
       }
       captionTone="prominent"
       controls={
         <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] w-full">
-          <div
-            role="tablist"
-            aria-label="scheduler mode"
-            className="inline-flex rounded-[var(--radius-md)]"
-            style={{
-              border: "1px solid var(--color-rule)",
-              padding: 2,
-            }}
-          >
-            {(["starve", "yield"] as const).map((m) => {
-              const active = m === mode;
-              return (
-                <motion.button
-                  key={m}
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => setMode(m)}
-                  className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-                  style={{
-                    padding: "6px 16px",
-                    fontSize: "var(--text-ui)",
-                    background: active
-                      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                      : "transparent",
-                    color: active
-                      ? "var(--color-accent)"
-                      : "var(--color-text-muted)",
-                    border: "none",
-                  }}
-                  {...PRESS}
-                >
-                  {m}
-                </motion.button>
-              );
-            })}
-          </div>
           <motion.button
             type="button"
-            onClick={running ? reset : run}
+            onClick={handleToggle}
             className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
             style={{
-              padding: "6px 18px",
+              padding: "8px 18px",
               fontSize: "var(--text-ui)",
-              background: running ? "transparent" : "var(--color-accent)",
-              color: running ? "var(--color-text-muted)" : "var(--color-bg)",
-              border: running
-                ? "1px solid var(--color-rule)"
+              background: isFrozen ? "transparent" : "var(--color-accent)",
+              color: isFrozen ? "var(--color-accent)" : "var(--color-bg)",
+              border: isFrozen
+                ? "1px solid var(--color-accent)"
                 : "none",
             }}
             {...PRESS}
           >
-            {running ? "stop" : final !== null ? "run again ▸" : "run ▸"}
+            {isFrozen ? "stop" : microCount > 0 ? "run again ▸" : "start runaway ▸"}
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={handleReset}
+            className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+            style={{
+              padding: "8px 14px",
+              fontSize: "var(--text-ui)",
+              color: "var(--color-text-muted)",
+              background: "transparent",
+              border: "1px solid var(--color-rule)",
+            }}
+            {...PRESS}
+          >
+            reset
           </motion.button>
         </div>
       }
     >
-      <div
-        className="flex flex-col gap-[var(--spacing-sm)]"
-        style={{ minHeight: 180 }}
-      >
-        <div className="flex flex-col gap-[var(--spacing-2xs)]">
-          <div
-            className="flex items-baseline justify-between font-mono tabular-nums"
-            style={{
-              fontSize: 14,
-              color: "var(--color-text)",
-            }}
-          >
-            <span>
-              counter:{" "}
-              <span style={{ color: "var(--color-accent)", minWidth: "8ch" }}>
-                {count.toString().padStart(5, "0")}
-              </span>
-            </span>
-            <PulseDot frozen={frozen} />
-          </div>
-          <div
-            style={{
-              height: 8,
-              borderRadius: 4,
-              overflow: "hidden",
-              background:
-                "color-mix(in oklab, var(--color-surface) 60%, transparent)",
-              border: "1px solid var(--color-rule)",
-              transformOrigin: "left center",
-            }}
-            aria-label={`${mode} run progress, ${count} of ${MAX_ITER} iterations`}
-            role="progressbar"
-            aria-valuenow={Math.round(pct)}
-            aria-valuemin={0}
-            aria-valuemax={100}
-          >
-            <motion.div
-              initial={false}
-              animate={{ scaleX: pct / 100 }}
-              transition={running ? { duration: 0 } : SPRING.snappy}
-              style={{
-                height: "100%",
-                width: "100%",
-                background: "var(--color-accent)",
-                transformOrigin: "left center",
-              }}
-            />
-          </div>
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        {/* Two columns on lg, stacked on mobile. Microtask lane on top so the
+            reader's eye lands there first when it suddenly fills. */}
+        <div className="bs-starvation-grid">
+          <Lane
+            label="microtask queue"
+            count={microCount}
+            dots={microDots}
+            filled
+            frozen={false}
+          />
+          <Lane
+            label="render frames (rAF)"
+            count={frameCount}
+            dots={frameDots}
+            filled={false}
+            frozen={isFrozen}
+          />
         </div>
-
+        <ClickMeButton
+          clicks={clicks}
+          onClick={() => setClicks((c) => c + 1)}
+          frozen={isFrozen}
+        />
+        <style>{`
+          .bs-starvation-grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-md);
+          }
+          @media (min-width: 640px) {
+            .bs-starvation-grid {
+              grid-template-columns: 1fr 1fr;
+            }
+          }
+        `}</style>
       </div>
     </WidgetShell>
   );

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING, PRESS } from "@/lib/motion";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * Bounded microtask flood vs setTimeout(0)-yielded loop. Hard cap at 50_000
+ * iterations OR 500 ms wall-clock so it can't brick the page even on slow
+ * devices. The reduced-motion path skips the live loop and shows the same
+ * outcome statically.
+ * --------------------------------------------------------------------------*/
+
+const MAX_ITER = 50_000;
+const MAX_MS = 500;
+const TICK_BATCH = 200; // for yield mode, repaint between batches
+
+type Mode = "starve" | "yield";
+
+function startStarve(
+  setCount: (n: number) => void,
+  onDone: (final: number) => void,
+) {
+  const start = performance.now();
+  let i = 0;
+  // Recursive .then chain — each tick of the chain is a microtask, so the
+  // browser gets no chance to repaint until the chain ends.
+  function step() {
+    if (i >= MAX_ITER || performance.now() - start > MAX_MS) {
+      // We can update React state here, but the paint won't happen until
+      // the current microtask drain finishes.
+      setCount(i);
+      onDone(i);
+      return;
+    }
+    i++;
+    Promise.resolve().then(step);
+  }
+  Promise.resolve().then(step);
+}
+
+function startYield(
+  setCount: (n: number) => void,
+  onDone: (final: number) => void,
+  shouldStop: () => boolean,
+) {
+  const start = performance.now();
+  let i = 0;
+  function batch() {
+    if (shouldStop()) {
+      onDone(i);
+      return;
+    }
+    if (i >= MAX_ITER || performance.now() - start > MAX_MS) {
+      setCount(i);
+      onDone(i);
+      return;
+    }
+    // Run a batch of work synchronously, then yield.
+    const end = Math.min(i + TICK_BATCH, MAX_ITER);
+    while (i < end) {
+      i++;
+    }
+    setCount(i);
+    setTimeout(batch, 0);
+  }
+  setTimeout(batch, 0);
+}
+
+/* Pulse-dot via rAF. Updates a ref-driven state so we can read it back to
+ * see if frames landed during the last 200 ms window. In starve mode the
+ * loop keeps ticking but `setCount` doesn't paint — so the dot freezes
+ * because the render thread never runs. We add an explicit "frozen" flag
+ * the parent flips while starve is in flight. */
+function PulseDot({ frozen }: { frozen: boolean }) {
+  const reduce = useReducedMotion();
+  return (
+    <span
+      aria-label={frozen ? "render thread blocked" : "render thread alive"}
+      className="inline-flex items-center gap-[var(--spacing-2xs)] font-sans"
+      style={{
+        fontSize: "var(--text-small)",
+        color: "var(--color-text-muted)",
+      }}
+    >
+      <motion.span
+        aria-hidden
+        style={{
+          display: "inline-block",
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: "var(--color-accent)",
+        }}
+        animate={
+          frozen || reduce ? { opacity: 0.25 } : { opacity: [0.3, 1, 0.3] }
+        }
+        transition={
+          frozen || reduce
+            ? { duration: 0 }
+            : { duration: 1.6, repeat: Infinity, ease: "linear" }
+        }
+      />
+      <span>{frozen ? "render frozen" : "render alive"}</span>
+    </span>
+  );
+}
+
+/**
+ * MicrotaskStarvation (W4) — bounded flood vs yielded loop. Toggle the
+ * mode; the counter races the same MAX_ITER iterations either way. In
+ * starve mode, the page can't repaint until the chain finishes; in yield
+ * mode, the counter ticks visibly and the pulse-dot keeps pulsing.
+ *
+ * One verb: toggle (mode segmented control). The "run" button is the
+ * engagement; the segmented control is parameter selection.
+ *
+ * Hard cap: 50_000 iterations OR 500 ms wall-clock — can't brick the page.
+ *
+ * Reduced motion: pulse-dot uses opacity only (no infinite scale animation).
+ */
+export function MicrotaskStarvation() {
+  const [mode, setMode] = useState<Mode>("starve");
+  const [running, setRunning] = useState(false);
+  const [count, setCount] = useState(0);
+  const [final, setFinal] = useState<number | null>(null);
+  const stopRef = useRef(false);
+
+  const reset = useCallback(() => {
+    stopRef.current = true;
+    setRunning(false);
+    setCount(0);
+    setFinal(null);
+  }, []);
+
+  function run() {
+    if (running) return;
+    stopRef.current = false;
+    setCount(0);
+    setFinal(null);
+    setRunning(true);
+
+    if (mode === "starve") {
+      startStarve(
+        (n) => setCount(n),
+        (n) => {
+          setFinal(n);
+          setRunning(false);
+        },
+      );
+    } else {
+      startYield(
+        (n) => setCount(n),
+        (n) => {
+          setFinal(n);
+          setRunning(false);
+        },
+        () => stopRef.current,
+      );
+    }
+  }
+
+  // Reset on mode change.
+  useEffect(() => {
+    reset();
+  }, [mode, reset]);
+
+  const pct = Math.min(100, (count / MAX_ITER) * 100);
+  // Frozen dot only while a starve run is in flight (counter goes 0 → final
+  // in one paint). In yield mode the dot keeps pulsing even between batches.
+  const frozen = mode === "starve" && running;
+
+  return (
+    <WidgetShell
+      title={`microtask starvation · mode: ${mode}`}
+      measurements={`${count.toLocaleString()} / ${MAX_ITER.toLocaleString()}`}
+      caption={
+        running ? (
+          <>
+            <CaptionCue>Running.</CaptionCue> {mode === "starve"
+              ? "The microtask drain holds the loop. The counter doesn't paint and the pulse-dot freezes until the chain finishes."
+              : "setTimeout(0) hands the loop back between batches. Rendering interleaves; the counter ticks visibly."}
+          </>
+        ) : final !== null ? (
+          <>
+            <CaptionCue>Done.</CaptionCue> {mode === "starve"
+              ? "Counter jumped from 0 straight to its final value in a single paint. The microtask checkpoint can't yield mid-drain."
+              : "Each batch yielded back to the loop. Rendering happened between every batch."}
+          </>
+        ) : (
+          <>
+            <CaptionCue>Toggle the mode</CaptionCue> and tap <em>run</em>. In
+            starve mode, a recursive <code className="font-mono">.then</code>{" "}
+            chain runs to completion before the browser repaints. In yield
+            mode, <code className="font-mono">setTimeout(0)</code> between
+            batches gives the renderer a turn.
+          </>
+        )
+      }
+      captionTone="prominent"
+      controls={
+        <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] w-full">
+          <div
+            role="tablist"
+            aria-label="scheduler mode"
+            className="inline-flex rounded-[var(--radius-md)]"
+            style={{
+              border: "1px solid var(--color-rule)",
+              padding: 2,
+            }}
+          >
+            {(["starve", "yield"] as const).map((m) => {
+              const active = m === mode;
+              return (
+                <motion.button
+                  key={m}
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setMode(m)}
+                  className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
+                  style={{
+                    padding: "6px 16px",
+                    fontSize: "var(--text-ui)",
+                    background: active
+                      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                      : "transparent",
+                    color: active
+                      ? "var(--color-accent)"
+                      : "var(--color-text-muted)",
+                    border: "none",
+                  }}
+                  {...PRESS}
+                >
+                  {m}
+                </motion.button>
+              );
+            })}
+          </div>
+          <motion.button
+            type="button"
+            onClick={running ? reset : run}
+            className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+            style={{
+              padding: "6px 18px",
+              fontSize: "var(--text-ui)",
+              background: running ? "transparent" : "var(--color-accent)",
+              color: running ? "var(--color-text-muted)" : "var(--color-bg)",
+              border: running
+                ? "1px solid var(--color-rule)"
+                : "none",
+            }}
+            {...PRESS}
+          >
+            {running ? "stop" : final !== null ? "run again ▸" : "run ▸"}
+          </motion.button>
+        </div>
+      }
+    >
+      <div
+        className="flex flex-col gap-[var(--spacing-sm)]"
+        style={{ minHeight: 180 }}
+      >
+        <div className="flex flex-col gap-[var(--spacing-2xs)]">
+          <div
+            className="flex items-baseline justify-between font-mono tabular-nums"
+            style={{
+              fontSize: 14,
+              color: "var(--color-text)",
+            }}
+          >
+            <span>
+              counter:{" "}
+              <span style={{ color: "var(--color-accent)", minWidth: "8ch" }}>
+                {count.toString().padStart(5, "0")}
+              </span>
+            </span>
+            <PulseDot frozen={frozen} />
+          </div>
+          <div
+            style={{
+              height: 8,
+              borderRadius: 4,
+              overflow: "hidden",
+              background:
+                "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+              border: "1px solid var(--color-rule)",
+              transformOrigin: "left center",
+            }}
+            aria-label="counter progress"
+            role="progressbar"
+            aria-valuenow={Math.round(pct)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <motion.div
+              initial={false}
+              animate={{ scaleX: pct / 100 }}
+              transition={running ? { duration: 0 } : SPRING.snappy}
+              style={{
+                height: "100%",
+                width: "100%",
+                background: "var(--color-accent)",
+                transformOrigin: "left center",
+              }}
+            />
+          </div>
+        </div>
+
+        <div
+          className="font-mono"
+          style={{
+            fontSize: 11,
+            color: "var(--color-text-muted)",
+            background:
+              "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+            padding: "var(--spacing-sm)",
+            borderRadius: "var(--radius-sm)",
+            lineHeight: 1.6,
+            whiteSpace: "pre",
+            overflowX: "auto",
+          }}
+        >
+          {mode === "starve"
+            ? `function step(i) {\n  if (i >= MAX) return;\n  Promise.resolve().then(() => step(i + 1));\n}\nstep(0); // microtask drains hold the loop`
+            : `function batch(i) {\n  if (i >= MAX) return;\n  for (let j = 0; j < 200; j++) i++;\n  setTimeout(() => batch(i), 0); // yield between batches\n}\nbatch(0);`}
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
@@ -111,7 +111,7 @@ const VARIANTS: Variant[] = [
     options: [
       `"first?" "second?"`,
       `"second?" "first?"`,
-      `tied (depends on browser)`,
+      `nondeterministic`,
       `only one prints`,
     ],
     correctIndex: 1,
@@ -249,7 +249,7 @@ export function PredictTheOutput() {
 
   return (
     <WidgetShell
-      title="predict the output · 3 variants"
+      title="predict the output"
       measurements={variant.label}
       caption={
         revealed ? (
@@ -259,7 +259,7 @@ export function PredictTheOutput() {
         ) : picked !== null ? (
           <>
             <CaptionCue>Locked in.</CaptionCue> Tap{" "}
-            <em>reveal</em> to play the run with queue annotations.
+            <em>play it</em> to run the program with queue annotations.
           </>
         ) : (
           <>
@@ -283,7 +283,7 @@ export function PredictTheOutput() {
               }}
               {...PRESS}
             >
-              reveal ▸
+              play it ▸
             </motion.button>
           ) : null}
           {revealed ? (
@@ -394,8 +394,11 @@ export function PredictTheOutput() {
                 transition={SPRING.snappy}
                 className="flex flex-col gap-[var(--spacing-xs)]"
               >
-                <div
+                <motion.div
                   className="font-sans"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={SPRING.snappy}
                   style={{
                     fontSize: "var(--text-small)",
                     color:
@@ -407,7 +410,7 @@ export function PredictTheOutput() {
                   {picked === variant.correctIndex
                     ? "Correct — here's why."
                     : `Actual run order (your pick: ${variant.options[picked ?? 0]}):`}
-                </div>
+                </motion.div>
                 <RevealStrip reveal={variant.reveal} />
               </motion.div>
             )}

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { memo, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING, PRESS } from "@/lib/motion";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * Three variants. None reproduces Archibald's `script start / promise1 /
+ * promise2 / setTimeout / script end` example. Different identifiers,
+ * different log strings, different microtask counts.
+ * --------------------------------------------------------------------------*/
+
+type Source = "sync" | "task" | "micro";
+
+type Variant = {
+  id: "alpha" | "beta" | "gamma";
+  label: string;
+  /** Human one-liner shown in the row above the variant tabs. */
+  blurb: string;
+  /** Code lines (mono). */
+  code: string[];
+  /** Four candidate orderings shown to the reader. */
+  options: string[];
+  /** The correct ordering (one of the options). */
+  correctIndex: number;
+  /** The reveal: list of (letter, source) pairs in actual run order. */
+  reveal: { letter: string; source: Source }[];
+  /** A one-line caption for the reveal panel. */
+  revealNote: React.ReactNode;
+};
+
+const VARIANTS: Variant[] = [
+  {
+    id: "alpha",
+    label: "α · baseline",
+    blurb: "setTimeout vs Promise.then with two synchronous logs.",
+    code: [
+      `console.log("A");`,
+      `setTimeout(() => console.log("B"), 0);`,
+      `Promise.resolve().then(() => console.log("C"));`,
+      `console.log("D");`,
+    ],
+    options: ["A B C D", "A D B C", "A D C B", "A C D B"],
+    correctIndex: 2,
+    reveal: [
+      { letter: "A", source: "sync" },
+      { letter: "D", source: "sync" },
+      { letter: "C", source: "micro" },
+      { letter: "B", source: "task" },
+    ],
+    revealNote: (
+      <>
+        Both <strong>sync</strong> logs print first inside <code className="font-mono">main</code>.
+        After the stack drains, the loop drains the microtask queue → C. Only
+        then does it run one task → B.
+      </>
+    ),
+  },
+  {
+    id: "beta",
+    label: "β · microtasks spawn microtasks",
+    blurb: "A .then whose body schedules another .then.",
+    code: [
+      `setTimeout(() => console.log("T"), 0);`,
+      `Promise.resolve().then(() => {`,
+      `  console.log("P1");`,
+      `  Promise.resolve().then(() => console.log("P2"));`,
+      `});`,
+    ],
+    options: ["T P1 P2", "P1 T P2", "P1 P2 T", "T P2 P1"],
+    correctIndex: 2,
+    reveal: [
+      { letter: "P1", source: "micro" },
+      { letter: "P2", source: "micro" },
+      { letter: "T", source: "task" },
+    ],
+    revealNote: (
+      <>
+        The microtask queue drains <em>completely</em> — including the new
+        microtask added <em>during</em> the drain. P2 runs before T, even
+        though T was scheduled first.
+      </>
+    ),
+  },
+  {
+    id: "gamma",
+    label: "γ · task scheduled first",
+    blurb: "setTimeout(0) called before any Promise. Microtask still wins.",
+    code: [
+      `setTimeout(() => console.log("first?"), 0);`,
+      `Promise.resolve().then(() => console.log("second?"));`,
+    ],
+    options: [
+      `"first?" "second?"`,
+      `"second?" "first?"`,
+      `tied (depends on browser)`,
+      `only one prints`,
+    ],
+    correctIndex: 1,
+    reveal: [
+      { letter: '"second?"', source: "micro" },
+      { letter: '"first?"', source: "task" },
+    ],
+    revealNote: (
+      <>
+        Source order doesn&apos;t decide queue order. The microtask wins
+        because the loop drains microtasks <em>before</em> running any task —
+        always.
+      </>
+    ),
+  },
+];
+
+const SOURCE_LABEL: Record<Source, string> = {
+  sync: "sync",
+  task: "task queue",
+  micro: "microtask queue",
+};
+
+const SOURCE_FILL: Record<Source, string> = {
+  sync: "transparent",
+  task: "transparent",
+  micro: "var(--color-accent)",
+};
+
+const SOURCE_TEXT: Record<Source, string> = {
+  sync: "var(--color-text-muted)",
+  task: "var(--color-accent)",
+  micro: "var(--color-bg)",
+};
+
+const SOURCE_STROKE: Record<Source, string> = {
+  sync: "var(--color-text-muted)",
+  task: "var(--color-accent)",
+  micro: "transparent",
+};
+
+function CodePane({ code }: { code: string[] }) {
+  return (
+    <pre
+      className="font-mono"
+      style={{
+        background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+        padding: "var(--spacing-sm)",
+        borderRadius: "var(--radius-sm)",
+        fontSize: 12,
+        color: "var(--color-text)",
+        lineHeight: 1.65,
+        margin: 0,
+        whiteSpace: "pre",
+        overflowX: "auto",
+        minHeight: "9em",
+      }}
+    >
+      {code.join("\n")}
+    </pre>
+  );
+}
+
+function RevealStrip({ reveal }: { reveal: Variant["reveal"] }) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-[var(--spacing-xs)]"
+      style={{ minHeight: "5.5em" }}
+    >
+      {reveal.map((item, i) => (
+        <motion.div
+          key={i}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...SPRING.snappy, delay: i * 0.18 }}
+          className="flex flex-col items-center gap-[2px]"
+        >
+          <span
+            className="font-mono inline-flex items-center justify-center"
+            style={{
+              padding: "4px 10px",
+              borderRadius: 4,
+              fontSize: 13,
+              fontWeight: 600,
+              background: SOURCE_FILL[item.source],
+              border: `1.5px solid ${SOURCE_STROKE[item.source]}`,
+              color: SOURCE_TEXT[item.source],
+              minWidth: "3ch",
+              textAlign: "center",
+            }}
+          >
+            {item.letter}
+          </span>
+          <span
+            className="font-sans"
+            style={{
+              fontSize: 10,
+              color: "var(--color-text-muted)",
+              letterSpacing: "0.02em",
+            }}
+          >
+            {SOURCE_LABEL[item.source]}
+          </span>
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+const MemoCodePane = memo(CodePane);
+
+/**
+ * PredictTheOutput (W2) — three selectable variants. Reader picks an
+ * ordering, then taps "reveal" to see the actual run with queue-source
+ * annotations.
+ *
+ * One verb: predict (predict → reveal). Variant chooser is parameter
+ * selection, not a competing verb (carve-out documented in widgets.md).
+ *
+ * Frame stability (R6): variant chooser, code pane, predict options, and
+ * reveal strip share a single fixed-rectangle canvas. The reveal strip has
+ * `min-height` so the card doesn't grow when it appears.
+ */
+export function PredictTheOutput() {
+  const [variantId, setVariantId] = useState<Variant["id"]>("alpha");
+  const [picked, setPicked] = useState<number | null>(null);
+  const [revealed, setRevealed] = useState(false);
+  const variant = VARIANTS.find((v) => v.id === variantId)!;
+
+  function selectVariant(id: Variant["id"]) {
+    setVariantId(id);
+    setPicked(null);
+    setRevealed(false);
+  }
+
+  return (
+    <WidgetShell
+      title="predict the output · 3 variants"
+      measurements={variant.label}
+      caption={
+        revealed ? (
+          <>
+            <CaptionCue>Revealed.</CaptionCue> {variant.revealNote}
+          </>
+        ) : picked !== null ? (
+          <>
+            <CaptionCue>Locked in.</CaptionCue> Tap{" "}
+            <em>reveal</em> to play the run with queue annotations.
+          </>
+        ) : (
+          <>
+            <CaptionCue>Predict.</CaptionCue> Tap the ordering you think the
+            runtime will produce. {variant.blurb}
+          </>
+        )
+      }
+      captionTone="prominent"
+      controls={
+        <div className="flex items-center justify-center gap-[var(--spacing-sm)] w-full">
+          {picked !== null && !revealed ? (
+            <motion.button
+              type="button"
+              onClick={() => setRevealed(true)}
+              className="font-sans rounded-[var(--radius-md)] px-[var(--spacing-md)] py-[var(--spacing-2xs)] min-h-[44px]"
+              style={{
+                fontSize: "var(--text-ui)",
+                background: "var(--color-accent)",
+                color: "var(--color-bg)",
+              }}
+              {...PRESS}
+            >
+              reveal ▸
+            </motion.button>
+          ) : null}
+          {revealed ? (
+            <motion.button
+              type="button"
+              onClick={() => {
+                setPicked(null);
+                setRevealed(false);
+              }}
+              className="font-sans rounded-[var(--radius-md)] px-[var(--spacing-md)] py-[var(--spacing-2xs)] min-h-[44px]"
+              style={{
+                fontSize: "var(--text-ui)",
+                color: "var(--color-text-muted)",
+                border: "1px solid var(--color-rule)",
+              }}
+              {...PRESS}
+            >
+              try again
+            </motion.button>
+          ) : null}
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-sm)]">
+        {/* Variant chooser — segmented control above the canvas. */}
+        <div
+          role="tablist"
+          aria-label="variant"
+          className="flex flex-wrap items-center gap-[var(--spacing-2xs)]"
+          style={{ fontSize: "var(--text-small)" }}
+        >
+          {VARIANTS.map((v) => {
+            const active = v.id === variantId;
+            return (
+              <motion.button
+                key={v.id}
+                role="tab"
+                aria-selected={active}
+                onClick={() => selectVariant(v.id)}
+                className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
+                style={{
+                  padding: "6px 12px",
+                  background: active
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "transparent",
+                  color: active
+                    ? "var(--color-text)"
+                    : "var(--color-text-muted)",
+                  border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+                }}
+                {...PRESS}
+              >
+                {v.label}
+              </motion.button>
+            );
+          })}
+        </div>
+
+        <MemoCodePane code={variant.code} />
+
+        {/* Predict / reveal area — fixed-rectangle, shares min-height. */}
+        <div style={{ minHeight: "9em" }}>
+          <AnimatePresence mode="wait" initial={false}>
+            {!revealed ? (
+              <motion.div
+                key="predict"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.snappy}
+                className="grid gap-[var(--spacing-2xs)]"
+                style={{
+                  gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+                }}
+              >
+                {variant.options.map((opt, i) => {
+                  const isPicked = picked === i;
+                  return (
+                    <motion.button
+                      key={i}
+                      type="button"
+                      onClick={() => setPicked(i)}
+                      className="font-mono rounded-[var(--radius-sm)] min-h-[44px] text-left"
+                      style={{
+                        padding: "10px 12px",
+                        fontSize: 12,
+                        background: isPicked
+                          ? "color-mix(in oklab, var(--color-accent) 18%, transparent)"
+                          : "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+                        color: "var(--color-text)",
+                        border: `1.5px solid ${
+                          isPicked ? "var(--color-accent)" : "var(--color-rule)"
+                        }`,
+                      }}
+                      {...PRESS}
+                    >
+                      {opt}
+                    </motion.button>
+                  );
+                })}
+              </motion.div>
+            ) : (
+              <motion.div
+                key="reveal"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.snappy}
+                className="flex flex-col gap-[var(--spacing-xs)]"
+              >
+                <div
+                  className="font-sans"
+                  style={{
+                    fontSize: "var(--text-small)",
+                    color:
+                      picked === variant.correctIndex
+                        ? "var(--color-accent)"
+                        : "var(--color-text-muted)",
+                  }}
+                >
+                  {picked === variant.correctIndex
+                    ? "Correct — here's why."
+                    : `Actual run order (your pick: ${variant.options[picked ?? 0]}):`}
+                </div>
+                <RevealStrip reveal={variant.reveal} />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { memo, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING, PRESS } from "@/lib/motion";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * The article's opening hook. The reader sees a deliberately hard snippet —
+ * sync + macro + micro + chained-Promise + await — and must guess the output.
+ * Most readers should fail. The verdict copy steers wrong-guessers into the
+ * article ("now we'll learn how"); right-guessers get a "let's see why".
+ *
+ * The snippet stays visible after the answer reveals — it's the article's
+ * anchor, referenced in §3, §5, and the closer.
+ *
+ * Correct trace (verified):
+ *   sync:       A, F, H
+ *   microtask:  C  (the .then prints C, then returns Promise.resolve("D")
+ *                   — but adopting that thenable costs two extra microtask
+ *                   hops, so D is delayed)
+ *   microtask:  E  (queueMicrotask)
+ *   microtask:  G  (await null continuation — one hop)
+ *   microtask:  D  (the chained .then((d) => log(d)) finally fires)
+ *   task:       B  (setTimeout drains last)
+ *   →  A · F · H · C · E · G · D · B
+ * --------------------------------------------------------------------------*/
+
+const SNIPPET = [
+  `console.log("A");`,
+  `setTimeout(() => console.log("B"), 0);`,
+  `Promise.resolve()`,
+  `  .then(() => {`,
+  `    console.log("C");`,
+  `    return Promise.resolve("D");`,
+  `  })`,
+  `  .then((d) => console.log(d));`,
+  `queueMicrotask(() => console.log("E"));`,
+  `(async () => {`,
+  `  console.log("F");`,
+  `  await null;`,
+  `  console.log("G");`,
+  `})();`,
+  `console.log("H");`,
+];
+
+type Option = {
+  /** Tokens, joined with a tabular separator for display. */
+  tokens: string[];
+  /** Why a reader might pick this — for the post-answer "your model" hint. */
+  rationale: string;
+};
+
+const OPTIONS: Option[] = [
+  // 0 — correct
+  {
+    tokens: ["A", "F", "H", "C", "E", "G", "D", "B"],
+    rationale: "spec-accurate: returning Promise.resolve(D) costs two extra microtask hops",
+  },
+  // 1 — most common wrong: forgets the chained-Promise extra hops
+  {
+    tokens: ["A", "F", "H", "C", "E", "D", "G", "B"],
+    rationale: "thinks returning Promise.resolve(D) resolves immediately",
+  },
+  // 2 — forgot await is a microtask
+  {
+    tokens: ["A", "F", "G", "H", "C", "E", "D", "B"],
+    rationale: "thinks await null continues synchronously",
+  },
+  // 3 — thinks setTimeout(0) outranks microtasks
+  {
+    tokens: ["A", "F", "H", "B", "C", "E", "G", "D"],
+    rationale: "thinks setTimeout(0) wins because zero means now",
+  },
+];
+
+const CORRECT_INDEX = 0;
+const SEP = "·";
+
+function tokensToLine(tokens: string[]) {
+  return tokens.join(` ${SEP} `);
+}
+
+function CodePane() {
+  return (
+    <pre
+      className="font-mono"
+      style={{
+        background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+        padding: "var(--spacing-sm)",
+        borderRadius: "var(--radius-sm)",
+        fontSize: 12,
+        lineHeight: 1.55,
+        color: "var(--color-text)",
+        margin: 0,
+        whiteSpace: "pre",
+        overflowX: "auto",
+        // Reserve enough rows that the pane doesn't shift when scrolling.
+        // 15 lines × ~19px line-height + 24px padding ≈ 309px.
+        minHeight: 280,
+      }}
+    >
+      {SNIPPET.join("\n")}
+    </pre>
+  );
+}
+
+const MemoCodePane = memo(CodePane);
+
+function OptionButton({
+  option,
+  index,
+  picked,
+  revealed,
+  onPick,
+}: {
+  option: Option;
+  index: number;
+  picked: number | null;
+  revealed: boolean;
+  onPick: (i: number) => void;
+}) {
+  const reduce = useReducedMotion();
+  const isPicked = picked === index;
+  const isCorrect = index === CORRECT_INDEX;
+  const isWrongPick = revealed && isPicked && !isCorrect;
+  const showCorrect = revealed && isCorrect;
+
+  // Frame-stability: the button geometry never changes; only fill/stroke/text
+  // colour swap on reveal. The pulse is one-shot scale 1 → 1.04 → 1.
+  const animate =
+    showCorrect && !reduce
+      ? { scale: [1, 1.04, 1] }
+      : { scale: 1 };
+
+  return (
+    <motion.button
+      type="button"
+      onClick={() => !revealed && onPick(index)}
+      disabled={revealed}
+      aria-label={`option ${index + 1}: ${option.tokens.join(" ")}`}
+      animate={animate}
+      transition={
+        showCorrect && !reduce
+          ? { duration: 0.25, times: [0, 0.5, 1] }
+          : SPRING.snappy
+      }
+      whileTap={revealed ? undefined : { scale: 0.97 }}
+      className="font-mono rounded-[var(--radius-sm)] min-h-[44px] text-center"
+      style={{
+        padding: "10px 12px",
+        fontSize: 13,
+        letterSpacing: "0.02em",
+        background: showCorrect
+          ? "var(--color-accent)"
+          : isWrongPick
+            ? "transparent"
+            : isPicked
+              ? "color-mix(in oklab, var(--color-accent) 18%, transparent)"
+              : "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+        color: showCorrect
+          ? "var(--color-bg)"
+          : isWrongPick
+            ? "var(--color-text-muted)"
+            : "var(--color-text)",
+        border: `1.5px solid ${
+          showCorrect
+            ? "transparent"
+            : isWrongPick
+              ? "var(--color-rule)"
+              : isPicked
+                ? "var(--color-accent)"
+                : "var(--color-rule)"
+        }`,
+        textDecoration: isWrongPick ? "line-through" : "none",
+        opacity: revealed && !showCorrect && !isPicked ? 0.5 : 1,
+        cursor: revealed ? "default" : "pointer",
+        transition: "background 200ms, color 200ms, border-color 200ms, opacity 200ms",
+      }}
+    >
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+        {showCorrect ? (
+          <span aria-hidden style={{ fontSize: 12 }}>✓</span>
+        ) : null}
+        <span style={{ whiteSpace: "nowrap" }}>{tokensToLine(option.tokens)}</span>
+      </span>
+    </motion.button>
+  );
+}
+
+/**
+ * PredictTheStart (W0) — the article's opening hook. A hard snippet the
+ * reader is expected to fail; the verdict steers them into the rest of the
+ * post.
+ *
+ * One verb: predict (predict → reveal). Reveal-answer link is a parameter
+ * shortcut, not a competing verb.
+ *
+ * Frame stability (R6): code pane has `min-height`; verdict slot has
+ * `min-height` reserved before any answer is given. No layout shift on
+ * pick. Correct option pulses scale 1 → 1.04 → 1 once on reveal.
+ *
+ * Mobile-first: 360px target. Options stack vertically on <lg, 2×2 on lg+.
+ * Snippet wraps to its own scroll container only as a last resort.
+ */
+export function PredictTheStart() {
+  const [picked, setPicked] = useState<number | null>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  const isCorrect = picked === CORRECT_INDEX;
+
+  function lockIn() {
+    if (picked === null) return;
+    setRevealed(true);
+  }
+
+  function revealUnguessed() {
+    setPicked(null);
+    setRevealed(true);
+  }
+
+  function reset() {
+    setPicked(null);
+    setRevealed(false);
+  }
+
+  return (
+    <WidgetShell
+      title="predict the output"
+      measurements={revealed ? (isCorrect ? "got it" : "most miss this") : "8 logs · 4 queues"}
+      caption={
+        revealed ? (
+          isCorrect ? (
+            <>
+              <CaptionCue>You&apos;ve seen this before.</CaptionCue> Let&apos;s
+              see <em>why</em> it produces this output — the rest of the post is
+              the trace, line by line.
+            </>
+          ) : (
+            <>
+              <CaptionCue>Most readers miss this.</CaptionCue> Now we&apos;ll
+              learn <em>how</em> this output emerges. Keep this snippet open —
+              every section below points back to a line of it.
+            </>
+          )
+        ) : (
+          <>
+            <CaptionCue>Predict the output.</CaptionCue> Pick the order{" "}
+            <code className="font-mono">console.log</code> will print. The
+            snippet mixes sync code, a timer, two Promises, a microtask, and an{" "}
+            <code className="font-mono">await</code>. Most readers get this
+            wrong on the first try.
+          </>
+        )
+      }
+      captionTone="prominent"
+      controls={
+        <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] w-full">
+          {!revealed ? (
+            <>
+              <motion.button
+                type="button"
+                onClick={lockIn}
+                disabled={picked === null}
+                className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+                style={{
+                  padding: "8px 18px",
+                  fontSize: "var(--text-ui)",
+                  background:
+                    picked === null
+                      ? "color-mix(in oklab, var(--color-accent) 30%, transparent)"
+                      : "var(--color-accent)",
+                  color: "var(--color-bg)",
+                  border: "none",
+                  cursor: picked === null ? "not-allowed" : "pointer",
+                  opacity: picked === null ? 0.6 : 1,
+                  transition: "opacity 200ms, background 200ms",
+                }}
+                {...(picked === null ? {} : PRESS)}
+              >
+                lock in ▸
+              </motion.button>
+              <button
+                type="button"
+                onClick={revealUnguessed}
+                className="font-sans min-h-[44px]"
+                style={{
+                  padding: "8px 12px",
+                  fontSize: "var(--text-small)",
+                  color: "var(--color-text-muted)",
+                  background: "transparent",
+                  border: "none",
+                  textDecoration: "underline",
+                  textDecorationStyle: "dotted",
+                  textUnderlineOffset: 4,
+                  cursor: "pointer",
+                }}
+              >
+                reveal answer
+              </button>
+            </>
+          ) : (
+            <motion.button
+              type="button"
+              onClick={reset}
+              className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
+              style={{
+                padding: "8px 16px",
+                fontSize: "var(--text-ui)",
+                color: "var(--color-text-muted)",
+                background: "transparent",
+                border: "1px solid var(--color-rule)",
+              }}
+              {...PRESS}
+            >
+              try again
+            </motion.button>
+          )}
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-sm)]">
+        <MemoCodePane />
+
+        {/* Options — stacked on mobile, 2x2 on lg+. Frame-stable: container
+            never resizes after pick or reveal. */}
+        <div
+          className="grid gap-[var(--spacing-2xs)]"
+          style={{
+            gridTemplateColumns: "1fr",
+          }}
+        >
+          <style>{`
+            @media (min-width: 640px) {
+              .bs-predict-options {
+                grid-template-columns: 1fr 1fr !important;
+              }
+            }
+          `}</style>
+          <div
+            className="bs-predict-options grid gap-[var(--spacing-2xs)]"
+            style={{ gridTemplateColumns: "1fr" }}
+          >
+            {OPTIONS.map((opt, i) => (
+              <OptionButton
+                key={i}
+                option={opt}
+                index={i}
+                picked={picked}
+                revealed={revealed}
+                onPick={setPicked}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Verdict slot — fixed height so the layout doesn't jump on reveal. */}
+        <div style={{ minHeight: "2.25em" }}>
+          <AnimatePresence initial={false} mode="wait">
+            {revealed ? (
+              <motion.div
+                key="verdict"
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.snappy}
+                className="font-mono"
+                style={{
+                  fontSize: 12,
+                  color: "var(--color-text-muted)",
+                  lineHeight: 1.6,
+                }}
+              >
+                <span style={{ color: "var(--color-accent)" }}>output</span>
+                {"  "}
+                <span style={{ color: "var(--color-text)" }}>
+                  {tokensToLine(OPTIONS[CORRECT_INDEX].tokens)}
+                </span>
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
@@ -314,9 +314,9 @@ function StackZone({ frames }: { frames: string[] }) {
   // never reflows.
   const SLOT_H = 24;
   const GAP = 4;
-  const ZONE_X = 212;
+  const ZONE_X = 224;
   const ZONE_Y = 0;
-  const ZONE_W = 148;
+  const ZONE_W = 136;
   const ZONE_H = 120;
   const reserved = 4;
   return (
@@ -599,7 +599,7 @@ function Canvas({ tick }: { tick: Tick }) {
         maxWidth: 480,
       }}
       role="img"
-      aria-label="JavaScript runtime simulator: program, call stack, Web APIs, microtask queue, task queue, and output."
+      aria-label="JavaScript runtime simulator. Step controls below."
     >
       <ProgramZone activeLine={tick.activeLine} />
       <StackZone frames={tick.stack} />
@@ -631,7 +631,7 @@ export function RuntimeSimulator() {
   return (
     <WidgetShell
       title="runtime · scripted stepper"
-      measurements={`tick ${step} / ${TICKS.length - 1}`}
+      measurements={`tick ${step + 1} / ${TICKS.length}`}
       caption={tick.caption}
       captionTone="prominent"
       controls={

--- a/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
@@ -1,0 +1,651 @@
+"use client";
+
+import { memo, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * The scripted program is hand-authored as 10 tick states. Each tick is a
+ * complete snapshot of the runtime — stack frames, web-API timers, queue
+ * contents, the output strip, and a one-sentence caption. No live execution.
+ * The program being simulated:
+ *
+ *    console.log("A");
+ *    setTimeout(() => console.log("B"), 0);
+ *    Promise.resolve().then(() => console.log("C"));
+ *    console.log("D");
+ *
+ * Output: A · D · C · B
+ * --------------------------------------------------------------------------*/
+
+type Tick = {
+  /** Frames currently on the call stack, top last. */
+  stack: string[];
+  /** Web-API slots currently holding work. */
+  webApi: string[];
+  /** Microtask queue, head first. */
+  micro: string[];
+  /** Task (macrotask) queue, head first. */
+  task: string[];
+  /** Letters logged so far. */
+  output: string[];
+  /** Which line of the program is "executing" (1-indexed) — null when stack is empty. */
+  activeLine: number | null;
+  /** Caption for this tick. */
+  caption: React.ReactNode;
+};
+
+const TICKS: Tick[] = [
+  {
+    stack: ["main"],
+    webApi: [],
+    micro: [],
+    task: [],
+    output: [],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 0.</CaptionCue> The script starts. The{" "}
+        <strong>main</strong> frame is on the call stack — every line of the
+        program runs inside it. The two queues and the Web-API row are empty.
+      </>
+    ),
+  },
+  {
+    stack: ["main", "console.log"],
+    webApi: [],
+    micro: [],
+    task: [],
+    output: ["A"],
+    activeLine: 1,
+    caption: (
+      <>
+        <CaptionCue>Tick 1.</CaptionCue> Line 1 runs synchronously inside the
+        main frame. Output:{" "}
+        <code className="font-mono">A</code>.
+      </>
+    ),
+  },
+  {
+    stack: ["main"],
+    webApi: ["timer 0 ms → B"],
+    micro: [],
+    task: [],
+    output: ["A"],
+    activeLine: 2,
+    caption: (
+      <>
+        <CaptionCue>Tick 2.</CaptionCue> Line 2 calls{" "}
+        <code className="font-mono">setTimeout(…, 0)</code>. The browser parks
+        the timer in its <strong>Web APIs</strong> — outside JavaScript — and
+        returns immediately. Nothing has been queued yet.
+      </>
+    ),
+  },
+  {
+    stack: ["main"],
+    webApi: ["timer 0 ms → B"],
+    micro: ["thenC"],
+    task: [],
+    output: ["A"],
+    activeLine: 3,
+    caption: (
+      <>
+        <CaptionCue>Tick 3.</CaptionCue> Line 3 resolves a Promise and attaches{" "}
+        <code className="font-mono">.then(C)</code>. The continuation lands{" "}
+        directly in the <strong>microtask queue</strong> — no Web-API detour.
+      </>
+    ),
+  },
+  {
+    stack: ["main", "console.log"],
+    webApi: ["timer 0 ms → B"],
+    micro: ["thenC"],
+    task: [],
+    output: ["A", "D"],
+    activeLine: 4,
+    caption: (
+      <>
+        <CaptionCue>Tick 4.</CaptionCue> Line 4 runs. Output:{" "}
+        <code className="font-mono">A · D</code>. The script reached the end{" "}
+        of <code className="font-mono">main</code> with two pieces of work
+        still parked outside it.
+      </>
+    ),
+  },
+  {
+    stack: [],
+    webApi: ["timer fires → B"],
+    micro: ["thenC"],
+    task: [],
+    output: ["A", "D"],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 5.</CaptionCue> The <strong>main</strong> frame pops.
+        The stack is empty. The 0 ms timer has elapsed; its callback is about
+        to land in the task queue.
+      </>
+    ),
+  },
+  {
+    stack: [],
+    webApi: [],
+    micro: ["thenC"],
+    task: ["timerB"],
+    output: ["A", "D"],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 6.</CaptionCue> The timer callback enters the{" "}
+        <strong>task queue</strong>. Both queues now hold one item — and the{" "}
+        timer was scheduled <em>first</em>.
+      </>
+    ),
+  },
+  {
+    stack: ["thenC"],
+    webApi: [],
+    micro: [],
+    task: ["timerB"],
+    output: ["A", "D", "C"],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 7.</CaptionCue> Stack empty → the loop drains the{" "}
+        <strong>microtask queue first</strong>. <code className="font-mono">thenC</code>{" "}
+        runs and logs <code className="font-mono">C</code> — even though{" "}
+        <code className="font-mono">timerB</code> was scheduled earlier.
+      </>
+    ),
+  },
+  {
+    stack: ["timerB"],
+    webApi: [],
+    micro: [],
+    task: [],
+    output: ["A", "D", "C", "B"],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 8.</CaptionCue> Microtask queue drained. Now the loop
+        runs <em>one</em> task. <code className="font-mono">timerB</code> logs{" "}
+        <code className="font-mono">B</code>.
+      </>
+    ),
+  },
+  {
+    stack: [],
+    webApi: [],
+    micro: [],
+    task: [],
+    output: ["A", "D", "C", "B"],
+    activeLine: null,
+    caption: (
+      <>
+        <CaptionCue>Tick 9.</CaptionCue> Both queues empty. Final output:{" "}
+        <code className="font-mono">A · D · C · B</code>. The microtask jumped{" "}
+        the line.
+      </>
+    ),
+  },
+];
+
+/* ---------------------------------------------------------------------------
+ * The simulated source. Constant — only the active-line highlight changes.
+ * --------------------------------------------------------------------------*/
+const PROGRAM = [
+  `console.log("A");`,
+  `setTimeout(() => console.log("B"), 0);`,
+  `Promise.resolve().then(() => console.log("C"));`,
+  `console.log("D");`,
+];
+
+/* ---------------------------------------------------------------------------
+ * Canvas — fixed 360 × 320 SVG. Five reserved zones:
+ *   1. program (top-left)              x=0  y=0   w=200 h=120
+ *   2. call stack (top-right)          x=212 y=0   w=148 h=120
+ *   3. web APIs (mid)                  x=0  y=132  w=360 h=44
+ *   4. microtask queue (bottom-upper)  x=0  y=184  w=360 h=44
+ *   5. task queue (bottom-mid)         x=0  y=232  w=360 h=44
+ *   6. output strip (bottom)           x=0  y=284  w=360 h=36
+ * Every zone is fixed-size with reserved rows so the frame never reflows.
+ * --------------------------------------------------------------------------*/
+
+const QUEUE_SLOT_W = 70;
+const QUEUE_SLOT_H = 26;
+const QUEUE_GAP = 8;
+
+function QueueRow({
+  label,
+  items,
+  y,
+  filled,
+}: {
+  label: string;
+  items: string[];
+  y: number;
+  /** Filled (terracotta) chip vs outlined chip. */
+  filled: boolean;
+}) {
+  return (
+    <g>
+      <text
+        x={0}
+        y={y - 6}
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        {label}
+      </text>
+      {/* Reserved row outline so empty rows don't collapse. */}
+      <rect
+        x={0}
+        y={y}
+        width={360}
+        height={QUEUE_SLOT_H + 4}
+        rx={3}
+        ry={3}
+        fill="transparent"
+        stroke="var(--color-rule)"
+        strokeDasharray="2 3"
+        strokeOpacity={0.5}
+      />
+      <AnimatePresence initial={false}>
+        {items.map((label, i) => (
+          <motion.g
+            key={`${label}-${i}`}
+            initial={{ opacity: 0, x: -6 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.snappy}
+          >
+            <rect
+              x={6 + i * (QUEUE_SLOT_W + QUEUE_GAP)}
+              y={y + 2}
+              width={QUEUE_SLOT_W}
+              height={QUEUE_SLOT_H}
+              rx={3}
+              ry={3}
+              fill={filled ? "var(--color-accent)" : "transparent"}
+              stroke={filled ? "transparent" : "var(--color-accent)"}
+              strokeWidth={1.5}
+            />
+            <text
+              x={6 + i * (QUEUE_SLOT_W + QUEUE_GAP) + QUEUE_SLOT_W / 2}
+              y={y + 2 + QUEUE_SLOT_H / 2 + 1}
+              dominantBaseline="central"
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill={filled ? "var(--color-bg)" : "var(--color-accent)"}
+            >
+              {label}
+            </text>
+          </motion.g>
+        ))}
+      </AnimatePresence>
+    </g>
+  );
+}
+
+function StackZone({ frames }: { frames: string[] }) {
+  // Stack grows upward — newest frame on top. Reserve 4 slots so the zone
+  // never reflows.
+  const SLOT_H = 24;
+  const GAP = 4;
+  const ZONE_X = 212;
+  const ZONE_Y = 0;
+  const ZONE_W = 148;
+  const ZONE_H = 120;
+  const reserved = 4;
+  return (
+    <g>
+      <text
+        x={ZONE_X}
+        y={ZONE_Y - 6}
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        call stack
+      </text>
+      <rect
+        x={ZONE_X}
+        y={ZONE_Y}
+        width={ZONE_W}
+        height={ZONE_H}
+        rx={3}
+        ry={3}
+        fill="transparent"
+        stroke="var(--color-rule)"
+        strokeDasharray="2 3"
+        strokeOpacity={0.5}
+      />
+      {/* Reserved slot outlines (faint) */}
+      {Array.from({ length: reserved }).map((_, i) => (
+        <rect
+          key={`slot-${i}`}
+          x={ZONE_X + 6}
+          y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP}
+          width={ZONE_W - 12}
+          height={SLOT_H}
+          rx={2}
+          ry={2}
+          fill="transparent"
+          stroke="var(--color-rule)"
+          strokeOpacity={0.25}
+        />
+      ))}
+      <AnimatePresence initial={false}>
+        {frames.map((frame, i) => (
+          <motion.g
+            key={`${frame}-${i}`}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={SPRING.snappy}
+          >
+            <rect
+              x={ZONE_X + 6}
+              y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP}
+              width={ZONE_W - 12}
+              height={SLOT_H}
+              rx={2}
+              ry={2}
+              fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
+              stroke="var(--color-accent)"
+              strokeWidth={1}
+            />
+            <text
+              x={ZONE_X + ZONE_W / 2}
+              y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP + SLOT_H / 2 + 1}
+              dominantBaseline="central"
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-text)"
+            >
+              {frame}
+            </text>
+          </motion.g>
+        ))}
+      </AnimatePresence>
+    </g>
+  );
+}
+
+function ProgramZone({ activeLine }: { activeLine: number | null }) {
+  const ZONE_X = 0;
+  const ZONE_Y = 0;
+  const ZONE_W = 200;
+  const ZONE_H = 120;
+  const LINE_H = 22;
+  return (
+    <g>
+      <text
+        x={ZONE_X}
+        y={ZONE_Y - 6}
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        program
+      </text>
+      <rect
+        x={ZONE_X}
+        y={ZONE_Y}
+        width={ZONE_W}
+        height={ZONE_H}
+        rx={3}
+        ry={3}
+        fill="transparent"
+        stroke="var(--color-rule)"
+        strokeDasharray="2 3"
+        strokeOpacity={0.5}
+      />
+      {PROGRAM.map((line, i) => {
+        const isActive = activeLine === i + 1;
+        return (
+          <g key={i}>
+            {isActive ? (
+              <motion.rect
+                x={ZONE_X + 4}
+                y={ZONE_Y + 8 + i * LINE_H - 2}
+                width={ZONE_W - 8}
+                height={LINE_H - 2}
+                rx={2}
+                ry={2}
+                initial={false}
+                animate={{
+                  fill: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+                }}
+                transition={SPRING.snappy}
+              />
+            ) : null}
+            <text
+              x={ZONE_X + 8}
+              y={ZONE_Y + 8 + i * LINE_H + LINE_H / 2}
+              dominantBaseline="central"
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill={
+                isActive ? "var(--color-text)" : "var(--color-text-muted)"
+              }
+            >
+              {line}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+function WebApiRow({ items }: { items: string[] }) {
+  const Y = 132;
+  return (
+    <g>
+      <text
+        x={0}
+        y={Y - 6}
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        web APIs (outside JS)
+      </text>
+      <rect
+        x={0}
+        y={Y}
+        width={360}
+        height={36}
+        rx={3}
+        ry={3}
+        fill="transparent"
+        stroke="var(--color-rule)"
+        strokeDasharray="2 3"
+        strokeOpacity={0.5}
+      />
+      <AnimatePresence initial={false}>
+        {items.map((label, i) => (
+          <motion.g
+            key={`${label}-${i}`}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.snappy}
+          >
+            <rect
+              x={8 + i * 140}
+              y={Y + 6}
+              width={132}
+              height={24}
+              rx={2}
+              ry={2}
+              fill="transparent"
+              stroke="var(--color-text-muted)"
+              strokeWidth={1}
+              strokeDasharray="3 2"
+            />
+            <text
+              x={8 + i * 140 + 66}
+              y={Y + 6 + 12 + 1}
+              dominantBaseline="central"
+              textAnchor="middle"
+              fontFamily="var(--font-mono)"
+              fontSize={11}
+              fill="var(--color-text-muted)"
+            >
+              {label}
+            </text>
+          </motion.g>
+        ))}
+      </AnimatePresence>
+    </g>
+  );
+}
+
+function OutputStrip({ output }: { output: string[] }) {
+  const Y = 284;
+  return (
+    <g>
+      <text
+        x={0}
+        y={Y - 6}
+        fontFamily="var(--font-sans)"
+        fontSize={11}
+        fill="var(--color-text-muted)"
+      >
+        output
+      </text>
+      <rect
+        x={0}
+        y={Y}
+        width={360}
+        height={36}
+        rx={3}
+        ry={3}
+        fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
+        stroke="var(--color-rule)"
+        strokeOpacity={0.4}
+      />
+      {output.map((letter, i) => (
+        <motion.text
+          key={`${letter}-${i}`}
+          x={16 + i * 28}
+          y={Y + 18 + 1}
+          dominantBaseline="central"
+          fontFamily="var(--font-mono)"
+          fontSize={16}
+          fill="var(--color-accent)"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={SPRING.snappy}
+        >
+          {letter}
+        </motion.text>
+      ))}
+      {output.length > 1 ? (
+        // separator dots between letters — pure decoration of the cumulative log
+        output.slice(0, -1).map((_, i) => (
+          <text
+            key={`sep-${i}`}
+            x={16 + i * 28 + 16}
+            y={Y + 18 + 1}
+            dominantBaseline="central"
+            fontFamily="var(--font-mono)"
+            fontSize={14}
+            fill="var(--color-text-muted)"
+            opacity={0.6}
+          >
+            ·
+          </text>
+        ))
+      ) : null}
+    </g>
+  );
+}
+
+function Canvas({ tick }: { tick: Tick }) {
+  return (
+    <svg
+      viewBox="0 0 360 320"
+      width="100%"
+      preserveAspectRatio="xMidYMid meet"
+      style={{
+        display: "block",
+        margin: "0 auto",
+        maxWidth: 480,
+      }}
+      role="img"
+      aria-label="JavaScript runtime simulator: program, call stack, Web APIs, microtask queue, task queue, and output."
+    >
+      <ProgramZone activeLine={tick.activeLine} />
+      <StackZone frames={tick.stack} />
+      <WebApiRow items={tick.webApi} />
+      <QueueRow label="microtask queue" items={tick.micro} y={196} filled />
+      <QueueRow label="task queue" items={tick.task} y={244} filled={false} />
+      <OutputStrip output={tick.output} />
+    </svg>
+  );
+}
+
+const MemoCanvas = memo(Canvas);
+
+/**
+ * RuntimeSimulator (W1) — the spine widget. Walks 10 ticks of a small
+ * program, showing how the call stack, Web APIs, microtask queue, and task
+ * queue interleave. The reader sees `A · D · C · B` after tick 7 — the
+ * post's first revelation, demonstrated before it's named.
+ *
+ * One verb: step (via WidgetNav). No play/scrub alongside.
+ *
+ * Frame stability (R6): SVG is fixed 360×320 with reserved zones for every
+ * row. Empty queues keep their dashed outline so nothing reflows.
+ */
+export function RuntimeSimulator() {
+  const [step, setStep] = useState(0);
+  const tick = TICKS[step];
+
+  return (
+    <WidgetShell
+      title="runtime · scripted stepper"
+      measurements={`tick ${step} / ${TICKS.length - 1}`}
+      caption={tick.caption}
+      captionTone="prominent"
+      controls={
+        <div className="flex items-center justify-center w-full">
+          <WidgetNav
+            value={step}
+            total={TICKS.length}
+            onChange={setStep}
+            counterNoun="tick"
+          />
+        </div>
+      }
+    >
+      <MemoCanvas tick={tick} />
+    </WidgetShell>
+  );
+}

--- a/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
@@ -24,10 +24,7 @@ function CaptionCue({ children }: { children: React.ReactNode }) {
 }
 
 /* ---------------------------------------------------------------------------
- * The scripted program is hand-authored as 10 tick states. Each tick is a
- * complete snapshot of the runtime — stack frames, web-API timers, queue
- * contents, the output strip, and a one-sentence caption. No live execution.
- * The program being simulated:
+ * The simulated program.
  *
  *    console.log("A");
  *    setTimeout(() => console.log("B"), 0);
@@ -210,9 +207,6 @@ const TICKS: Tick[] = [
   },
 ];
 
-/* ---------------------------------------------------------------------------
- * The simulated source. Constant — only the active-line highlight changes.
- * --------------------------------------------------------------------------*/
 const PROGRAM = [
   `console.log("A");`,
   `setTimeout(() => console.log("B"), 0);`,
@@ -221,393 +215,422 @@ const PROGRAM = [
 ];
 
 /* ---------------------------------------------------------------------------
- * Canvas — fixed 360 × 320 SVG. Five reserved zones:
- *   1. program (top-left)              x=0  y=0   w=200 h=120
- *   2. call stack (top-right)          x=212 y=0   w=148 h=120
- *   3. web APIs (mid)                  x=0  y=132  w=360 h=44
- *   4. microtask queue (bottom-upper)  x=0  y=184  w=360 h=44
- *   5. task queue (bottom-mid)         x=0  y=232  w=360 h=44
- *   6. output strip (bottom)           x=0  y=284  w=360 h=36
- * Every zone is fixed-size with reserved rows so the frame never reflows.
+ * Mobile-first redesign. Six stacked HTML zones (single column on <lg) — no
+ * SVG overlay, no overlapping panes. At lg+ the program + call stack pair
+ * sit side-by-side, with the Web-APIs / queues / output rows underneath.
+ *
+ * Every zone has a fixed `min-height` so the frame is invariant across
+ * ticks (R6).
  * --------------------------------------------------------------------------*/
 
-const QUEUE_SLOT_W = 70;
-const QUEUE_SLOT_H = 26;
-const QUEUE_GAP = 8;
+function ProgramPane({ activeLine }: { activeLine: number | null }) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="font-sans"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          letterSpacing: "0.02em",
+        }}
+      >
+        program
+      </div>
+      <div
+        className="font-mono"
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: "10px 12px",
+          fontSize: 12,
+          lineHeight: "22px",
+          // Reserve space for 4 lines.
+          minHeight: 4 * 22 + 20,
+          overflowX: "auto",
+          whiteSpace: "pre",
+        }}
+      >
+        {PROGRAM.map((line, i) => {
+          const isActive = activeLine === i + 1;
+          return (
+            <div
+              key={i}
+              style={{
+                position: "relative",
+                paddingLeft: 4,
+                color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
+              }}
+            >
+              {isActive ? (
+                <motion.span
+                  aria-hidden
+                  initial={false}
+                  animate={{ opacity: 1 }}
+                  transition={SPRING.snappy}
+                  style={{
+                    position: "absolute",
+                    inset: "0 -8px 0 -8px",
+                    background:
+                      "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+                    borderRadius: 2,
+                    pointerEvents: "none",
+                  }}
+                />
+              ) : null}
+              <span style={{ position: "relative" }}>{line}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
-function QueueRow({
+function StackPane({ frames }: { frames: string[] }) {
+  // Reserve 4 slots so the column never reflows.
+  const reserved = 4;
+  const SLOT_H = 26;
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="font-sans"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          letterSpacing: "0.02em",
+        }}
+      >
+        call stack
+      </div>
+      <div
+        style={{
+          position: "relative",
+          background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: 8,
+          minHeight: reserved * (SLOT_H + 4) + 16,
+          display: "flex",
+          flexDirection: "column-reverse",
+          gap: 4,
+        }}
+      >
+        <AnimatePresence initial={false}>
+          {frames.map((frame, i) => (
+            <motion.div
+              key={`${frame}-${i}`}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 6 }}
+              transition={SPRING.snappy}
+              className="font-mono"
+              style={{
+                height: SLOT_H,
+                lineHeight: `${SLOT_H}px`,
+                textAlign: "center",
+                fontSize: 12,
+                color: "var(--color-text)",
+                background: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+                border: "1px solid var(--color-accent)",
+                borderRadius: 3,
+              }}
+            >
+              {frame}
+            </motion.div>
+          ))}
+        </AnimatePresence>
+        {/* Faint reserved-slot guides (drawn first, behind frames). */}
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: 8,
+            display: "flex",
+            flexDirection: "column-reverse",
+            gap: 4,
+            pointerEvents: "none",
+            zIndex: 0,
+          }}
+        >
+          {Array.from({ length: reserved }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: SLOT_H,
+                border: "1px dashed var(--color-rule)",
+                borderRadius: 3,
+                opacity: 0.4,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WebApiPane({ items }: { items: string[] }) {
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="font-sans"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          letterSpacing: "0.02em",
+        }}
+      >
+        web APIs (outside JS)
+      </div>
+      <div
+        style={{
+          border: "1px dashed var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: 8,
+          minHeight: 44,
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 8,
+          alignItems: "center",
+        }}
+      >
+        <AnimatePresence initial={false}>
+          {items.length === 0 ? (
+            <motion.span
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-sans"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                opacity: 0.6,
+                fontStyle: "italic",
+              }}
+            >
+              empty
+            </motion.span>
+          ) : (
+            items.map((label, i) => (
+              <motion.span
+                key={`${label}-${i}`}
+                initial={{ opacity: 0, x: -4 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.snappy}
+                className="font-mono"
+                style={{
+                  padding: "4px 10px",
+                  fontSize: 11,
+                  border: "1px dashed var(--color-text-muted)",
+                  borderRadius: 3,
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {label}
+              </motion.span>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function QueuePane({
   label,
   items,
-  y,
   filled,
 }: {
   label: string;
   items: string[];
-  y: number;
-  /** Filled (terracotta) chip vs outlined chip. */
   filled: boolean;
 }) {
   return (
-    <g>
-      <text
-        x={0}
-        y={y - 6}
-        fontFamily="var(--font-sans)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="font-sans"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          letterSpacing: "0.02em",
+        }}
       >
         {label}
-      </text>
-      {/* Reserved row outline so empty rows don't collapse. */}
-      <rect
-        x={0}
-        y={y}
-        width={360}
-        height={QUEUE_SLOT_H + 4}
-        rx={3}
-        ry={3}
-        fill="transparent"
-        stroke="var(--color-rule)"
-        strokeDasharray="2 3"
-        strokeOpacity={0.5}
-      />
-      <AnimatePresence initial={false}>
-        {items.map((label, i) => (
-          <motion.g
-            key={`${label}-${i}`}
-            initial={{ opacity: 0, x: -6 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0 }}
-            transition={SPRING.snappy}
-          >
-            <rect
-              x={6 + i * (QUEUE_SLOT_W + QUEUE_GAP)}
-              y={y + 2}
-              width={QUEUE_SLOT_W}
-              height={QUEUE_SLOT_H}
-              rx={3}
-              ry={3}
-              fill={filled ? "var(--color-accent)" : "transparent"}
-              stroke={filled ? "transparent" : "var(--color-accent)"}
-              strokeWidth={1.5}
-            />
-            <text
-              x={6 + i * (QUEUE_SLOT_W + QUEUE_GAP) + QUEUE_SLOT_W / 2}
-              y={y + 2 + QUEUE_SLOT_H / 2 + 1}
-              dominantBaseline="central"
-              textAnchor="middle"
-              fontFamily="var(--font-mono)"
-              fontSize={11}
-              fill={filled ? "var(--color-bg)" : "var(--color-accent)"}
-            >
-              {label}
-            </text>
-          </motion.g>
-        ))}
-      </AnimatePresence>
-    </g>
-  );
-}
-
-function StackZone({ frames }: { frames: string[] }) {
-  // Stack grows upward — newest frame on top. Reserve 4 slots so the zone
-  // never reflows.
-  const SLOT_H = 24;
-  const GAP = 4;
-  const ZONE_X = 224;
-  const ZONE_Y = 0;
-  const ZONE_W = 136;
-  const ZONE_H = 120;
-  const reserved = 4;
-  return (
-    <g>
-      <text
-        x={ZONE_X}
-        y={ZONE_Y - 6}
-        fontFamily="var(--font-sans)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
+      </div>
+      <div
+        style={{
+          border: "1px dashed var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: 8,
+          minHeight: 44,
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 8,
+          alignItems: "center",
+        }}
       >
-        call stack
-      </text>
-      <rect
-        x={ZONE_X}
-        y={ZONE_Y}
-        width={ZONE_W}
-        height={ZONE_H}
-        rx={3}
-        ry={3}
-        fill="transparent"
-        stroke="var(--color-rule)"
-        strokeDasharray="2 3"
-        strokeOpacity={0.5}
-      />
-      {/* Reserved slot outlines (faint) */}
-      {Array.from({ length: reserved }).map((_, i) => (
-        <rect
-          key={`slot-${i}`}
-          x={ZONE_X + 6}
-          y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP}
-          width={ZONE_W - 12}
-          height={SLOT_H}
-          rx={2}
-          ry={2}
-          fill="transparent"
-          stroke="var(--color-rule)"
-          strokeOpacity={0.25}
-        />
-      ))}
-      <AnimatePresence initial={false}>
-        {frames.map((frame, i) => (
-          <motion.g
-            key={`${frame}-${i}`}
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 6 }}
-            transition={SPRING.snappy}
-          >
-            <rect
-              x={ZONE_X + 6}
-              y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP}
-              width={ZONE_W - 12}
-              height={SLOT_H}
-              rx={2}
-              ry={2}
-              fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
-              stroke="var(--color-accent)"
-              strokeWidth={1}
-            />
-            <text
-              x={ZONE_X + ZONE_W / 2}
-              y={ZONE_Y + ZONE_H - 6 - (i + 1) * SLOT_H - i * GAP + SLOT_H / 2 + 1}
-              dominantBaseline="central"
-              textAnchor="middle"
-              fontFamily="var(--font-mono)"
-              fontSize={11}
-              fill="var(--color-text)"
+        <AnimatePresence initial={false}>
+          {items.length === 0 ? (
+            <motion.span
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-sans"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                opacity: 0.6,
+                fontStyle: "italic",
+              }}
             >
-              {frame}
-            </text>
-          </motion.g>
-        ))}
-      </AnimatePresence>
-    </g>
-  );
-}
-
-function ProgramZone({ activeLine }: { activeLine: number | null }) {
-  const ZONE_X = 0;
-  const ZONE_Y = 0;
-  const ZONE_W = 200;
-  const ZONE_H = 120;
-  const LINE_H = 22;
-  return (
-    <g>
-      <text
-        x={ZONE_X}
-        y={ZONE_Y - 6}
-        fontFamily="var(--font-sans)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
-      >
-        program
-      </text>
-      <rect
-        x={ZONE_X}
-        y={ZONE_Y}
-        width={ZONE_W}
-        height={ZONE_H}
-        rx={3}
-        ry={3}
-        fill="transparent"
-        stroke="var(--color-rule)"
-        strokeDasharray="2 3"
-        strokeOpacity={0.5}
-      />
-      {PROGRAM.map((line, i) => {
-        const isActive = activeLine === i + 1;
-        return (
-          <g key={i}>
-            {isActive ? (
-              <motion.rect
-                x={ZONE_X + 4}
-                y={ZONE_Y + 8 + i * LINE_H - 2}
-                width={ZONE_W - 8}
-                height={LINE_H - 2}
-                rx={2}
-                ry={2}
-                initial={false}
-                animate={{
-                  fill: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
-                }}
+              empty
+            </motion.span>
+          ) : (
+            items.map((slot, i) => (
+              <motion.span
+                key={`${slot}-${i}`}
+                initial={{ opacity: 0, x: -4 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0 }}
                 transition={SPRING.snappy}
-              />
-            ) : null}
-            <text
-              x={ZONE_X + 8}
-              y={ZONE_Y + 8 + i * LINE_H + LINE_H / 2}
-              dominantBaseline="central"
-              fontFamily="var(--font-mono)"
-              fontSize={10}
-              fill={
-                isActive ? "var(--color-text)" : "var(--color-text-muted)"
-              }
-            >
-              {line}
-            </text>
-          </g>
-        );
-      })}
-    </g>
+                className="font-mono"
+                style={{
+                  padding: "4px 12px",
+                  fontSize: 12,
+                  borderRadius: 3,
+                  background: filled ? "var(--color-accent)" : "transparent",
+                  color: filled ? "var(--color-bg)" : "var(--color-accent)",
+                  border: filled ? "none" : "1.5px solid var(--color-accent)",
+                }}
+              >
+                {slot}
+              </motion.span>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
   );
 }
 
-function WebApiRow({ items }: { items: string[] }) {
-  const Y = 132;
+function OutputPane({ output }: { output: string[] }) {
   return (
-    <g>
-      <text
-        x={0}
-        y={Y - 6}
-        fontFamily="var(--font-sans)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
-      >
-        web APIs (outside JS)
-      </text>
-      <rect
-        x={0}
-        y={Y}
-        width={360}
-        height={36}
-        rx={3}
-        ry={3}
-        fill="transparent"
-        stroke="var(--color-rule)"
-        strokeDasharray="2 3"
-        strokeOpacity={0.5}
-      />
-      <AnimatePresence initial={false}>
-        {items.map((label, i) => (
-          <motion.g
-            key={`${label}-${i}`}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={SPRING.snappy}
-          >
-            <rect
-              x={8 + i * 140}
-              y={Y + 6}
-              width={132}
-              height={24}
-              rx={2}
-              ry={2}
-              fill="transparent"
-              stroke="var(--color-text-muted)"
-              strokeWidth={1}
-              strokeDasharray="3 2"
-            />
-            <text
-              x={8 + i * 140 + 66}
-              y={Y + 6 + 12 + 1}
-              dominantBaseline="central"
-              textAnchor="middle"
-              fontFamily="var(--font-mono)"
-              fontSize={11}
-              fill="var(--color-text-muted)"
-            >
-              {label}
-            </text>
-          </motion.g>
-        ))}
-      </AnimatePresence>
-    </g>
-  );
-}
-
-function OutputStrip({ output }: { output: string[] }) {
-  const Y = 284;
-  return (
-    <g>
-      <text
-        x={0}
-        y={Y - 6}
-        fontFamily="var(--font-sans)"
-        fontSize={11}
-        fill="var(--color-text-muted)"
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="font-sans"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          letterSpacing: "0.02em",
+        }}
       >
         output
-      </text>
-      <rect
-        x={0}
-        y={Y}
-        width={360}
-        height={36}
-        rx={3}
-        ry={3}
-        fill="color-mix(in oklab, var(--color-surface) 60%, transparent)"
-        stroke="var(--color-rule)"
-        strokeOpacity={0.4}
-      />
-      {output.map((letter, i) => (
-        <motion.text
-          key={`${letter}-${i}`}
-          x={16 + i * 28}
-          y={Y + 18 + 1}
-          dominantBaseline="central"
-          fontFamily="var(--font-mono)"
-          fontSize={16}
-          fill="var(--color-accent)"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={SPRING.snappy}
-        >
-          {letter}
-        </motion.text>
-      ))}
-      {output.length > 1 ? (
-        // separator dots between letters — pure decoration of the cumulative log
-        output.slice(0, -1).map((_, i) => (
-          <text
-            key={`sep-${i}`}
-            x={16 + i * 28 + 16}
-            y={Y + 18 + 1}
-            dominantBaseline="central"
-            fontFamily="var(--font-mono)"
-            fontSize={14}
-            fill="var(--color-text-muted)"
-            opacity={0.6}
-          >
-            ·
-          </text>
-        ))
-      ) : null}
-    </g>
+      </div>
+      <div
+        style={{
+          background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: "8px 12px",
+          minHeight: 40,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
+        <AnimatePresence initial={false}>
+          {output.length === 0 ? (
+            <motion.span
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="font-sans"
+              style={{
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                opacity: 0.6,
+                fontStyle: "italic",
+              }}
+            >
+              empty
+            </motion.span>
+          ) : (
+            output.flatMap((letter, i) => {
+              const elements = [
+                <motion.span
+                  key={`${letter}-${i}`}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={SPRING.snappy}
+                  className="font-mono"
+                  style={{
+                    fontSize: 16,
+                    color: "var(--color-accent)",
+                    fontWeight: 600,
+                    minWidth: "1ch",
+                    textAlign: "center",
+                  }}
+                >
+                  {letter}
+                </motion.span>,
+              ];
+              if (i < output.length - 1) {
+                elements.push(
+                  <span
+                    key={`sep-${i}`}
+                    aria-hidden
+                    className="font-mono"
+                    style={{
+                      fontSize: 14,
+                      color: "var(--color-text-muted)",
+                      opacity: 0.6,
+                    }}
+                  >
+                    ·
+                  </span>,
+                );
+              }
+              return elements;
+            })
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
   );
 }
 
 function Canvas({ tick }: { tick: Tick }) {
   return (
-    <svg
-      viewBox="0 0 360 320"
-      width="100%"
-      preserveAspectRatio="xMidYMid meet"
-      style={{
-        display: "block",
-        margin: "0 auto",
-        maxWidth: 480,
-      }}
-      role="img"
-      aria-label="JavaScript runtime simulator. Step controls below."
-    >
-      <ProgramZone activeLine={tick.activeLine} />
-      <StackZone frames={tick.stack} />
-      <WebApiRow items={tick.webApi} />
-      <QueueRow label="microtask queue" items={tick.micro} y={196} filled />
-      <QueueRow label="task queue" items={tick.task} y={244} filled={false} />
-      <OutputStrip output={tick.output} />
-    </svg>
+    <div className="flex flex-col gap-[var(--spacing-md)]">
+      {/* Top row: program + call stack. Stacked on mobile, side-by-side on lg. */}
+      <div className="bs-runtime-top">
+        <ProgramPane activeLine={tick.activeLine} />
+        <StackPane frames={tick.stack} />
+      </div>
+      <WebApiPane items={tick.webApi} />
+      <QueuePane label="microtask queue" items={tick.micro} filled />
+      <QueuePane label="task queue" items={tick.task} filled={false} />
+      <OutputPane output={tick.output} />
+      <style>{`
+        .bs-runtime-top {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-md);
+        }
+        @media (min-width: 720px) {
+          .bs-runtime-top {
+            grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+            align-items: stretch;
+          }
+        }
+      `}</style>
+    </div>
   );
 }
 
@@ -621,8 +644,10 @@ const MemoCanvas = memo(Canvas);
  *
  * One verb: step (via WidgetNav). No play/scrub alongside.
  *
- * Frame stability (R6): SVG is fixed 360×320 with reserved zones for every
- * row. Empty queues keep their dashed outline so nothing reflows.
+ * Layout: mobile-first. Single column at <720px (program → stack → web-apis
+ * → micro queue → task queue → output). At lg+, program and call stack sit
+ * side-by-side; the queues + output remain full-width below them. No
+ * overlapping panes; every zone has its own fixed min-height (R6).
  */
 export function RuntimeSimulator() {
   const [step, setStep] = useState(0);

--- a/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { memo, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
+import { memo, useId, useState } from "react";
+import { motion, AnimatePresence, LayoutGroup } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING } from "@/lib/motion";
@@ -224,6 +224,9 @@ const PROGRAM = [
  * --------------------------------------------------------------------------*/
 
 function ProgramPane({ activeLine }: { activeLine: number | null }) {
+  // Stable per-instance layoutId so the highlight glides between lines
+  // instead of remount-fading on every step.
+  const markerId = useId();
   return (
     <div className="flex flex-col gap-[var(--spacing-2xs)]">
       <div
@@ -251,37 +254,43 @@ function ProgramPane({ activeLine }: { activeLine: number | null }) {
           whiteSpace: "pre",
         }}
       >
-        {PROGRAM.map((line, i) => {
-          const isActive = activeLine === i + 1;
-          return (
-            <div
-              key={i}
-              style={{
-                position: "relative",
-                paddingLeft: 4,
-                color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
-              }}
-            >
-              {isActive ? (
-                <motion.span
-                  aria-hidden
-                  initial={false}
-                  animate={{ opacity: 1 }}
-                  transition={SPRING.snappy}
-                  style={{
-                    position: "absolute",
-                    inset: "0 -8px 0 -8px",
-                    background:
-                      "color-mix(in oklab, var(--color-accent) 14%, transparent)",
-                    borderRadius: 2,
-                    pointerEvents: "none",
-                  }}
-                />
-              ) : null}
-              <span style={{ position: "relative" }}>{line}</span>
-            </div>
-          );
-        })}
+        <LayoutGroup id={markerId}>
+          {PROGRAM.map((line, i) => {
+            const isActive = activeLine === i + 1;
+            return (
+              <motion.div
+                key={i}
+                style={{
+                  position: "relative",
+                  paddingLeft: 4,
+                }}
+                animate={{
+                  color: isActive
+                    ? "var(--color-text)"
+                    : "var(--color-text-muted)",
+                }}
+                transition={SPRING.smooth}
+              >
+                {isActive ? (
+                  <motion.span
+                    layoutId={`pc-${markerId}`}
+                    aria-hidden
+                    transition={SPRING.smooth}
+                    style={{
+                      position: "absolute",
+                      inset: "0 -8px 0 -8px",
+                      background:
+                        "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+                      borderRadius: 2,
+                      pointerEvents: "none",
+                    }}
+                  />
+                ) : null}
+                <span style={{ position: "relative" }}>{line}</span>
+              </motion.div>
+            );
+          })}
+        </LayoutGroup>
       </div>
     </div>
   );
@@ -320,10 +329,11 @@ function StackPane({ frames }: { frames: string[] }) {
           {frames.map((frame, i) => (
             <motion.div
               key={`${frame}-${i}`}
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 6 }}
-              transition={SPRING.snappy}
+              layout
+              initial={{ opacity: 0, y: 8, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 8, scale: 0.96 }}
+              transition={SPRING.smooth}
               className="font-mono"
               style={{
                 height: SLOT_H,
@@ -416,10 +426,11 @@ function WebApiPane({ items }: { items: string[] }) {
             items.map((label, i) => (
               <motion.span
                 key={`${label}-${i}`}
-                initial={{ opacity: 0, x: -4 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0 }}
-                transition={SPRING.snappy}
+                layout
+                initial={{ opacity: 0, scale: 0.85, x: -6 }}
+                animate={{ opacity: 1, scale: 1, x: 0 }}
+                exit={{ opacity: 0, scale: 0.85 }}
+                transition={SPRING.smooth}
                 className="font-mono"
                 style={{
                   padding: "4px 10px",
@@ -493,10 +504,11 @@ function QueuePane({
             items.map((slot, i) => (
               <motion.span
                 key={`${slot}-${i}`}
-                initial={{ opacity: 0, x: -4 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0 }}
-                transition={SPRING.snappy}
+                layout
+                initial={{ opacity: 0, scale: 0.85, x: -6 }}
+                animate={{ opacity: 1, scale: 1, x: 0 }}
+                exit={{ opacity: 0, scale: 0.85 }}
+                transition={SPRING.smooth}
                 className="font-mono"
                 style={{
                   padding: "4px 12px",
@@ -564,10 +576,11 @@ function OutputPane({ output }: { output: string[] }) {
               const elements = [
                 <motion.span
                   key={`${letter}-${i}`}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={SPRING.snappy}
+                  layout
+                  initial={{ opacity: 0, scale: 0.6, y: -4 }}
+                  animate={{ opacity: 1, scale: 1, y: 0 }}
+                  exit={{ opacity: 0, scale: 0.6 }}
+                  transition={SPRING.smooth}
                   className="font-mono"
                   style={{
                     fontSize: 16,

--- a/app/posts/the-line-that-waits-its-turn/widgets/index.ts
+++ b/app/posts/the-line-that-waits-its-turn/widgets/index.ts
@@ -1,0 +1,4 @@
+export { RuntimeSimulator } from "./RuntimeSimulator";
+export { PredictTheOutput } from "./PredictTheOutput";
+export { AwaitDesugar } from "./AwaitDesugar";
+export { MicrotaskStarvation } from "./MicrotaskStarvation";

--- a/app/posts/the-line-that-waits-its-turn/widgets/index.ts
+++ b/app/posts/the-line-that-waits-its-turn/widgets/index.ts
@@ -1,4 +1,5 @@
 export { RuntimeSimulator } from "./RuntimeSimulator";
+export { PredictTheStart } from "./PredictTheStart";
 export { PredictTheOutput } from "./PredictTheOutput";
 export { AwaitDesugar } from "./AwaitDesugar";
 export { MicrotaskStarvation } from "./MicrotaskStarvation";

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -23,6 +23,16 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "the-line-that-waits-its-turn",
+    title:
+      "How the JavaScript event loop, microtasks, and the call stack work",
+    date: "2026-04-25",
+    hook:
+      "why setTimeout(0) is never zero, why await feels seamless, and why one runaway Promise can stall a tab.",
+    readingMinutes: 15,
+    tags: ["javascript", "language-internals", "async"],
+  },
+  {
     slug: "the-webpage-that-reads-the-agent",
     title: "AI agent traps & prompt injection on the open web",
     date: "2026-04-24",


### PR DESCRIPTION
## Summary

New bytesize post on the JavaScript runtime concurrency model — call stack, Web APIs, task vs microtask queues, the event loop, `await` desugaring, and microtask starvation. Pedagogy-first; four widgets carry the structural weight; sister-post coordination with `how-javascript-reads-its-own-future`.

- **Word/widget budget**: ~1390 / 1500 words; 4 widgets; 5 HL + 1 VerticalCutReveal = 6 climax devices; ~15 min reading.
- **Widgets**: `RuntimeSimulator` (L — stack + Web APIs + 2 queues, 10-tick scrubber); `PredictTheOutput` (M — 3 variants, vote-then-reveal); `AwaitDesugar` (M — async/await ↔ `.then` lock-step stepper); `MicrotaskStarvation` (M — starve vs yield mode toggle, bounded 50k iterations).
- **Sister-post coordination**: Option C (minimal redundancy) chosen at Checkpoint 1; both posts cover the call stack with their own framing — data-structure (sister) vs gatekeeper (this). Reciprocal §1 crosslink in this post; the original §6 trailing crosslink was removed per voice-diff V1 to preserve the closer's VCR climax.

## What changed (per commit)

- `ec45a35` — scaffold post directory + widgets barrel
- `fb24a04` — implement 4 widgets (RuntimeSimulator, PredictTheOutput, AwaitDesugar, MicrotaskStarvation)
- `202f02d` — narrative TSX + manifest entry
- `e7cc080` — mechanical batch (Phase G round 1): 2 DESIGN.md ban fixes + 12 a11y/microcopy/layout items
- `1681436` — voice-diff bundle (Phase G round 2): closer cleanup, HL cadence, H2 sharpens, paradox-shape, "can"→fact

## DESIGN.md ban enforcement

Two confirmed ban violations from Phase F design review fixed in the mechanical batch:

- **§12 #1** (`border-left > 1px` as colored accent stripe — #1 AI-slop tell): `AwaitDesugar.tsx:220` active-line `borderLeft` replaced with background-wash-only treatment (14% → 18%).
- **§9** (`linear` ease for UI motion): `MicrotaskStarvation.tsx:119` infinite `linear` pulse-dot replaced with `SPRING.gentle` reverse-loop on `opacity: 0.3 ↔ 1`. The motion teaches (paint-thread liveness) per voice-profile §5; only the easing curve was banned.

**8 reviewer suggestions rejected** with ban citations in `research/the-line-that-waits-its-turn/action-items.md` (RJ-1 through RJ-8). Highlights: rejected confetti burst on W4 completion (§1 editorial-calm); rejected second `VerticalCutReveal` use (§2.5 budget cap); rejected gradient text on §3 thesis (§12); rejected wiggle motion on AwaitDesugar pane sync (§9 + voice-profile §5).

## IP

Original writing throughout. Citations via `<A>` to HTML spec §8.1.7, MDN event loop, MDN `await`, V8 blog, Node docs, web.dev, and Jake Archibald's 2018 talk. No verbatim copy or close-paraphrase from source materials (Will Sentence course, Archibald, Hallie, YDKJS).

## Validation

Full results in `research/the-line-that-waits-its-turn/validation.md`. All 7 checks PASS:

- Technical correctness — every numeric/factual claim traces to inline citation
- Code correctness — `pnpm exec tsc --noEmit` PASS, `pnpm build` PASS
- A11y — keyboard nav across all 4 widgets, `useReducedMotion` gates the rAF pulse, color-only-info dual-encoded with shape/position/label, focus rings preserved
- Build — 14/14 static pages, 2.2s compile
- Lighthouse — deferred to Vercel preview comments (modern practice)
- Reading-sanity — no voice drift, no undefined terms, no flow-breaking moments
- Frame-stability R6 — container size invariant across every widget interaction
- DESIGN.md §3, §9, §12 compliance verified post-diff

## Test plan

- [ ] Read end-to-end on Vercel preview at desktop (1280px) and mobile (360px)
- [ ] Step through RuntimeSimulator all 10 ticks; check empty-stack → microtask-pull at tick 7
- [ ] Vote on each PredictTheOutput variant; confirm correct-answer reveal fades in
- [ ] Step AwaitDesugar to step 2; confirm both panes annotate `microtask queue` simultaneously
- [ ] Toggle MicrotaskStarvation between starve / yield; tap run; confirm pulse-dot freezes in starve, keeps pulsing in yield
- [ ] Tab through every widget keyboard-only; confirm focus rings visible
- [ ] Toggle macOS "reduce motion"; confirm pulse-dot stays static
- [ ] Toggle dark mode; confirm wash, accent, and HL colors all hold
- [ ] Click sister-post crosslink in §1; confirm it lands on `how-javascript-reads-its-own-future`
- [ ] Lighthouse on the deployed preview URL — check perf / a11y / SEO ≥ 95

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>