### PR TITLE
post: how-javascript-reads-its-own-future — JS execution context, hoisting, call stack

### DIFF
--- a/app/posts/how-javascript-reads-its-own-future/metadata.ts
+++ b/app/posts/how-javascript-reads-its-own-future/metadata.ts
@@ -4,7 +4,7 @@ import { SITE_URL as SITE } from "@/lib/site";
 const SLUG = "how-javascript-reads-its-own-future";
 const VISIBLE_HEADING = "How JavaScript reads its own future";
 const LYRICAL_TAGLINE =
-  "Hoisting, the TDZ, and the call stack — one mechanism, not three quirks";
+  "One mechanism — hoisting, the TDZ, and the call stack.";
 const HOOK =
   "Before line 1 runs, the JavaScript engine has already walked your file. Hoisting, the TDZ, and the call stack are one mechanism — explored with playable widgets.";
 

--- a/app/posts/how-javascript-reads-its-own-future/metadata.ts
+++ b/app/posts/how-javascript-reads-its-own-future/metadata.ts
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import { SITE_URL as SITE } from "@/lib/site";
 
 const SLUG = "how-javascript-reads-its-own-future";
-const VISIBLE_HEADING = "How JavaScript reads its own future";
-const LYRICAL_TAGLINE =
-  "One mechanism — hoisting, the TDZ, and the call stack.";
+const VISIBLE_HEADING =
+  "JavaScript Hoisting, the TDZ, and the Call Stack Explained";
+const LYRICAL_TAGLINE = "How JavaScript reads its own future";
 const HOOK =
-  "Before line 1 runs, the JavaScript engine has already walked your file. Hoisting, the TDZ, and the call stack are one mechanism — explored with playable widgets.";
+  "How JavaScript hoisting works, why let and const enter a temporal dead zone, and how execution contexts stack — with playable widgets that show each step.";
 
 /** Visible subtitle on the post page (poetic tagline under the descriptive H1). */
 export const subtitle = LYRICAL_TAGLINE;
@@ -14,6 +14,19 @@ export const subtitle = LYRICAL_TAGLINE;
 export const metadata: Metadata = {
   title: `${VISIBLE_HEADING} — bytesize`,
   description: HOOK,
+  keywords: [
+    "javascript hoisting",
+    "temporal dead zone",
+    "tdz",
+    "call stack",
+    "execution context",
+    "variable environment",
+    "let const var",
+    "javascript engine",
+  ],
+  alternates: {
+    canonical: `${SITE}/posts/${SLUG}`,
+  },
   openGraph: {
     title: `${VISIBLE_HEADING} — bytesize`,
     description: HOOK,

--- a/app/posts/how-javascript-reads-its-own-future/metadata.ts
+++ b/app/posts/how-javascript-reads-its-own-future/metadata.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "how-javascript-reads-its-own-future";
+const VISIBLE_HEADING = "How JavaScript reads its own future";
+const LYRICAL_TAGLINE =
+  "Hoisting, the TDZ, and the call stack — one mechanism, not three quirks";
+const HOOK =
+  "Before line 1 runs, the JavaScript engine has already walked your file. Hoisting, the TDZ, and the call stack are one mechanism — explored with playable widgets.";
+
+/** Visible subtitle on the post page (poetic tagline under the descriptive H1). */
+export const subtitle = LYRICAL_TAGLINE;
+
+export const metadata: Metadata = {
+  title: `${VISIBLE_HEADING} — bytesize`,
+  description: HOOK,
+  openGraph: {
+    title: `${VISIBLE_HEADING} — bytesize`,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${VISIBLE_HEADING} — bytesize`,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
-import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
+import { TextHighlighter } from "@/components/fancy";
 import {
   CreationVsExecution,
   DeclarationStates,
@@ -294,9 +294,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           className="[margin-block-start:1.25em]"
           style={{ fontFamily: "var(--font-serif)", fontSize: "var(--text-body)" }}
         >
-          <VerticalCutReveal as="span" staggerDuration={0.035}>
-            The engine reads your future to run your present.
-          </VerticalCutReveal>
+          The engine reads your future to run your present.
         </p>
         <ClosingDot />
       </div>

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -225,11 +225,17 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           it had paused.
         </P>
         <P>
-          Step through the widget below. Two columns, one cursor. The left
-          column is the call stack growing and shrinking. The right column is
-          the variable environment of whichever frame is on top — the running
-          execution context. They move together because they&apos;re the same
-          thing seen twice. <HL>Whichever frame is on top is the engine&apos;s thread of execution.</HL>
+          Press <Em>Run</Em> in the widget below to step through a tiny
+          program: <Code>compute(7)</Code> calls <Code>multiply(7, 2)</Code>,
+          which returns <Code>14</Code>. Each call pushes a new EC card onto
+          the stage; each return pops one. The console pane mirrors the
+          actual <Code>console.log</Code> output as the runtime emits it. The
+          card glowing terracotta is the running EC — drag the cards around
+          if you like; the metaphor is literal.{" "}
+          <HL>
+            Whichever frame is on top is the engine&apos;s thread of
+            execution.
+          </HL>
         </P>
       </div>
 
@@ -237,9 +243,13 @@ export default function HowJavaScriptReadsItsOwnFuture() {
 
       <div className="pt-[var(--spacing-lg)]">
         <P>
-          That&apos;s also the answer to the opening scene. The line that
-          printed <Code>undefined</Code> was running inside the global EC.
-          Its <Em>variable environment</Em> already held{" "}
+          Each function call gets its own execution context — its own
+          private memory and its own slot on the stack. The thread of
+          execution moves into a new context when a function is called, and
+          back to the previous one when it returns. That&apos;s also the
+          answer to the opening scene. The line that printed{" "}
+          <Code>undefined</Code> was running inside the global EC. Its{" "}
+          <Em>variable environment</Em> already held{" "}
           <Code>x: undefined</Code>, courtesy of the pre-walk. The console
           asked memory; memory answered.
         </P>

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -261,30 +261,14 @@ export default function HowJavaScriptReadsItsOwnFuture() {
 
       <div className="pt-[var(--spacing-md)]">
         <P>
-          The first reason is the most visible. The language guarantees that a{" "}
-          <Code>function</Code> declaration is callable from anywhere in its
-          scope, including before its textual position. If the engine tried to
-          run line 1 without scanning ahead, a function call on line 1 to a{" "}
-          <Code>function</Code> declared on line 200 would fail. The
-          guarantee forces the scan.
-        </P>
-        <P>
-          The second is the spec being strict. Two <Code>let</Code>{" "}
-          declarations of the same name in the same scope must throw a{" "}
-          <Code>SyntaxError</Code> — and crucially, that error has to fire
-          before any of the surrounding code runs. The only way to enforce
-          that is to walk the scope first and refuse to start. V8&apos;s
-          preparser was{" "}
-          <A href="https://v8.dev/blog/preparser">extended specifically</A> to
-          catch these conflicts on the first pass.
-        </P>
-        <P>
-          The third is the subtlest. A <Code>const</Code> binding has to be
-          immutable from the moment it has a value. If the pre-walk gave it{" "}
-          <Code>undefined</Code> first and the initialiser later flipped it to
-          something else, the binding would have changed value once — by
-          definition not <Code>const</Code>. The TDZ resolves this:{" "}
-          <HL>required, not an optimisation.</HL>
+          Three constraints, three categories. <Em>Semantic</Em>: function
+          declarations must be callable from anywhere in scope.{" "}
+          <Em>Syntactic</Em>: duplicate <Code>let</Code>s must throw a{" "}
+          <Code>SyntaxError</Code> before any line runs — V8&apos;s preparser
+          was <A href="https://v8.dev/blog/preparser">extended specifically</A>{" "}
+          to catch them. <Em>Immutability</Em>: a <Code>const</Code> can&apos;t
+          read as <Code>undefined</Code> first and bind later. The TDZ resolves
+          all three: <HL>required, not an optimisation.</HL>
         </P>
         <Aside>
           The spec describes two passes; V8&apos;s pipeline (parser → AST →
@@ -301,10 +285,9 @@ export default function HowJavaScriptReadsItsOwnFuture() {
       <div>
         <Dots />
         <P>
-          The opening scene wasn&apos;t a quirk. Hoisting, TDZ errors,
-          functions callable from above their declaration — every weird
-          ordering rule you&apos;ve hit is the same mechanism, surfacing in
-          three places.
+          Hoisting, the TDZ, functions callable from above — three names for
+          one mechanism. The opening scene wasn&apos;t a quirk. It was the
+          mechanism showing through.
         </P>
         <p
           className="[margin-block-start:1.25em]"
@@ -314,11 +297,6 @@ export default function HowJavaScriptReadsItsOwnFuture() {
             The engine reads your future to run your present.
           </VerticalCutReveal>
         </p>
-        <P>
-          What happens when the stack empties — when the engine starts
-          listening for events instead of running lines — is a different
-          post.
-        </P>
         <p
           aria-hidden
           className="font-mono text-center select-none"

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -1,0 +1,336 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  Dots,
+  Em,
+  Aside,
+  A,
+  HeroTile,
+} from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
+import { TextHighlighter, VerticalCutReveal } from "@/components/fancy";
+import {
+  CreationVsExecution,
+  DeclarationStates,
+  CallStackECs,
+  WhyTwoPasses,
+} from "./widgets";
+import { metadata, subtitle } from "./metadata";
+
+export { metadata };
+
+const HL_TRANSITION = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/**
+ * `<HL>` — load-bearing-phrase highlighter. Used sparingly (~5 per post).
+ * Reserve for inversions, mechanism first-appearances, and section payoffs.
+ */
+function HL({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      transition={HL_TRANSITION}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/** Eyebrow — the small all-caps numeric label that sits above each H2. */
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="mt-[var(--spacing-md)] font-sans"
+      style={{
+        fontSize: "var(--text-small)",
+        color: "var(--color-text-muted)",
+        letterSpacing: "0.12em",
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </p>
+  );
+}
+
+export default function HowJavaScriptReadsItsOwnFuture() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <PostBackLink />
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+          <HeroTile slug="how-javascript-reads-its-own-future" />
+        </div>
+        <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
+          How JavaScript reads its own future
+        </H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-25">apr 25, 2026</time>
+          <span className="mx-2">·</span>
+          <span>15 min read</span>
+        </p>
+        <p
+          className="mt-[var(--spacing-md)]"
+          style={{
+            fontSize: "var(--text-medium)",
+            color: "var(--color-text-muted)",
+            fontStyle: "normal",
+            maxWidth: "56ch",
+            lineHeight: "1.45",
+          }}
+        >
+          {subtitle}
+        </p>
+
+        {/* §0 — Scene */}
+        <P>
+          You type two lines into a console:{" "}
+          <Code>console.log(x); var x = 5;</Code>. You expect an error — line 1
+          reads a name that line 2 hasn&apos;t introduced yet. Instead, the
+          console prints <Code>undefined</Code>. The error never comes. By the
+          time line 1 ran, the engine had already read line 2.
+        </P>
+      </div>
+
+      {/* §1 — The pre-walk */}
+      <div>
+        <Dots />
+        <Eyebrow>1 · the pre-walk</Eyebrow>
+        <H2>The engine reads your file before it runs line 1.</H2>
+        <P>
+          The trick isn&apos;t that <Code>var</Code> moved anywhere.{" "}
+          <HL>
+            Nothing moves. The engine walks the body once before any of it
+            runs.
+          </HL>{" "}
+          On that first pass — call it the <Em>creation phase</Em> — every{" "}
+          <Code>var</Code>, every <Code>let</Code>, every function declaration,
+          every parameter gets a binding installed in the function&apos;s
+          memory. Only after the whole body has been scanned does line 1
+          actually start.
+        </P>
+        <P>
+          Drag the scrubber below across the labelled boundary. To the left,
+          the engine is still scanning; the binding for <Code>x</Code> is
+          already there with value <Code>undefined</Code>, but no source line
+          has run. To the right, line 1 finally executes. It reads what was
+          installed on the left.
+        </P>
+      </div>
+
+      <CreationVsExecution />
+
+      <div className="pt-[var(--spacing-md)]">
+        <Aside>
+          The spec name for this pre-walk is{" "}
+          <Code>FunctionDeclarationInstantiation</Code> for function bodies
+          and <Code>GlobalDeclarationInstantiation</Code> for the script. See{" "}
+          <A href="https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-functiondeclarationinstantiation">
+            ECMA-262 §10.2.11
+          </A>
+          . Throughout this post we&apos;ll just call it the creation phase.
+        </Aside>
+      </div>
+
+      {/* §2 — Declaration states */}
+      <div>
+        <Dots />
+        <Eyebrow>2 · what the pre-walk records</Eyebrow>
+        <H2>Different declarations arrive at line 1 in different shapes.</H2>
+        <P>
+          The pre-walk isn&apos;t uniform. It looks at the syntactic kind of
+          each declaration and decides what state the binding is in when
+          execution begins. Four cases cover almost everything you&apos;ll
+          ever hit.
+        </P>
+        <P>
+          A <Code>var</Code> binding is created and initialised to{" "}
+          <Code>undefined</Code> — that&apos;s the case the opening scene
+          showed. A function declaration goes further: the binding exists{" "}
+          <Em>and</Em> already points at the function value, which is why{" "}
+          <Code>f()</Code> can call <Code>f</Code> two lines above the{" "}
+          <Code>function f(){}</Code> that defines it. A{" "}
+          <Code>var x = function(){}</Code> is the deceptive one: only the{" "}
+          <Code>var x = undefined</Code> half survives the pre-walk; the
+          function value attaches when the assignment line runs, so calling{" "}
+          <Code>f()</Code> above it throws <Code>TypeError</Code>.
+        </P>
+        <P>
+          And then there&apos;s <Code>let</Code>, <Code>const</Code>, and{" "}
+          <Code>class</Code>. Their bindings are created on the pre-walk too,
+          but they arrive at line 1 in a fourth state: uninitialised. The TC39
+          spec has a name for it — the <Em>temporal dead zone</Em> — and a
+          rule for it:{" "}
+          <HL>the binding exists, but reading it throws.</HL>
+        </P>
+        <P>
+          Switch declaration kinds in the widget below to see the four memory
+          shapes side by side. The hatched cell is the TDZ — the binding
+          isn&apos;t missing, it&apos;s on hold.
+        </P>
+      </div>
+
+      <DeclarationStates />
+
+      <div className="pt-[var(--spacing-md)]">
+        <P>
+          One detail worth keeping: a <Code>let</Code> inside a block creates
+          its binding in a fresh inner <Em>lexical environment</Em> attached
+          to that block, not in the function&apos;s top-level memory. That&apos;s
+          why <Code>{"{ let x = 2 }"}</Code> doesn&apos;t collide with an
+          outer <Code>let x</Code> — same name, different environment record.
+          See <A href="https://developer.mozilla.org/en-US/docs/Glossary/Hoisting">MDN&apos;s hoisting catalogue</A>{" "}
+          for the full taxonomy.
+        </P>
+      </div>
+
+      {/* §3 — Call stack of ECs */}
+      <div>
+        <Dots />
+        <Eyebrow>3 · the call stack, plural</Eyebrow>
+        <H2>The call stack is a stack of execution contexts, not function calls.</H2>
+        <P>
+          Hoisting, the TDZ, and the question the opening scene started with
+          all live inside one frame: the global execution context. Every
+          script begins with that frame at the bottom of a stack. The frame is
+          a structure, not a name on a list — it carries its own variable
+          environment (where <Code>var</Code> and function-declaration
+          bindings live) and its own lexical environment (where{" "}
+          <Code>let</Code>, <Code>const</Code>, and block scopes live).
+        </P>
+        <P>
+          When a function is invoked, the engine pushes a new execution
+          context on top. That new frame runs its own creation phase —
+          parameters, vars, function declarations, the TDZ rules — and starts
+          executing line 1 of the function body. When the function returns,
+          its frame pops, and whichever frame is now on top resumes wherever
+          it had paused.
+        </P>
+        <P>
+          Step through the widget below. Two columns, one cursor. The left
+          column is the call stack growing and shrinking. The right column is
+          the variable environment of whichever frame is on top — the running
+          execution context. They move together because they&apos;re the same
+          thing seen twice. <HL>Whichever frame is on top is the engine&apos;s thread of execution.</HL>
+        </P>
+      </div>
+
+      <CallStackECs />
+
+      <div className="pt-[var(--spacing-md)]">
+        <P>
+          That&apos;s also the answer to the opening scene. The line that
+          printed <Code>undefined</Code> was running inside the global EC.
+          Its <Em>variable environment</Em> already held{" "}
+          <Code>x: undefined</Code>, courtesy of the pre-walk. The console
+          asked memory; memory answered.
+        </P>
+      </div>
+
+      {/* §4 — Why two passes */}
+      <div>
+        <Dots />
+        <Eyebrow>4 · why two passes</Eyebrow>
+        <H2>The two-pass model is required, not an optimisation.</H2>
+        <P>
+          A reasonable question at this point: couldn&apos;t the engine just
+          run the file top to bottom and look up names as it goes? It would be
+          simpler. It would also be wrong — three different ways. Toggle
+          through the reasons below.
+        </P>
+      </div>
+
+      <WhyTwoPasses />
+
+      <div className="pt-[var(--spacing-md)]">
+        <P>
+          The first reason is the most visible. The language guarantees that a{" "}
+          <Code>function</Code> declaration is callable from anywhere in its
+          scope, including before its textual position. If the engine tried to
+          run line 1 without scanning ahead, a function call on line 1 to a{" "}
+          <Code>function</Code> declared on line 200 would fail. The
+          guarantee forces the scan.
+        </P>
+        <P>
+          The second is the spec being strict. Two <Code>let</Code>{" "}
+          declarations of the same name in the same scope must throw a{" "}
+          <Code>SyntaxError</Code> — and crucially, that error has to fire
+          before any of the surrounding code runs. The only way to enforce
+          that is to walk the scope first and refuse to start. V8&apos;s
+          preparser was{" "}
+          <A href="https://v8.dev/blog/preparser">extended specifically</A> to
+          catch these conflicts on the first pass.
+        </P>
+        <P>
+          The third is the subtlest. A <Code>const</Code> binding has to be
+          immutable from the moment it has a value. If the pre-walk gave it{" "}
+          <Code>undefined</Code> first and the initialiser later flipped it to
+          something else, the binding would have changed value once — by
+          definition not <Em>const</Em>. The TDZ resolves this:{" "}
+          <HL>required, not an optimisation.</HL>
+        </P>
+        <Aside>
+          The spec describes two passes; V8&apos;s pipeline (parser → AST →
+          Ignition bytecode → TurboFan) implements them lazily — a function
+          body is preparsed once for syntax + variable refs, and only fully
+          parsed on first invocation. A{" "}
+          <A href="https://v8.dev/blog/preparser">syntax error inside an
+          unused function still throws at script load</A>, but its variable
+          bindings aren&apos;t fully resolved until the call.
+        </Aside>
+      </div>
+
+      {/* §5 — Closer */}
+      <div>
+        <Dots />
+        <P>
+          The opening scene wasn&apos;t a quirk. Hoisting, TDZ errors,
+          functions callable from above their declaration — every weird
+          ordering rule you&apos;ve hit is the same mechanism, surfacing in
+          three places.
+        </P>
+        <p
+          className="[margin-block-start:1.25em]"
+          style={{ fontFamily: "var(--font-serif)", fontSize: "var(--text-body)" }}
+        >
+          <VerticalCutReveal as="span">
+            The engine reads your future to run your present.
+          </VerticalCutReveal>
+        </p>
+        <P>
+          What happens when the stack empties — when the engine starts
+          listening for events instead of running lines — is a different
+          post.
+        </P>
+        <p
+          aria-hidden
+          className="font-mono text-center select-none"
+          style={{
+            marginBlock: "var(--spacing-xl)",
+            color: "var(--color-accent)",
+            opacity: 0.8,
+            fontSize: "var(--text-body)",
+            letterSpacing: "0.2em",
+          }}
+        >
+          ·
+        </p>
+      </div>
+      <PostNavCards slug="how-javascript-reads-its-own-future" />
+    </Prose>
+  );
+}

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -19,6 +19,7 @@ import {
   DeclarationStates,
   CallStackECs,
   WhyTwoPasses,
+  ClosingDot,
 } from "./widgets";
 import { metadata, subtitle } from "./metadata";
 
@@ -297,19 +298,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
             The engine reads your future to run your present.
           </VerticalCutReveal>
         </p>
-        <p
-          aria-hidden
-          className="font-mono text-center select-none"
-          style={{
-            marginBlock: "var(--spacing-xl)",
-            color: "var(--color-accent)",
-            opacity: 0.8,
-            fontSize: "var(--text-body)",
-            letterSpacing: "0.2em",
-          }}
-        >
-          ·
-        </p>
+        <ClosingDot />
       </div>
       <PostNavCards slug="how-javascript-reads-its-own-future" />
     </Prose>

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -72,7 +72,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           <HeroTile slug="how-javascript-reads-its-own-future" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
-          How JavaScript reads its own future
+          JavaScript Hoisting, the TDZ, and the Call Stack Explained
         </H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"
@@ -225,13 +225,11 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           it had paused.
         </P>
         <P>
-          Press <Em>Run</Em> in the widget below to step through a tiny
-          program: <Code>compute(7)</Code> calls <Code>multiply(7, 2)</Code>,
-          which returns <Code>14</Code>. Each call pushes a new EC card onto
-          the stage; each return pops one. The console pane mirrors the
-          actual <Code>console.log</Code> output as the runtime emits it. The
-          card glowing terracotta is the running EC — drag the cards around
-          if you like; the metaphor is literal.{" "}
+          Step through the widget below to watch a tiny program run:{" "}
+          <Code>compute(7)</Code> calls <Code>multiply(7, 2)</Code>, which
+          returns <Code>14</Code>. The arrow shows where the thread is —
+          pointing from the line being run to the context running it. Each
+          call pushes a new EC onto the stack; each return pops one.{" "}
           <HL>
             Whichever frame is on top is the engine&apos;s thread of
             execution.

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -9,6 +9,7 @@ import {
   Aside,
   A,
   HeroTile,
+  Term,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
@@ -66,7 +67,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
+        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex">
           <HeroTile slug="how-javascript-reads-its-own-future" />
         </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
@@ -101,8 +102,8 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           You type two lines into a console:{" "}
           <Code>console.log(x); var x = 5;</Code>. You expect an error — line 1
           reads a name that line 2 hasn&apos;t introduced yet. Instead, the
-          console prints <Code>undefined</Code>. The error never comes. By the
-          time line 1 ran, the engine had already read line 2.
+          console quietly logs <Code>undefined</Code>. The error never comes.
+          Line 1 ran with line 2 already known.
         </P>
       </div>
 
@@ -117,14 +118,14 @@ export default function HowJavaScriptReadsItsOwnFuture() {
             Nothing moves. The engine walks the body once before any of it
             runs.
           </HL>{" "}
-          On that first pass — call it the <Em>creation phase</Em> — every{" "}
+          On that first pass — call it the <Term>creation phase</Term> — every{" "}
           <Code>var</Code>, every <Code>let</Code>, every function declaration,
           every parameter gets a binding installed in the function&apos;s
           memory. Only after the whole body has been scanned does line 1
           actually start.
         </P>
         <P>
-          Drag the scrubber below across the labelled boundary. To the left,
+          Drag the scrubber below — past the labelled boundary. To the left,
           the engine is still scanning; the binding for <Code>x</Code> is
           already there with value <Code>undefined</Code>, but no source line
           has run. To the right, line 1 finally executes. It reads what was
@@ -160,12 +161,14 @@ export default function HowJavaScriptReadsItsOwnFuture() {
         <P>
           A <Code>var</Code> binding is created and initialised to{" "}
           <Code>undefined</Code> — that&apos;s the case the opening scene
-          showed. A function declaration goes further: the binding exists{" "}
-          <Em>and</Em> already points at the function value, which is why{" "}
-          <Code>f()</Code> can call <Code>f</Code> two lines above the{" "}
-          <Code>function f(){}</Code> that defines it. A{" "}
-          <Code>var x = function(){}</Code> is the deceptive one: only the{" "}
-          <Code>var x = undefined</Code> half survives the pre-walk; the
+          showed. A function declaration goes further: the binding exists and
+          already points at the function value, which is why <Code>f()</Code>{" "}
+          can call <Code>f</Code> two lines above the{" "}
+          <Code>function f(){}</Code> that defines it.
+        </P>
+        <P>
+          A <Code>var x = function(){}</Code> is the deceptive one. Only the{" "}
+          <Code>var x = undefined</Code> half survives the pre-walk. The
           function value attaches when the assignment line runs, so calling{" "}
           <Code>f()</Code> above it throws <Code>TypeError</Code>.
         </P>
@@ -173,7 +176,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           And then there&apos;s <Code>let</Code>, <Code>const</Code>, and{" "}
           <Code>class</Code>. Their bindings are created on the pre-walk too,
           but they arrive at line 1 in a fourth state: uninitialised. The TC39
-          spec has a name for it — the <Em>temporal dead zone</Em> — and a
+          spec has a name for it — the <Term>temporal dead zone</Term> — and a
           rule for it:{" "}
           <HL>the binding exists, but reading it throws.</HL>
         </P>
@@ -189,7 +192,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
       <div className="pt-[var(--spacing-md)]">
         <P>
           One detail worth keeping: a <Code>let</Code> inside a block creates
-          its binding in a fresh inner <Em>lexical environment</Em> attached
+          its binding in a fresh inner <Term>lexical environment</Term> attached
           to that block, not in the function&apos;s top-level memory. That&apos;s
           why <Code>{"{ let x = 2 }"}</Code> doesn&apos;t collide with an
           outer <Code>let x</Code> — same name, different environment record.
@@ -207,10 +210,10 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           Hoisting, the TDZ, and the question the opening scene started with
           all live inside one frame: the global execution context. Every
           script begins with that frame at the bottom of a stack. The frame is
-          a structure, not a name on a list — it carries its own variable
-          environment (where <Code>var</Code> and function-declaration
-          bindings live) and its own lexical environment (where{" "}
-          <Code>let</Code>, <Code>const</Code>, and block scopes live).
+          a structure, not a name on a list — it carries its own{" "}
+          <Term>variable environment</Term> (where <Code>var</Code> and
+          function-declaration bindings live) and its own lexical environment
+          (where <Code>let</Code>, <Code>const</Code>, and block scopes live).
         </P>
         <P>
           When a function is invoked, the engine pushes a new execution
@@ -231,7 +234,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
 
       <CallStackECs />
 
-      <div className="pt-[var(--spacing-md)]">
+      <div className="pt-[var(--spacing-lg)]">
         <P>
           That&apos;s also the answer to the opening scene. The line that
           printed <Code>undefined</Code> was running inside the global EC.
@@ -245,7 +248,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
       <div>
         <Dots />
         <Eyebrow>4 · why two passes</Eyebrow>
-        <H2>The two-pass model is required, not an optimisation.</H2>
+        <H2>The two-pass model is required.</H2>
         <P>
           A reasonable question at this point: couldn&apos;t the engine just
           run the file top to bottom and look up names as it goes? It would be
@@ -280,7 +283,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           immutable from the moment it has a value. If the pre-walk gave it{" "}
           <Code>undefined</Code> first and the initialiser later flipped it to
           something else, the binding would have changed value once — by
-          definition not <Em>const</Em>. The TDZ resolves this:{" "}
+          definition not <Code>const</Code>. The TDZ resolves this:{" "}
           <HL>required, not an optimisation.</HL>
         </P>
         <Aside>
@@ -307,7 +310,7 @@ export default function HowJavaScriptReadsItsOwnFuture() {
           className="[margin-block-start:1.25em]"
           style={{ fontFamily: "var(--font-serif)", fontSize: "var(--text-body)" }}
         >
-          <VerticalCutReveal as="span">
+          <VerticalCutReveal as="span" staggerDuration={0.035}>
             The engine reads your future to run your present.
           </VerticalCutReveal>
         </p>

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -1,30 +1,35 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { DragElements } from "@/components/fancy";
 import { WidgetShell } from "@/components/viz/WidgetShell";
 import { PRESS, SPRING } from "@/lib/motion";
 
 /**
  * CallStackECs — W3, the SPINE of "how JavaScript reads its own future".
  *
- * The reader presses Run to step through a tiny program. Execution-context
- * cards push and pop on a draggable stage on each step. The live "console"
- * pane below mirrors what the runtime actually emitted — so the abstract
- * idea (thread of execution moves between contexts) becomes literal: the
- * "current" indicator hops from card to card, and the console writes the
- * output of whichever line just ran.
+ * A static, annotated call-stack visualization. The reader presses Step
+ * (or Run) to walk through a tiny program. On each step:
+ *   - the active source line lights up in the code pane,
+ *   - execution-context cards push/pop on the stack pane via spring,
+ *   - on desktop, an SVG arrow connects the active line to the active EC
+ *     ("the thread of execution is here"),
+ *   - on mobile (≤ 640px container) the arrow collapses to a small
+ *     down-glyph between the two stacked panes,
+ *   - the console pane mirrors `console.log` output as it fires.
  *
- * The cards themselves are children of `DragElements` (vendored at
- * components/fancy/drag-elements.tsx). The reader can drag them around the
- * stage to spatially organise the stack — which makes the stack-as-stack
- * metaphor concrete instead of just theoretical.
+ * Replaces the round-2 DragElements implementation. The cards are not
+ * draggable; the thread of execution is *annotated*, not manipulated.
  *
- * Mobile-first: panes stack vertically on narrow widths (code → stage →
- * console). At container ≥ 640px, code+console live on the left and the
- * EC stage takes the right half. Frame-stability R6: every pane has a
- * fixed min-height; the outer shell never reflows during interaction.
+ * Frame stability (R6): every pane reserves a fixed min-height that fits
+ * the deepest stack the snippet produces (3 frames) and the longest
+ * console output, so step changes never reflow the outer shell.
  */
 
 type ECName = "global" | "compute" | "multiply";
@@ -35,8 +40,7 @@ type Binding = {
 };
 
 type EC = {
-  /** Stable identifier — survives across steps so DragElements can keep
-   *  position state when a card stays mounted. */
+  /** Stable identifier — keeps cards mounted across steps where possible. */
   id: ECName;
   /** Header label inside the card. */
   label: string;
@@ -45,7 +49,7 @@ type EC = {
 };
 
 type ConsoleLine = {
-  /** Monotonically incremented per step. */
+  /** Monotonically incremented per emit. */
   id: number;
   text: string;
 };
@@ -152,7 +156,7 @@ const STEPS: Step[] = [
         ],
       },
     ],
-    activeLine: 8,
+    activeLine: 7,
     emit: null,
     beat:
       "multiply returned 14. Its EC popped. compute resumes — doubled is now 14.",
@@ -189,30 +193,14 @@ const STEPS: Step[] = [
 ];
 
 const TOTAL = STEPS.length;
-
-/**
- * Static initial positions for cards on the stage. The stage is sized
- * fluidly via CSS, so positions are expressed in percentages — DragElements
- * accepts string values (px / %) for top/left.
- *
- * Order matches `cardOrder` keys below: [global, compute, multiply].
- */
-const INITIAL_POSITIONS: Record<
-  ECName,
-  { top: string; left: string }
-> = {
-  global: { top: "8%", left: "8%" },
-  compute: { top: "30%", left: "26%" },
-  multiply: { top: "52%", left: "44%" },
-};
-
-const CARD_ORDER: ECName[] = ["global", "compute", "multiply"];
+const RUN_INTERVAL_MS = 900;
 
 type Props = { initialStep?: number };
 
 export function CallStackECs({ initialStep = 0 }: Props) {
   const [step, setStep] = useState(initialStep);
   const [consoleLog, setConsoleLog] = useState<ConsoleLine[]>([]);
+  const [running, setRunning] = useState(false);
   const lastEmittedStep = useRef<number>(-1);
   const reducedMotion = useReducedMotion();
 
@@ -220,7 +208,7 @@ export function CallStackECs({ initialStep = 0 }: Props) {
   const current = STEPS[clamped];
   const topFrame = current.stack[current.stack.length - 1];
 
-  // Record console emissions when a step's emit is fresh (not on rewind).
+  // Console-log emissions: append once per fresh step.
   useEffect(() => {
     if (lastEmittedStep.current === clamped) return;
     lastEmittedStep.current = clamped;
@@ -232,31 +220,45 @@ export function CallStackECs({ initialStep = 0 }: Props) {
     }
   }, [clamped, current.emit]);
 
-  const onRun = () => {
+  // Auto-run loop.
+  useEffect(() => {
+    if (!running) return;
+    if (clamped >= TOTAL - 1) {
+      setRunning(false);
+      return;
+    }
+    const id = window.setTimeout(() => {
+      setStep((s) => Math.min(s + 1, TOTAL - 1));
+    }, RUN_INTERVAL_MS);
+    return () => window.clearTimeout(id);
+  }, [running, clamped]);
+
+  const onStep = useCallback(() => {
     if (clamped < TOTAL - 1) setStep(clamped + 1);
-  };
-  const onBack = () => {
+  }, [clamped]);
+  const onBack = useCallback(() => {
+    if (running) setRunning(false);
     if (clamped > 0) setStep(clamped - 1);
-  };
-  const onReset = () => {
+  }, [clamped, running]);
+  const onReset = useCallback(() => {
+    setRunning(false);
     setStep(0);
     setConsoleLog([]);
-    lastEmittedStep.current = 0;
-  };
-
-  // Which cards are on the stack right now?
-  const liveIds = useMemo(
-    () => new Set(current.stack.map((f) => f.id)),
-    [current.stack],
-  );
-
-  // Resolve VE for any card that's currently live (so popped cards keep
-  // their last VE while their exit animation plays).
-  const veById = useMemo(() => {
-    const m = new Map<ECName, Binding[]>();
-    for (const f of current.stack) m.set(f.id, f.ve);
-    return m;
-  }, [current.stack]);
+    lastEmittedStep.current = -1;
+  }, []);
+  const onRunToggle = useCallback(() => {
+    if (running) {
+      setRunning(false);
+      return;
+    }
+    if (clamped >= TOTAL - 1) {
+      // restart from beginning
+      setStep(0);
+      setConsoleLog([]);
+      lastEmittedStep.current = -1;
+    }
+    setRunning(true);
+  }, [running, clamped]);
 
   const caption = (
     <>
@@ -266,6 +268,14 @@ export function CallStackECs({ initialStep = 0 }: Props) {
       is on top. {current.beat}
     </>
   );
+
+  const runLabel = running
+    ? "Pause"
+    : clamped >= TOTAL - 1
+    ? "Run again"
+    : clamped === 0
+    ? "Run"
+    : "Resume";
 
   return (
     <WidgetShell
@@ -287,17 +297,26 @@ export function CallStackECs({ initialStep = 0 }: Props) {
             style={btnStyle(false, clamped === 0)}
             {...PRESS}
           >
-            ←
+            ← Back
           </motion.button>
           <motion.button
             type="button"
-            onClick={onRun}
-            disabled={clamped === TOTAL - 1}
-            aria-label="Step forward"
-            style={btnStyle(true, clamped === TOTAL - 1)}
+            onClick={onRunToggle}
+            aria-label={running ? "Pause auto-run" : "Run auto-step"}
+            style={btnStyle(true, false)}
             {...PRESS}
           >
-            {clamped === 0 ? "Run" : "Step →"}
+            {runLabel}
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={onStep}
+            disabled={clamped === TOTAL - 1 || running}
+            aria-label="Step forward"
+            style={btnStyle(false, clamped === TOTAL - 1 || running)}
+            {...PRESS}
+          >
+            Step →
           </motion.button>
           <motion.button
             type="button"
@@ -321,331 +340,568 @@ export function CallStackECs({ initialStep = 0 }: Props) {
         </div>
       }
     >
-      <div
-        className="bs-csec-grid"
-        style={{
-          display: "grid",
-          gap: "var(--spacing-sm)",
-          gridTemplateColumns: "minmax(0, 1fr)",
-        }}
-      >
-        {/* Code + console column */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--spacing-sm)",
-            minWidth: 0,
-          }}
-        >
-          {/* Code pane */}
-          <div
-            style={{
-              background:
-                "color-mix(in oklab, var(--color-surface) 35%, transparent)",
-              border: "1px solid var(--color-rule)",
-              borderRadius: 3,
-              padding: "10px 12px",
-              minWidth: 0,
-            }}
-          >
-            <div
-              className="font-sans"
-              style={{
-                fontSize: 9,
-                letterSpacing: "0.08em",
-                color: "var(--color-text-muted)",
-                marginBottom: 8,
-              }}
-            >
-              SNIPPET
-            </div>
-            <ol
-              className="font-mono"
-              style={{
-                listStyle: "none",
-                margin: 0,
-                padding: 0,
-                display: "flex",
-                flexDirection: "column",
-                gap: 1,
-                fontSize: 11.5,
-                lineHeight: 1.5,
-              }}
-            >
-              {SNIPPET.map((line, i) => {
-                const lineNum = i + 1;
-                const isActive = current.activeLine === lineNum;
-                return (
-                  <motion.li
-                    key={lineNum}
-                    initial={false}
-                    animate={{ opacity: isActive ? 1 : 0.62 }}
-                    transition={SPRING.smooth}
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "2em minmax(0, 1fr)",
-                      alignItems: "center",
-                      columnGap: 8,
-                      padding: "1px 6px",
-                      borderRadius: 2,
-                      background: isActive
-                        ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                        : "transparent",
-                      color: isActive
-                        ? "var(--color-accent)"
-                        : "var(--color-text)",
-                    }}
-                  >
-                    <span
-                      style={{
-                        color: "var(--color-text-muted)",
-                        fontSize: 10,
-                        textAlign: "right",
-                      }}
-                    >
-                      {lineNum}
-                    </span>
-                    <span
-                      style={{
-                        minWidth: 0,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {line || " "}
-                    </span>
-                  </motion.li>
-                );
-              })}
-            </ol>
-          </div>
-
-          {/* Console pane */}
-          <div
-            aria-label="console output"
-            style={{
-              background: "var(--color-surface)",
-              border: "1px solid var(--color-rule)",
-              borderRadius: 3,
-              padding: "10px 12px",
-              minHeight: 92,
-              minWidth: 0,
-              fontFamily: "var(--font-mono)",
-              fontSize: 11.5,
-              color: "var(--color-text)",
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-            }}
-          >
-            <div
-              className="font-sans"
-              style={{
-                fontSize: 9,
-                letterSpacing: "0.08em",
-                color: "var(--color-text-muted)",
-                marginBottom: 6,
-              }}
-            >
-              CONSOLE
-            </div>
-            <AnimatePresence initial={false}>
-              {consoleLog.map((l) => (
-                <motion.div
-                  key={l.id}
-                  initial={
-                    reducedMotion ? { opacity: 1 } : { opacity: 0, y: 4 }
-                  }
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={SPRING.smooth}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "1.2em minmax(0, 1fr)",
-                    columnGap: 6,
-                    minWidth: 0,
-                  }}
-                >
-                  <span style={{ color: "var(--color-text-muted)" }}>›</span>
-                  <span
-                    style={{
-                      minWidth: 0,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {l.text}
-                  </span>
-                </motion.div>
-              ))}
-            </AnimatePresence>
-            {consoleLog.length === 0 ? (
-              <div
-                style={{
-                  color: "var(--color-text-muted)",
-                  fontSize: 11,
-                  fontStyle: "italic",
-                }}
-              >
-                (no output yet — press Run)
-              </div>
-            ) : null}
-          </div>
-        </div>
-
-        {/* Stage column — DragElements with EC cards */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--spacing-2xs)",
-            minWidth: 0,
-          }}
-        >
-          <div
-            className="font-sans"
-            style={{
-              fontSize: 9,
-              letterSpacing: "0.08em",
-              color: "var(--color-text-muted)",
-              marginLeft: 2,
-            }}
-          >
-            CALL STACK · DRAG ME
-          </div>
-          <div
-            style={{
-              position: "relative",
-              width: "100%",
-              height: 280,
-              border: "1px dashed var(--color-rule)",
-              borderRadius: 3,
-              background:
-                "color-mix(in oklab, var(--color-surface) 25%, transparent)",
-              overflow: "hidden",
-            }}
-          >
-            <DragElements
-              dragMomentum={false}
-              selectedOnTop
-              initialPositions={CARD_ORDER.map((id) => INITIAL_POSITIONS[id])}
-            >
-              {CARD_ORDER.map((id) => {
-                const isLive = liveIds.has(id);
-                const isTop = topFrame.id === id;
-                const ve =
-                  veById.get(id) ??
-                  (id === "global" ? GLOBAL_VE_INITIAL : []);
-                const label = labelFor(id, ve);
-                return (
-                  <ECCard
-                    key={id}
-                    label={label}
-                    ve={ve}
-                    isLive={isLive}
-                    isTop={isTop}
-                    reducedMotion={Boolean(reducedMotion)}
-                  />
-                );
-              })}
-            </DragElements>
-          </div>
-        </div>
-
-        <style jsx>{`
-          @container widget (min-width: 640px) {
-            .bs-csec-grid {
-              grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
-            }
-          }
-        `}</style>
-      </div>
+      <CallStackBoard
+        snippet={SNIPPET}
+        activeLine={current.activeLine}
+        stack={current.stack}
+        topId={topFrame.id}
+        consoleLog={consoleLog}
+        reducedMotion={Boolean(reducedMotion)}
+      />
     </WidgetShell>
   );
 }
 
-function labelFor(id: ECName, ve: Binding[]): string {
-  if (id === "global") return "Global EC";
-  if (id === "compute") {
-    const x = ve.find((b) => b.name === "x");
-    return `compute(${x?.value ?? "_"})`;
-  }
-  // multiply
-  const a = ve.find((b) => b.name === "a");
-  const b = ve.find((b) => b.name === "b");
-  return `multiply(${a?.value ?? "_"}, ${b?.value ?? "_"})`;
-}
+/* ------------------------------------------------------------------ */
+/*  Board: code pane + stack pane + arrow overlay + console pane.     */
+/* ------------------------------------------------------------------ */
 
-function btnStyle(primary: boolean, disabled: boolean): React.CSSProperties {
-  return {
-    minHeight: 36,
-    padding: "0 12px",
-    borderRadius: "var(--radius-sm)",
-    border: `1px solid ${primary ? "var(--color-accent)" : "var(--color-rule)"}`,
-    background: primary
-      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-      : "transparent",
-    color: primary ? "var(--color-accent)" : "var(--color-text)",
-    fontFamily: "var(--font-mono)",
-    fontSize: 12,
-    cursor: disabled ? "not-allowed" : "pointer",
-    opacity: disabled ? 0.5 : 1,
-  };
-}
-
-function ECCard({
-  label,
-  ve,
-  isLive,
-  isTop,
+function CallStackBoard({
+  snippet,
+  activeLine,
+  stack,
+  topId,
+  consoleLog,
   reducedMotion,
 }: {
+  snippet: string[];
+  activeLine: number | null;
+  stack: EC[];
+  topId: ECName;
+  consoleLog: ConsoleLine[];
+  reducedMotion: boolean;
+}) {
+  // Geometry refs for the SVG arrow (desktop only).
+  const boardRef = useRef<HTMLDivElement | null>(null);
+  const codePaneRef = useRef<HTMLDivElement | null>(null);
+  const stackPaneRef = useRef<HTMLDivElement | null>(null);
+  const lineRefs = useRef<Map<number, HTMLLIElement>>(new Map());
+  const cardRefs = useRef<Map<ECName, HTMLDivElement>>(new Map());
+
+  const [arrow, setArrow] = useState<{
+    from: { x: number; y: number };
+    to: { x: number; y: number };
+    visible: boolean;
+  } | null>(null);
+
+  const [isWide, setIsWide] = useState(false);
+
+  // Track container width via ResizeObserver — drives the desktop/mobile split.
+  useLayoutEffect(() => {
+    const el = boardRef.current;
+    if (!el) return;
+    const update = () => setIsWide(el.clientWidth >= 640);
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Recompute arrow geometry whenever the active line / top card / width changes.
+  useLayoutEffect(() => {
+    if (!isWide) {
+      setArrow(null);
+      return;
+    }
+    const board = boardRef.current;
+    const lineEl = activeLine != null ? lineRefs.current.get(activeLine) : null;
+    const cardEl = cardRefs.current.get(topId);
+    if (!board || !lineEl || !cardEl) {
+      setArrow(null);
+      return;
+    }
+    const boardRect = board.getBoundingClientRect();
+    const lineRect = lineEl.getBoundingClientRect();
+    const cardRect = cardEl.getBoundingClientRect();
+    const from = {
+      x: lineRect.right - boardRect.left + 4,
+      y: lineRect.top - boardRect.top + lineRect.height / 2,
+    };
+    const to = {
+      x: cardRect.left - boardRect.left - 8,
+      y: cardRect.top - boardRect.top + Math.min(20, cardRect.height / 2),
+    };
+    setArrow({ from, to, visible: true });
+  }, [activeLine, topId, isWide, stack.length]);
+
+  // Re-measure on window resize too (covers font swaps, etc.).
+  useEffect(() => {
+    const onResize = () => {
+      // Trigger a re-render via state nudge.
+      setIsWide((w) => w);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  return (
+    <div
+      ref={boardRef}
+      className="bs-csec-board"
+      style={{
+        position: "relative",
+        display: "grid",
+        gap: "var(--spacing-sm)",
+        gridTemplateColumns: "minmax(0, 1fr)",
+      }}
+    >
+      {/* Code pane */}
+      <div
+        ref={codePaneRef}
+        style={{
+          background:
+            "color-mix(in oklab, var(--color-surface) 35%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: 3,
+          padding: "10px 12px",
+          minWidth: 0,
+          minHeight: 220,
+        }}
+      >
+        <div
+          className="font-sans"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.08em",
+            color: "var(--color-text-muted)",
+            marginBottom: 8,
+          }}
+        >
+          CODE
+        </div>
+        <ol
+          className="font-mono"
+          style={{
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+            fontSize: 11.5,
+            lineHeight: 1.5,
+          }}
+        >
+          {snippet.map((line, i) => {
+            const lineNum = i + 1;
+            const isActive = activeLine === lineNum;
+            return (
+              <motion.li
+                key={lineNum}
+                ref={(el) => {
+                  if (el) lineRefs.current.set(lineNum, el);
+                  else lineRefs.current.delete(lineNum);
+                }}
+                initial={false}
+                animate={{ opacity: isActive ? 1 : 0.6 }}
+                transition={
+                  reducedMotion ? { duration: 0 } : { duration: 0.2 }
+                }
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1.2em 2em minmax(0, 1fr)",
+                  alignItems: "center",
+                  columnGap: 6,
+                  padding: "1px 6px",
+                  borderRadius: 2,
+                  background: isActive
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "transparent",
+                  color: isActive
+                    ? "var(--color-accent)"
+                    : "var(--color-text)",
+                  fontWeight: isActive ? 600 : 400,
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    color: "var(--color-accent)",
+                    fontSize: 10,
+                    visibility: isActive ? "visible" : "hidden",
+                  }}
+                >
+                  ▶
+                </span>
+                <span
+                  style={{
+                    color: "var(--color-text-muted)",
+                    fontSize: 10,
+                    textAlign: "right",
+                  }}
+                >
+                  {lineNum}
+                </span>
+                <span
+                  style={{
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {line || " "}
+                </span>
+              </motion.li>
+            );
+          })}
+        </ol>
+      </div>
+
+      {/* Mobile-only down-glyph hint between code and stack.
+          Always rendered so :nth-child indexes stay stable; CSS hides on
+          desktop. */}
+      <div
+        aria-hidden
+        className="bs-csec-glyph"
+        style={{
+          display: isWide ? "none" : "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          margin: "-4px 0 -4px 0",
+        }}
+      >
+        <motion.span
+          key={`${activeLine}-${topId}`}
+          initial={
+            reducedMotion
+              ? { opacity: 1, y: 0 }
+              : { opacity: 0, y: -4 }
+          }
+          animate={{ opacity: 1, y: 0 }}
+          transition={reducedMotion ? { duration: 0 } : SPRING.smooth}
+          style={{
+            color: "var(--color-accent)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 14,
+            lineHeight: 1,
+          }}
+        >
+          ↓
+        </motion.span>
+      </div>
+
+      {/* Stack pane */}
+      <div
+        ref={stackPaneRef}
+        style={{
+          position: "relative",
+          background:
+            "color-mix(in oklab, var(--color-surface) 25%, transparent)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: 3,
+          padding: "10px 12px",
+          minHeight: 240,
+          minWidth: 0,
+        }}
+      >
+        <div
+          className="font-sans"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.08em",
+            color: "var(--color-text-muted)",
+            marginBottom: 8,
+          }}
+        >
+          CALL STACK
+        </div>
+        {/* Cards laid out top-of-stack at the top, bottom-of-stack below. */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column-reverse",
+            gap: "var(--spacing-2xs)",
+            justifyContent: "flex-start",
+          }}
+        >
+          <AnimatePresence initial={false}>
+            {stack.map((frame) => (
+              <ECCard
+                key={frame.id}
+                frameId={frame.id}
+                label={frame.label}
+                ve={frame.ve}
+                isTop={frame.id === topId}
+                reducedMotion={reducedMotion}
+                cardRefs={cardRefs}
+              />
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* Console pane */}
+      <div
+        aria-label="console output"
+        style={{
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: 3,
+          padding: "10px 12px",
+          minHeight: 92,
+          minWidth: 0,
+          fontFamily: "var(--font-mono)",
+          fontSize: 11.5,
+          color: "var(--color-text)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        <div
+          className="font-sans"
+          style={{
+            fontSize: 9,
+            letterSpacing: "0.08em",
+            color: "var(--color-text-muted)",
+            marginBottom: 6,
+          }}
+        >
+          CONSOLE
+        </div>
+        <AnimatePresence initial={false}>
+          {consoleLog.map((l) => (
+            <motion.div
+              key={l.id}
+              initial={
+                reducedMotion ? { opacity: 1 } : { opacity: 0, y: 4 }
+              }
+              animate={{ opacity: 1, y: 0 }}
+              transition={
+                reducedMotion ? { duration: 0 } : { duration: 0.2 }
+              }
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1.2em minmax(0, 1fr)",
+                columnGap: 6,
+                minWidth: 0,
+              }}
+            >
+              <span style={{ color: "var(--color-text-muted)" }}>›</span>
+              <span
+                style={{
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {l.text}
+              </span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+        {consoleLog.length === 0 ? (
+          <div
+            style={{
+              color: "var(--color-text-muted)",
+              fontSize: 11,
+              fontStyle: "italic",
+            }}
+          >
+            (no output yet — press Run)
+          </div>
+        ) : null}
+      </div>
+
+      {/* Desktop SVG arrow overlay. */}
+      {isWide && arrow ? (
+        <ArrowOverlay arrow={arrow} reducedMotion={reducedMotion} />
+      ) : null}
+
+      <style jsx>{`
+        @container widget (min-width: 640px) {
+          .bs-csec-board {
+            grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+            grid-template-rows: auto auto;
+          }
+          /* code pane: top-left */
+          .bs-csec-board > :global(:nth-child(1)) {
+            grid-column: 1 / 2;
+            grid-row: 1 / 2;
+          }
+          /* mobile glyph: hidden on desktop */
+          .bs-csec-board > :global(.bs-csec-glyph) {
+            display: none !important;
+          }
+          /* stack pane: top-right */
+          .bs-csec-board > :global(:nth-child(3)) {
+            grid-column: 2 / 3;
+            grid-row: 1 / 2;
+          }
+          /* console pane: spans both columns, row 2 */
+          .bs-csec-board > :global(:nth-child(4)) {
+            grid-column: 1 / 3;
+            grid-row: 2 / 3;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Arrow overlay — desktop only.                                     */
+/* ------------------------------------------------------------------ */
+
+function ArrowOverlay({
+  arrow,
+  reducedMotion,
+}: {
+  arrow: { from: { x: number; y: number }; to: { x: number; y: number } };
+  reducedMotion: boolean;
+}) {
+  const { from, to } = arrow;
+  // Cubic curve with horizontal handles for a gentle s-shape.
+  const dx = Math.max(40, (to.x - from.x) * 0.5);
+  const c1 = { x: from.x + dx, y: from.y };
+  const c2 = { x: to.x - dx, y: to.y };
+  const path = `M ${from.x} ${from.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${to.x} ${to.y}`;
+  // Arrowhead at the end of the curve.
+  const angle = Math.atan2(to.y - c2.y, to.x - c2.x);
+  const headLen = 8;
+  const headW = 5;
+  const hx = to.x;
+  const hy = to.y;
+  const ax = hx - headLen * Math.cos(angle);
+  const ay = hy - headLen * Math.sin(angle);
+  const lx = ax - headW * Math.cos(angle - Math.PI / 2);
+  const ly = ay - headW * Math.sin(angle - Math.PI / 2);
+  const rx = ax - headW * Math.cos(angle + Math.PI / 2);
+  const ry = ay - headW * Math.sin(angle + Math.PI / 2);
+  const arrowKey = `${from.x.toFixed(0)}-${from.y.toFixed(0)}-${to.x.toFixed(
+    0,
+  )}-${to.y.toFixed(0)}`;
+  return (
+    <svg
+      aria-hidden
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+        overflow: "visible",
+      }}
+    >
+      <AnimatePresence mode="wait">
+        <motion.g
+          key={arrowKey}
+          initial={reducedMotion ? { opacity: 1 } : { opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={
+            reducedMotion ? { duration: 0 } : { duration: 0.15 }
+          }
+        >
+          <motion.path
+            d={path}
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth={2}
+            strokeLinecap="round"
+            initial={
+              reducedMotion ? { pathLength: 1 } : { pathLength: 0 }
+            }
+            animate={{ pathLength: 1 }}
+            transition={
+              reducedMotion
+                ? { duration: 0 }
+                : { type: "spring", stiffness: 240, damping: 28 }
+            }
+          />
+          <motion.polygon
+            points={`${hx},${hy} ${lx},${ly} ${rx},${ry}`}
+            fill="var(--color-accent)"
+            initial={reducedMotion ? { opacity: 1 } : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={
+              reducedMotion ? { duration: 0 } : { duration: 0.2, delay: 0.2 }
+            }
+          />
+        </motion.g>
+      </AnimatePresence>
+    </svg>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  EC card — push from above, pop upward, no drag.                   */
+/* ------------------------------------------------------------------ */
+
+function ECCard({
+  frameId,
+  label,
+  ve,
+  isTop,
+  reducedMotion,
+  cardRefs,
+}: {
+  frameId: ECName;
   label: string;
   ve: Binding[];
-  isLive: boolean;
   isTop: boolean;
   reducedMotion: boolean;
+  cardRefs: React.MutableRefObject<Map<ECName, HTMLDivElement>>;
 }) {
   return (
     <motion.div
-      initial={false}
-      animate={{
-        opacity: isLive ? 1 : 0.18,
-        scale: isLive ? 1 : 0.96,
+      ref={(el) => {
+        if (el) cardRefs.current.set(frameId, el);
+        else cardRefs.current.delete(frameId);
       }}
+      layout={!reducedMotion}
+      initial={
+        reducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: -16 }
+      }
+      animate={{ opacity: 1, y: 0 }}
+      exit={
+        reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -16 }
+      }
       transition={reducedMotion ? { duration: 0 } : SPRING.smooth}
       style={{
-        width: 168,
-        minHeight: 96,
         padding: "8px 10px",
         borderRadius: 4,
         background: isTop
-          ? "color-mix(in oklab, var(--color-accent) 16%, var(--color-surface))"
-          : "var(--color-surface)",
-        border: `1.4px solid ${
+          ? "color-mix(in oklab, var(--color-accent) 6%, transparent)"
+          : "transparent",
+        border: `1px solid ${
           isTop ? "var(--color-accent)" : "var(--color-rule)"
         }`,
-        userSelect: "none",
-        // No drop-shadow — DESIGN.md §12
+        minWidth: 0,
       }}
     >
       <div
         style={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
           gap: 6,
           marginBottom: 6,
+          minWidth: 0,
         }}
       >
+        <span
+          aria-hidden
+          style={{
+            color: isTop ? "var(--color-accent)" : "transparent",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            width: "0.9em",
+            display: "inline-block",
+          }}
+        >
+          ▶
+        </span>
         <span
           className="font-mono"
           style={{
             fontSize: 12,
             fontWeight: 600,
-            color: isTop ? "var(--color-accent)" : "var(--color-text)",
+            color: isTop
+              ? "var(--color-accent)"
+              : "var(--color-text-muted)",
             minWidth: 0,
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -656,20 +912,6 @@ function ECCard({
         >
           {label}
         </span>
-        {isTop ? (
-          <span
-            className="font-sans"
-            aria-label="thread of execution"
-            style={{
-              fontSize: 8,
-              letterSpacing: "0.08em",
-              color: "var(--color-accent)",
-              flexShrink: 0,
-            }}
-          >
-            ▶ RUN
-          </span>
-        ) : null}
       </div>
       <ul
         className="font-mono"
@@ -711,6 +953,7 @@ function ECCard({
                   overflow: "hidden",
                   textOverflow: "ellipsis",
                   whiteSpace: "nowrap",
+                  fontVariantNumeric: "tabular-nums",
                 }}
                 title={b.value}
               >
@@ -722,4 +965,21 @@ function ECCard({
       </ul>
     </motion.div>
   );
+}
+
+function btnStyle(primary: boolean, disabled: boolean): React.CSSProperties {
+  return {
+    minHeight: 44,
+    padding: "0 12px",
+    borderRadius: "var(--radius-sm)",
+    border: `1px solid ${primary ? "var(--color-accent)" : "var(--color-rule)"}`,
+    background: primary
+      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+      : "transparent",
+    color: primary ? "var(--color-accent)" : "var(--color-text)",
+    fontFamily: "var(--font-mono)",
+    fontSize: 12,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+  };
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -52,7 +52,7 @@ const STEPS: Step[] = [
       { name: "inner", value: "[fn]" },
     ],
     beat:
-      "Global EC is the only frame. Both function declarations are bound at creation — the pre-walk has run.",
+      "Global EC is the only frame. Both function declarations are bound — the creation phase has run.",
   },
   {
     stack: [{ name: "global" }],
@@ -167,7 +167,7 @@ export function CallStackECs({ initialStep = 0 }: Props) {
           margin: "0 auto",
         }}
         role="img"
-        aria-label={`Call stack and variable environment. Step ${clamped + 1} of ${TOTAL}. Running: ${current.runningName}.`}
+        aria-label={`Call stack and variable environment. Step ${clamped + 1} of ${TOTAL}. Running: ${current.runningName === "global" ? "global" : `${current.runningName}()`}.`}
       >
         {/* Stack column header */}
         <text

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -1,147 +1,271 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
-import { WidgetNav } from "@/components/viz/WidgetNav";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { DragElements } from "@/components/fancy";
 import { WidgetShell } from "@/components/viz/WidgetShell";
-import { SPRING } from "@/lib/motion";
+import { PRESS, SPRING } from "@/lib/motion";
 
 /**
  * CallStackECs — W3, the SPINE of "how JavaScript reads its own future".
  *
- * Single verb: step (via WidgetNav). Both panes (call stack + variable
- * environment of the running EC) are pure functions of the step index — one
- * shared cursor.
+ * The reader presses Run to step through a tiny program. Execution-context
+ * cards push and pop on a draggable stage on each step. The live "console"
+ * pane below mirrors what the runtime actually emitted — so the abstract
+ * idea (thread of execution moves between contexts) becomes literal: the
+ * "current" indicator hops from card to card, and the console writes the
+ * output of whichever line just ran.
  *
- * 6 hand-authored steps walk a tiny program: outer() calls inner(). Each
- * push and pop animates with SPRING.snappy on transform + opacity only.
+ * The cards themselves are children of `DragElements` (vendored at
+ * components/fancy/drag-elements.tsx). The reader can drag them around the
+ * stage to spatially organise the stack — which makes the stack-as-stack
+ * metaphor concrete instead of just theoretical.
  *
- * Frame-stability R6: 360 wide, fixed canvas height. Stack column reserves
- * space for max-3-frame depth across all steps; VE column reserves space
- * for max-2-binding rows.
+ * Mobile-first: panes stack vertically on narrow widths (code → stage →
+ * console). At container ≥ 640px, code+console live on the left and the
+ * EC stage takes the right half. Frame-stability R6: every pane has a
+ * fixed min-height; the outer shell never reflows during interaction.
  */
 
-type Frame = {
-  /** Display label inside the frame block. */
-  name: string;
-};
+type ECName = "global" | "compute" | "multiply";
 
 type Binding = {
   name: string;
-  /** Shown to the right of the binding name. */
   value: string;
 };
 
-type Step = {
-  /** Stack from bottom (index 0) to top. The top frame is the running EC. */
-  stack: Frame[];
-  /** The running EC's name for caption attribution. */
-  runningName: string;
-  /** Variable environment of the running EC. */
+type EC = {
+  /** Stable identifier — survives across steps so DragElements can keep
+   *  position state when a card stays mounted. */
+  id: ECName;
+  /** Header label inside the card. */
+  label: string;
+  /** The card's variable environment at this step. */
   ve: Binding[];
+};
+
+type ConsoleLine = {
+  /** Monotonically incremented per step. */
+  id: number;
+  text: string;
+};
+
+type Step = {
+  /** Stack from bottom to top. The top frame is the running EC. */
+  stack: EC[];
+  /** Active line in the source panel (1-indexed). */
+  activeLine: number | null;
+  /** New console.log output appended at this step (if any). */
+  emit: string | null;
   /** Caption beat. */
   beat: string;
 };
 
+const SNIPPET = [
+  "function multiply(a, b) {",
+  "  const result = a * b;",
+  "  return result;",
+  "}",
+  "",
+  "function compute(x) {",
+  "  const doubled = multiply(x, 2);",
+  "  console.log(doubled);",
+  "  return doubled;",
+  "}",
+  "",
+  "const answer = compute(7);",
+  "console.log(answer);",
+];
+
+const GLOBAL_VE_INITIAL: Binding[] = [
+  { name: "multiply", value: "ƒ" },
+  { name: "compute", value: "ƒ" },
+  { name: "answer", value: "<uninit>" },
+];
+
+const GLOBAL_VE_FINAL: Binding[] = [
+  { name: "multiply", value: "ƒ" },
+  { name: "compute", value: "ƒ" },
+  { name: "answer", value: "14" },
+];
+
 const STEPS: Step[] = [
   {
-    stack: [{ name: "global" }],
-    runningName: "global",
-    ve: [
-      { name: "outer", value: "[fn]" },
-      { name: "inner", value: "[fn]" },
-    ],
+    stack: [{ id: "global", label: "Global EC", ve: GLOBAL_VE_INITIAL }],
+    activeLine: 12,
+    emit: null,
     beat:
-      "Global EC is the only frame. Both function declarations are bound — the creation phase has run.",
-  },
-  {
-    stack: [{ name: "global" }],
-    runningName: "global",
-    ve: [
-      { name: "outer", value: "[fn]" },
-      { name: "inner", value: "[fn]" },
-    ],
-    beat:
-      "About to call outer(). Step forward to push its execution context onto the stack.",
-  },
-  {
-    stack: [{ name: "global" }, { name: "outer()" }],
-    runningName: "outer",
-    ve: [{ name: "a", value: "1" }],
-    beat:
-      "outer() invoked. Its EC pushed; it is now the running context. The variable-environment pane swapped to outer's bindings.",
+      "Pre-walk done. The Global EC holds bindings for multiply, compute, and answer (still uninitialised).",
   },
   {
     stack: [
-      { name: "global" },
-      { name: "outer()" },
-      { name: "inner()" },
+      { id: "global", label: "Global EC", ve: GLOBAL_VE_INITIAL },
+      {
+        id: "compute",
+        label: "compute(7)",
+        ve: [
+          { name: "x", value: "7" },
+          { name: "doubled", value: "<uninit>" },
+        ],
+      },
     ],
-    runningName: "inner",
-    ve: [{ name: "b", value: "2" }],
+    activeLine: 7,
+    emit: null,
     beat:
-      "inner() called from inside outer. A third frame pushed. The running EC is whichever frame is on top — that is the engine's thread of execution.",
+      "compute(7) called. A new EC pushes onto the stack — its variable environment holds x = 7.",
   },
   {
-    stack: [{ name: "global" }, { name: "outer()" }],
-    runningName: "outer",
-    ve: [{ name: "a", value: "1" }],
+    stack: [
+      { id: "global", label: "Global EC", ve: GLOBAL_VE_INITIAL },
+      {
+        id: "compute",
+        label: "compute(7)",
+        ve: [
+          { name: "x", value: "7" },
+          { name: "doubled", value: "<uninit>" },
+        ],
+      },
+      {
+        id: "multiply",
+        label: "multiply(7, 2)",
+        ve: [
+          { name: "a", value: "7" },
+          { name: "b", value: "2" },
+          { name: "result", value: "<uninit>" },
+        ],
+      },
+    ],
+    activeLine: 2,
+    emit: null,
     beat:
-      "inner returned. Its frame popped. outer is the running EC again — its variable environment is right there where it was left.",
+      "multiply(7, 2) called from inside compute. A third EC pushes — the thread of execution is now in multiply.",
   },
   {
-    stack: [{ name: "global" }],
-    runningName: "global",
-    ve: [
-      { name: "outer", value: "[fn]" },
-      { name: "inner", value: "[fn]" },
+    stack: [
+      { id: "global", label: "Global EC", ve: GLOBAL_VE_INITIAL },
+      {
+        id: "compute",
+        label: "compute(7)",
+        ve: [
+          { name: "x", value: "7" },
+          { name: "doubled", value: "14" },
+        ],
+      },
     ],
+    activeLine: 8,
+    emit: null,
     beat:
-      "outer returned. The stack is back to a single frame: the global EC, where the script started.",
+      "multiply returned 14. Its EC popped. compute resumes — doubled is now 14.",
+  },
+  {
+    stack: [
+      { id: "global", label: "Global EC", ve: GLOBAL_VE_INITIAL },
+      {
+        id: "compute",
+        label: "compute(7)",
+        ve: [
+          { name: "x", value: "7" },
+          { name: "doubled", value: "14" },
+        ],
+      },
+    ],
+    activeLine: 8,
+    emit: "14",
+    beat: "console.log(doubled) fires. The runtime writes 14.",
+  },
+  {
+    stack: [{ id: "global", label: "Global EC", ve: GLOBAL_VE_FINAL }],
+    activeLine: 13,
+    emit: null,
+    beat: "compute returned 14. answer is now bound. Stack is back to Global.",
+  },
+  {
+    stack: [{ id: "global", label: "Global EC", ve: GLOBAL_VE_FINAL }],
+    activeLine: 13,
+    emit: "14",
+    beat:
+      "console.log(answer) fires — the runtime writes 14 again. Script done.",
   },
 ];
 
-type Props = { initialStep?: number };
-
 const TOTAL = STEPS.length;
-const MAX_DEPTH = 3;
-const MAX_VE = 2;
+
+/**
+ * Static initial positions for cards on the stage. The stage is sized
+ * fluidly via CSS, so positions are expressed in percentages — DragElements
+ * accepts string values (px / %) for top/left.
+ *
+ * Order matches `cardOrder` keys below: [global, compute, multiply].
+ */
+const INITIAL_POSITIONS: Record<
+  ECName,
+  { top: string; left: string }
+> = {
+  global: { top: "8%", left: "8%" },
+  compute: { top: "30%", left: "26%" },
+  multiply: { top: "52%", left: "44%" },
+};
+
+const CARD_ORDER: ECName[] = ["global", "compute", "multiply"];
+
+type Props = { initialStep?: number };
 
 export function CallStackECs({ initialStep = 0 }: Props) {
   const [step, setStep] = useState(initialStep);
+  const [consoleLog, setConsoleLog] = useState<ConsoleLine[]>([]);
+  const lastEmittedStep = useRef<number>(-1);
+  const reducedMotion = useReducedMotion();
+
   const clamped = Math.max(0, Math.min(step, TOTAL - 1));
   const current = STEPS[clamped];
+  const topFrame = current.stack[current.stack.length - 1];
 
-  const caption = useMemo(
-    () => (
-      <>
-        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
-          {current.runningName}
-        </span>{" "}
-        is on top. {current.beat}
-      </>
-    ),
-    [current],
+  // Record console emissions when a step's emit is fresh (not on rewind).
+  useEffect(() => {
+    if (lastEmittedStep.current === clamped) return;
+    lastEmittedStep.current = clamped;
+    if (current.emit !== null) {
+      setConsoleLog((prev) => [
+        ...prev,
+        { id: prev.length + 1, text: current.emit as string },
+      ]);
+    }
+  }, [clamped, current.emit]);
+
+  const onRun = () => {
+    if (clamped < TOTAL - 1) setStep(clamped + 1);
+  };
+  const onBack = () => {
+    if (clamped > 0) setStep(clamped - 1);
+  };
+  const onReset = () => {
+    setStep(0);
+    setConsoleLog([]);
+    lastEmittedStep.current = 0;
+  };
+
+  // Which cards are on the stack right now?
+  const liveIds = useMemo(
+    () => new Set(current.stack.map((f) => f.id)),
+    [current.stack],
   );
 
-  // Geometry — 360 wide, two columns.
-  const WIDTH = 360;
-  const PAD = 14;
-  const STACK_X = PAD;
-  const STACK_W = 150;
-  const VE_X = STACK_X + STACK_W + 16;
-  const VE_W = WIDTH - VE_X - PAD;
-  const HEADER_Y = 18;
-  const FRAME_H = 32;
-  const FRAME_GAP = 6;
-  const STACK_BASE_Y =
-    HEADER_Y + 18 + (MAX_DEPTH - 1) * (FRAME_H + FRAME_GAP);
-  const STACK_BOTTOM_Y = STACK_BASE_Y + FRAME_H;
-  const VE_BASE_Y = HEADER_Y + 18;
-  const VE_ROW_H = 28;
-  const VE_GAP = 6;
-  const HEIGHT =
-    Math.max(STACK_BOTTOM_Y, VE_BASE_Y + MAX_VE * (VE_ROW_H + VE_GAP)) + 14;
+  // Resolve VE for any card that's currently live (so popped cards keep
+  // their last VE while their exit animation plays).
+  const veById = useMemo(() => {
+    const m = new Map<ECName, Binding[]>();
+    for (const f of current.stack) m.set(f.id, f.ve);
+    return m;
+  }, [current.stack]);
+
+  const caption = (
+    <>
+      <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+        {topFrame.label.toLowerCase().split("(")[0]}
+      </span>{" "}
+      is on top. {current.beat}
+    </>
+  );
 
   return (
     <WidgetShell
@@ -149,188 +273,453 @@ export function CallStackECs({ initialStep = 0 }: Props) {
       caption={caption}
       captionTone="prominent"
       controls={
-        <WidgetNav
-          value={clamped}
-          total={TOTAL}
-          onChange={setStep}
-          counterNoun="step"
-        />
+        <div
+          role="group"
+          aria-label="Step controls"
+          className="flex flex-wrap items-center justify-center gap-[var(--spacing-2xs)] font-sans"
+          style={{ fontSize: "var(--text-ui)" }}
+        >
+          <motion.button
+            type="button"
+            onClick={onBack}
+            disabled={clamped === 0}
+            aria-label="Step back"
+            style={btnStyle(false, clamped === 0)}
+            {...PRESS}
+          >
+            ←
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={onRun}
+            disabled={clamped === TOTAL - 1}
+            aria-label="Step forward"
+            style={btnStyle(true, clamped === TOTAL - 1)}
+            {...PRESS}
+          >
+            {clamped === 0 ? "Run" : "Step →"}
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={onReset}
+            aria-label="Reset"
+            style={btnStyle(false, false)}
+            {...PRESS}
+          >
+            Reset
+          </motion.button>
+          <span
+            className="font-mono tabular-nums"
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              marginLeft: 6,
+            }}
+          >
+            {clamped + 1}/{TOTAL}
+          </span>
+        </div>
       }
     >
-      <svg
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        width="100%"
+      <div
+        className="bs-csec-grid"
         style={{
-          maxWidth: WIDTH,
-          height: "auto",
-          display: "block",
-          margin: "0 auto",
+          display: "grid",
+          gap: "var(--spacing-sm)",
+          gridTemplateColumns: "minmax(0, 1fr)",
         }}
-        role="img"
-        aria-label={`Call stack and variable environment. Step ${clamped + 1} of ${TOTAL}. Running: ${current.runningName === "global" ? "global" : `${current.runningName}()`}.`}
       >
-        {/* Stack column header */}
-        <text
-          x={STACK_X}
-          y={HEADER_Y}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
+        {/* Code + console column */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--spacing-sm)",
+            minWidth: 0,
+          }}
         >
-          CALL STACK
-        </text>
-
-        {/* Stack column outline — reserves max-depth height */}
-        <rect
-          x={STACK_X}
-          y={HEADER_Y + 6}
-          width={STACK_W}
-          height={STACK_BOTTOM_Y - (HEADER_Y + 6)}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-
-        {/* Frames stack from bottom up. Bottom (index 0) = global. Top = running EC. */}
-        <AnimatePresence initial={false}>
-          {current.stack.map((frame, i) => {
-            const yFromBottom = i; // 0 = bottom
-            const y = STACK_BASE_Y - yFromBottom * (FRAME_H + FRAME_GAP);
-            const isTop = i === current.stack.length - 1;
-            return (
-              <motion.g
-                key={`${frame.name}-${i}`}
-                initial={{ opacity: 0, y: y + 8 }}
-                animate={{ opacity: 1, y }}
-                exit={{ opacity: 0, y: y + 6 }}
-                transition={SPRING.snappy}
-              >
-                <rect
-                  x={STACK_X + 6}
-                  width={STACK_W - 12}
-                  height={FRAME_H}
-                  rx={3}
-                  fill={
-                    isTop
-                      ? "color-mix(in oklab, var(--color-accent) 22%, transparent)"
-                      : "color-mix(in oklab, var(--color-surface) 60%, transparent)"
-                  }
-                  stroke={isTop ? "var(--color-accent)" : "var(--color-rule)"}
-                  strokeWidth={isTop ? 1.6 : 1}
-                />
-                <text
-                  x={STACK_X + STACK_W / 2}
-                  y={FRAME_H / 2}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fontFamily="var(--font-mono)"
-                  fontSize={12}
-                  fill={isTop ? "var(--color-accent)" : "var(--color-text)"}
-                  fontWeight={isTop ? 600 : 400}
-                >
-                  {frame.name}
-                </text>
-                {isTop ? (
-                  <text
-                    x={STACK_X + STACK_W - 10}
-                    y={FRAME_H / 2}
-                    textAnchor="end"
-                    dominantBaseline="central"
-                    fontFamily="var(--font-sans)"
-                    fontSize={8}
-                    letterSpacing="0.08em"
-                    fill="var(--color-accent)"
+          {/* Code pane */}
+          <div
+            style={{
+              background:
+                "color-mix(in oklab, var(--color-surface) 35%, transparent)",
+              border: "1px solid var(--color-rule)",
+              borderRadius: 3,
+              padding: "10px 12px",
+              minWidth: 0,
+            }}
+          >
+            <div
+              className="font-sans"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.08em",
+                color: "var(--color-text-muted)",
+                marginBottom: 8,
+              }}
+            >
+              SNIPPET
+            </div>
+            <ol
+              className="font-mono"
+              style={{
+                listStyle: "none",
+                margin: 0,
+                padding: 0,
+                display: "flex",
+                flexDirection: "column",
+                gap: 1,
+                fontSize: 11.5,
+                lineHeight: 1.5,
+              }}
+            >
+              {SNIPPET.map((line, i) => {
+                const lineNum = i + 1;
+                const isActive = current.activeLine === lineNum;
+                return (
+                  <motion.li
+                    key={lineNum}
+                    initial={false}
+                    animate={{ opacity: isActive ? 1 : 0.62 }}
+                    transition={SPRING.smooth}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "2em minmax(0, 1fr)",
+                      alignItems: "center",
+                      columnGap: 8,
+                      padding: "1px 6px",
+                      borderRadius: 2,
+                      background: isActive
+                        ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                        : "transparent",
+                      color: isActive
+                        ? "var(--color-accent)"
+                        : "var(--color-text)",
+                    }}
                   >
-                    RUNNING
-                  </text>
-                ) : null}
-              </motion.g>
-            );
-          })}
-        </AnimatePresence>
+                    <span
+                      style={{
+                        color: "var(--color-text-muted)",
+                        fontSize: 10,
+                        textAlign: "right",
+                      }}
+                    >
+                      {lineNum}
+                    </span>
+                    <span
+                      style={{
+                        minWidth: 0,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {line || " "}
+                    </span>
+                  </motion.li>
+                );
+              })}
+            </ol>
+          </div>
 
-        {/* VE column header */}
-        <text
-          x={VE_X}
-          y={HEADER_Y}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          VARIABLE ENVIRONMENT
-        </text>
-
-        <rect
-          x={VE_X}
-          y={HEADER_Y + 6}
-          width={VE_W}
-          height={MAX_VE * (VE_ROW_H + VE_GAP) + 8}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-accent)"
-          strokeWidth={1.4}
-        />
-        <text
-          x={VE_X + 8}
-          y={HEADER_Y + 18}
-          fontFamily="var(--font-sans)"
-          fontSize={8}
-          letterSpacing="0.08em"
-          fill="var(--color-accent)"
-        >
-          OF {current.runningName.toUpperCase()}
-        </text>
-
-        {/* VE rows — keyed by running-name + binding so they crossfade on EC switch */}
-        <AnimatePresence initial={false} mode="popLayout">
-          {current.ve.map((b, i) => {
-            const y = VE_BASE_Y + 14 + i * (VE_ROW_H + VE_GAP);
-            return (
-              <motion.g
-                key={`${current.runningName}-${b.name}`}
-                initial={{ opacity: 0, y: y + 4 }}
-                animate={{ opacity: 1, y }}
-                exit={{ opacity: 0, y: y - 4 }}
-                transition={{ ...SPRING.smooth, delay: i * 0.06 }}
+          {/* Console pane */}
+          <div
+            aria-label="console output"
+            style={{
+              background: "var(--color-surface)",
+              border: "1px solid var(--color-rule)",
+              borderRadius: 3,
+              padding: "10px 12px",
+              minHeight: 92,
+              minWidth: 0,
+              fontFamily: "var(--font-mono)",
+              fontSize: 11.5,
+              color: "var(--color-text)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
+            <div
+              className="font-sans"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.08em",
+                color: "var(--color-text-muted)",
+                marginBottom: 6,
+              }}
+            >
+              CONSOLE
+            </div>
+            <AnimatePresence initial={false}>
+              {consoleLog.map((l) => (
+                <motion.div
+                  key={l.id}
+                  initial={
+                    reducedMotion ? { opacity: 1 } : { opacity: 0, y: 4 }
+                  }
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={SPRING.smooth}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1.2em minmax(0, 1fr)",
+                    columnGap: 6,
+                    minWidth: 0,
+                  }}
+                >
+                  <span style={{ color: "var(--color-text-muted)" }}>›</span>
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {l.text}
+                  </span>
+                </motion.div>
+              ))}
+            </AnimatePresence>
+            {consoleLog.length === 0 ? (
+              <div
+                style={{
+                  color: "var(--color-text-muted)",
+                  fontSize: 11,
+                  fontStyle: "italic",
+                }}
               >
-                <rect
-                  x={VE_X + 6}
-                  width={VE_W - 12}
-                  height={VE_ROW_H}
-                  rx={2}
-                  fill="transparent"
-                  stroke="var(--color-rule)"
-                  strokeWidth={1}
-                />
-                <text
-                  x={VE_X + 14}
-                  y={VE_ROW_H / 2}
-                  dominantBaseline="central"
-                  fontFamily="var(--font-mono)"
-                  fontSize={12}
-                  fill="var(--color-text)"
-                >
-                  {b.name}
-                </text>
-                <text
-                  x={VE_X + VE_W - 14}
-                  y={VE_ROW_H / 2}
-                  textAnchor="end"
-                  dominantBaseline="central"
-                  fontFamily="var(--font-mono)"
-                  fontSize={11}
-                  fill="var(--color-accent)"
-                >
-                  {b.value}
-                </text>
-              </motion.g>
-            );
-          })}
-        </AnimatePresence>
-      </svg>
+                (no output yet — press Run)
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Stage column — DragElements with EC cards */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--spacing-2xs)",
+            minWidth: 0,
+          }}
+        >
+          <div
+            className="font-sans"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.08em",
+              color: "var(--color-text-muted)",
+              marginLeft: 2,
+            }}
+          >
+            CALL STACK · DRAG ME
+          </div>
+          <div
+            style={{
+              position: "relative",
+              width: "100%",
+              height: 280,
+              border: "1px dashed var(--color-rule)",
+              borderRadius: 3,
+              background:
+                "color-mix(in oklab, var(--color-surface) 25%, transparent)",
+              overflow: "hidden",
+            }}
+          >
+            <DragElements
+              dragMomentum={false}
+              selectedOnTop
+              initialPositions={CARD_ORDER.map((id) => INITIAL_POSITIONS[id])}
+            >
+              {CARD_ORDER.map((id) => {
+                const isLive = liveIds.has(id);
+                const isTop = topFrame.id === id;
+                const ve =
+                  veById.get(id) ??
+                  (id === "global" ? GLOBAL_VE_INITIAL : []);
+                const label = labelFor(id, ve);
+                return (
+                  <ECCard
+                    key={id}
+                    label={label}
+                    ve={ve}
+                    isLive={isLive}
+                    isTop={isTop}
+                    reducedMotion={Boolean(reducedMotion)}
+                  />
+                );
+              })}
+            </DragElements>
+          </div>
+        </div>
+
+        <style jsx>{`
+          @container widget (min-width: 640px) {
+            .bs-csec-grid {
+              grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+            }
+          }
+        `}</style>
+      </div>
     </WidgetShell>
+  );
+}
+
+function labelFor(id: ECName, ve: Binding[]): string {
+  if (id === "global") return "Global EC";
+  if (id === "compute") {
+    const x = ve.find((b) => b.name === "x");
+    return `compute(${x?.value ?? "_"})`;
+  }
+  // multiply
+  const a = ve.find((b) => b.name === "a");
+  const b = ve.find((b) => b.name === "b");
+  return `multiply(${a?.value ?? "_"}, ${b?.value ?? "_"})`;
+}
+
+function btnStyle(primary: boolean, disabled: boolean): React.CSSProperties {
+  return {
+    minHeight: 36,
+    padding: "0 12px",
+    borderRadius: "var(--radius-sm)",
+    border: `1px solid ${primary ? "var(--color-accent)" : "var(--color-rule)"}`,
+    background: primary
+      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+      : "transparent",
+    color: primary ? "var(--color-accent)" : "var(--color-text)",
+    fontFamily: "var(--font-mono)",
+    fontSize: 12,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+  };
+}
+
+function ECCard({
+  label,
+  ve,
+  isLive,
+  isTop,
+  reducedMotion,
+}: {
+  label: string;
+  ve: Binding[];
+  isLive: boolean;
+  isTop: boolean;
+  reducedMotion: boolean;
+}) {
+  return (
+    <motion.div
+      initial={false}
+      animate={{
+        opacity: isLive ? 1 : 0.18,
+        scale: isLive ? 1 : 0.96,
+      }}
+      transition={reducedMotion ? { duration: 0 } : SPRING.smooth}
+      style={{
+        width: 168,
+        minHeight: 96,
+        padding: "8px 10px",
+        borderRadius: 4,
+        background: isTop
+          ? "color-mix(in oklab, var(--color-accent) 16%, var(--color-surface))"
+          : "var(--color-surface)",
+        border: `1.4px solid ${
+          isTop ? "var(--color-accent)" : "var(--color-rule)"
+        }`,
+        userSelect: "none",
+        // No drop-shadow — DESIGN.md §12
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 6,
+          marginBottom: 6,
+        }}
+      >
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: isTop ? "var(--color-accent)" : "var(--color-text)",
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flex: 1,
+          }}
+          title={label}
+        >
+          {label}
+        </span>
+        {isTop ? (
+          <span
+            className="font-sans"
+            aria-label="thread of execution"
+            style={{
+              fontSize: 8,
+              letterSpacing: "0.08em",
+              color: "var(--color-accent)",
+              flexShrink: 0,
+            }}
+          >
+            ▶ RUN
+          </span>
+        ) : null}
+      </div>
+      <ul
+        className="font-mono"
+        style={{
+          listStyle: "none",
+          margin: 0,
+          padding: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          fontSize: 10.5,
+          color: "var(--color-text)",
+        }}
+      >
+        {ve.length === 0 ? (
+          <li style={{ color: "var(--color-text-muted)" }}>(empty)</li>
+        ) : (
+          ve.map((b) => (
+            <li
+              key={b.name}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "minmax(0, auto) minmax(0, 1fr)",
+                columnGap: 6,
+                minWidth: 0,
+              }}
+            >
+              <span style={{ color: "var(--color-text-muted)" }}>
+                {b.name}
+              </span>
+              <span
+                style={{
+                  textAlign: "right",
+                  color:
+                    b.value === "<uninit>"
+                      ? "var(--color-text-muted)"
+                      : "var(--color-accent)",
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                title={b.value}
+              >
+                {b.value}
+              </span>
+            </li>
+          ))
+        )}
+      </ul>
+    </motion.div>
   );
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+
+/**
+ * CallStackECs — W3, the SPINE of "how JavaScript reads its own future".
+ *
+ * Single verb: step (via WidgetNav). Both panes (call stack + variable
+ * environment of the running EC) are pure functions of the step index — one
+ * shared cursor.
+ *
+ * 6 hand-authored steps walk a tiny program: outer() calls inner(). Each
+ * push and pop animates with SPRING.snappy on transform + opacity only.
+ *
+ * Frame-stability R6: 360 wide, fixed canvas height. Stack column reserves
+ * space for max-3-frame depth across all steps; VE column reserves space
+ * for max-2-binding rows.
+ */
+
+type Frame = {
+  /** Display label inside the frame block. */
+  name: string;
+};
+
+type Binding = {
+  name: string;
+  /** Shown to the right of the binding name. */
+  value: string;
+};
+
+type Step = {
+  /** Stack from bottom (index 0) to top. The top frame is the running EC. */
+  stack: Frame[];
+  /** The running EC's name for caption attribution. */
+  runningName: string;
+  /** Variable environment of the running EC. */
+  ve: Binding[];
+  /** Caption beat. */
+  beat: string;
+};
+
+const STEPS: Step[] = [
+  {
+    stack: [{ name: "global" }],
+    runningName: "global",
+    ve: [
+      { name: "outer", value: "[fn]" },
+      { name: "inner", value: "[fn]" },
+    ],
+    beat:
+      "Global EC is the only frame. Both function declarations are bound at creation — the pre-walk has run.",
+  },
+  {
+    stack: [{ name: "global" }],
+    runningName: "global",
+    ve: [
+      { name: "outer", value: "[fn]" },
+      { name: "inner", value: "[fn]" },
+    ],
+    beat:
+      "About to call outer(). Step forward to push its execution context onto the stack.",
+  },
+  {
+    stack: [{ name: "global" }, { name: "outer()" }],
+    runningName: "outer",
+    ve: [{ name: "a", value: "1" }],
+    beat:
+      "outer() invoked. Its EC pushed; it is now the running context. The variable-environment pane swapped to outer's bindings.",
+  },
+  {
+    stack: [
+      { name: "global" },
+      { name: "outer()" },
+      { name: "inner()" },
+    ],
+    runningName: "inner",
+    ve: [{ name: "b", value: "2" }],
+    beat:
+      "inner() called from inside outer. A third frame pushed. The running EC is whichever frame is on top — that is the engine's thread of execution.",
+  },
+  {
+    stack: [{ name: "global" }, { name: "outer()" }],
+    runningName: "outer",
+    ve: [{ name: "a", value: "1" }],
+    beat:
+      "inner returned. Its frame popped. outer is the running EC again — its variable environment is right there where it was left.",
+  },
+  {
+    stack: [{ name: "global" }],
+    runningName: "global",
+    ve: [
+      { name: "outer", value: "[fn]" },
+      { name: "inner", value: "[fn]" },
+    ],
+    beat:
+      "outer returned. The stack is back to a single frame: the global EC, where the script started.",
+  },
+];
+
+type Props = { initialStep?: number };
+
+const TOTAL = STEPS.length;
+const MAX_DEPTH = 3;
+const MAX_VE = 2;
+
+export function CallStackECs({ initialStep = 0 }: Props) {
+  const [step, setStep] = useState(initialStep);
+  const clamped = Math.max(0, Math.min(step, TOTAL - 1));
+  const current = STEPS[clamped];
+
+  const caption = useMemo(
+    () => (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          {current.runningName}
+        </span>{" "}
+        is on top. {current.beat}
+      </>
+    ),
+    [current],
+  );
+
+  // Geometry — 360 wide, two columns.
+  const WIDTH = 360;
+  const PAD = 14;
+  const STACK_X = PAD;
+  const STACK_W = 150;
+  const VE_X = STACK_X + STACK_W + 16;
+  const VE_W = WIDTH - VE_X - PAD;
+  const HEADER_Y = 18;
+  const FRAME_H = 32;
+  const FRAME_GAP = 6;
+  const STACK_BASE_Y =
+    HEADER_Y + 18 + (MAX_DEPTH - 1) * (FRAME_H + FRAME_GAP);
+  const STACK_BOTTOM_Y = STACK_BASE_Y + FRAME_H;
+  const VE_BASE_Y = HEADER_Y + 18;
+  const VE_ROW_H = 28;
+  const VE_GAP = 6;
+  const HEIGHT =
+    Math.max(STACK_BOTTOM_Y, VE_BASE_Y + MAX_VE * (VE_ROW_H + VE_GAP)) + 14;
+
+  return (
+    <WidgetShell
+      title="call stack · execution contexts"
+      caption={caption}
+      captionTone="prominent"
+      controls={
+        <WidgetNav
+          value={clamped}
+          total={TOTAL}
+          onChange={setStep}
+          counterNoun="step"
+        />
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{
+          maxWidth: WIDTH,
+          height: "auto",
+          display: "block",
+          margin: "0 auto",
+        }}
+        role="img"
+        aria-label={`Call stack and variable environment. Step ${clamped + 1} of ${TOTAL}. Running: ${current.runningName}.`}
+      >
+        {/* Stack column header */}
+        <text
+          x={STACK_X}
+          y={HEADER_Y}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          CALL STACK
+        </text>
+
+        {/* Stack column outline — reserves max-depth height */}
+        <rect
+          x={STACK_X}
+          y={HEADER_Y + 6}
+          width={STACK_W}
+          height={STACK_BOTTOM_Y - (HEADER_Y + 6)}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+
+        {/* Frames stack from bottom up. Bottom (index 0) = global. Top = running EC. */}
+        <AnimatePresence initial={false}>
+          {current.stack.map((frame, i) => {
+            const yFromBottom = i; // 0 = bottom
+            const y = STACK_BASE_Y - yFromBottom * (FRAME_H + FRAME_GAP);
+            const isTop = i === current.stack.length - 1;
+            return (
+              <motion.g
+                key={`${frame.name}-${i}`}
+                initial={{ opacity: 0, y: y + 8 }}
+                animate={{ opacity: 1, y }}
+                exit={{ opacity: 0, y: y + 6 }}
+                transition={SPRING.snappy}
+              >
+                <rect
+                  x={STACK_X + 6}
+                  width={STACK_W - 12}
+                  height={FRAME_H}
+                  rx={3}
+                  fill={
+                    isTop
+                      ? "color-mix(in oklab, var(--color-accent) 22%, transparent)"
+                      : "color-mix(in oklab, var(--color-surface) 60%, transparent)"
+                  }
+                  stroke={isTop ? "var(--color-accent)" : "var(--color-rule)"}
+                  strokeWidth={isTop ? 1.6 : 1}
+                />
+                <text
+                  x={STACK_X + STACK_W / 2}
+                  y={FRAME_H / 2}
+                  textAnchor="middle"
+                  dominantBaseline="central"
+                  fontFamily="var(--font-mono)"
+                  fontSize={12}
+                  fill={isTop ? "var(--color-accent)" : "var(--color-text)"}
+                  fontWeight={isTop ? 600 : 400}
+                >
+                  {frame.name}
+                </text>
+                {isTop ? (
+                  <text
+                    x={STACK_X + STACK_W - 10}
+                    y={FRAME_H / 2}
+                    textAnchor="end"
+                    dominantBaseline="central"
+                    fontFamily="var(--font-sans)"
+                    fontSize={8}
+                    letterSpacing="0.08em"
+                    fill="var(--color-accent)"
+                  >
+                    RUNNING
+                  </text>
+                ) : null}
+              </motion.g>
+            );
+          })}
+        </AnimatePresence>
+
+        {/* VE column header */}
+        <text
+          x={VE_X}
+          y={HEADER_Y}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          VARIABLE ENVIRONMENT
+        </text>
+
+        <rect
+          x={VE_X}
+          y={HEADER_Y + 6}
+          width={VE_W}
+          height={MAX_VE * (VE_ROW_H + VE_GAP) + 8}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+        />
+        <text
+          x={VE_X + 8}
+          y={HEADER_Y + 18}
+          fontFamily="var(--font-sans)"
+          fontSize={8}
+          letterSpacing="0.08em"
+          fill="var(--color-accent)"
+        >
+          OF {current.runningName.toUpperCase()}
+        </text>
+
+        {/* VE rows — keyed by running-name + binding so they crossfade on EC switch */}
+        <AnimatePresence initial={false} mode="popLayout">
+          {current.ve.map((b, i) => {
+            const y = VE_BASE_Y + 14 + i * (VE_ROW_H + VE_GAP);
+            return (
+              <motion.g
+                key={`${current.runningName}-${b.name}`}
+                initial={{ opacity: 0, y: y + 4 }}
+                animate={{ opacity: 1, y }}
+                exit={{ opacity: 0, y: y - 4 }}
+                transition={{ ...SPRING.smooth, delay: i * 0.06 }}
+              >
+                <rect
+                  x={VE_X + 6}
+                  width={VE_W - 12}
+                  height={VE_ROW_H}
+                  rx={2}
+                  fill="transparent"
+                  stroke="var(--color-rule)"
+                  strokeWidth={1}
+                />
+                <text
+                  x={VE_X + 14}
+                  y={VE_ROW_H / 2}
+                  dominantBaseline="central"
+                  fontFamily="var(--font-mono)"
+                  fontSize={12}
+                  fill="var(--color-text)"
+                >
+                  {b.name}
+                </text>
+                <text
+                  x={VE_X + VE_W - 14}
+                  y={VE_ROW_H / 2}
+                  textAnchor="end"
+                  dominantBaseline="central"
+                  fontFamily="var(--font-mono)"
+                  fontSize={11}
+                  fill="var(--color-accent)"
+                >
+                  {b.value}
+                </text>
+              </motion.g>
+            );
+          })}
+        </AnimatePresence>
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-javascript-reads-its-own-future/widgets/ClosingDot.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/ClosingDot.tsx
@@ -6,7 +6,7 @@ import { SPRING } from "@/lib/motion";
 /**
  * ClosingDot — final brand signature for the post closer.
  * Reveals once on viewport entry with SPRING.smooth opacity.
- * Aria-hidden — purely decorative; the climax is the VerticalCutReveal above.
+ * Aria-hidden — purely decorative.
  */
 export function ClosingDot() {
   return (

--- a/app/posts/how-javascript-reads-its-own-future/widgets/ClosingDot.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/ClosingDot.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { motion } from "motion/react";
+import { SPRING } from "@/lib/motion";
+
+/**
+ * ClosingDot — final brand signature for the post closer.
+ * Reveals once on viewport entry with SPRING.smooth opacity.
+ * Aria-hidden — purely decorative; the climax is the VerticalCutReveal above.
+ */
+export function ClosingDot() {
+  return (
+    <motion.p
+      aria-hidden
+      className="font-mono text-center select-none"
+      style={{
+        marginBlock: "var(--spacing-xl)",
+        color: "var(--color-accent)",
+        fontSize: "var(--text-body)",
+        letterSpacing: "0.2em",
+      }}
+      initial={{ opacity: 0 }}
+      whileInView={{ opacity: 0.8 }}
+      viewport={{ once: true, amount: 0.6 }}
+      transition={SPRING.smooth}
+    >
+      ·
+    </motion.p>
+  );
+}

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
@@ -368,16 +368,20 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
           </motion.tspan>
         </text>
 
-        {/* Beat tag inside memory pane */}
-        <text
+        {/* Beat tag inside memory pane — crossfade per stop */}
+        <motion.text
+          key={`beat-${current.beat}`}
           x={MEM_X + 8}
           y={PANE_Y + PANE_H - 10}
           fontFamily="var(--font-sans)"
           fontSize={10}
           fill="var(--color-text-muted)"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={SPRING.smooth}
         >
           {current.beat}
-        </text>
+        </motion.text>
       </svg>
     </WidgetShell>
   );

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
@@ -40,19 +40,19 @@ const STOPS: Stop[] = [
     phase: "creation",
     activeLine: null,
     memory: { name: "x", value: "undefined" },
-    beat: "found var x",
+    beat: "finding var x",
   },
   {
     phase: "creation",
     activeLine: null,
     memory: { name: "x", value: "undefined" },
-    beat: "binding installed",
+    beat: "installing the binding",
   },
   {
     phase: "creation",
     activeLine: null,
     memory: { name: "x", value: "undefined" },
-    beat: "ready to run line 1",
+    beat: "holding at line 1 — last creation stop",
   },
   {
     phase: "execution",
@@ -76,7 +76,7 @@ const STOPS: Stop[] = [
     phase: "execution",
     activeLine: 2,
     memory: { name: "x", value: "5" },
-    beat: "execution complete",
+    beat: "execution finishes",
   },
 ];
 
@@ -98,16 +98,14 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
   const caption = useMemo(() => {
     const phaseLabel =
       current.phase === "creation" ? "creation phase" : "execution phase";
-    const detail =
-      current.phase === "creation"
-        ? `The engine has not run a single line yet — it is ${current.beat}. The binding for `
-        : `${current.beat}. Memory holds `;
     return (
       <>
         <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
           {phaseLabel}.
         </span>{" "}
-        {detail}
+        {current.phase === "creation"
+          ? "No source line has run. The binding for "
+          : "Memory holds "}
         <span style={{ fontFamily: "var(--font-mono)" }}>x</span>{" "}
         {current.phase === "creation"
           ? "is already installed with value "

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
@@ -14,8 +14,14 @@ import { SPRING } from "@/lib/motion";
  * already populated (`x: undefined`). On the execution side, code lines
  * highlight as the cursor advances.
  *
- * Frame-stability R6: 360 wide, fixed canvas height, every stop reserves the
- * same memory-column geometry.
+ * Layout is mobile-first: on narrow widths the time-track sits on top with
+ * source + memory stacked below as flexible HTML rows (proper text-overflow
+ * handling — values like `undefined` can never escape the cell). At
+ * container ≥ 480px, source + memory sit side-by-side.
+ *
+ * Frame-stability R6: the widget shell reserves a fixed minimum height for
+ * each pane so the layout doesn't reflow as the scrubber advances. Memory
+ * row is one binding deep at every stop — geometry never moves.
  */
 
 type Stop = {
@@ -123,24 +129,17 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
     );
   }, [current]);
 
-  // Geometry — 360 wide, mobile-first.
-  const WIDTH = 360;
-  const PAD = 14;
-  const SOURCE_X = PAD;
-  const SOURCE_W = 200;
-  const MEM_X = SOURCE_X + SOURCE_W + 12;
-  const MEM_W = WIDTH - MEM_X - PAD;
+  // Time-track geometry — SVG only renders the temporal axis.
+  const TRACK_W = 360;
+  const TRACK_PAD = 14;
   const TRACK_Y = 22;
   const TRACK_H = 28;
-  const PANE_Y = TRACK_Y + TRACK_H + 22;
-  const PANE_H = 92;
-  const HEIGHT = PANE_Y + PANE_H + 14;
-
-  // Boundary x in the time-track band.
+  const TRACK_TOTAL_H = TRACK_Y + TRACK_H + 14;
   const BOUNDARY_X =
-    PAD + ((BOUNDARY_INDEX - 0.5) / (TOTAL - 1)) * (WIDTH - PAD * 2);
+    TRACK_PAD +
+    ((BOUNDARY_INDEX - 0.5) / (TOTAL - 1)) * (TRACK_W - TRACK_PAD * 2);
   const CURSOR_X =
-    PAD + (clamped / (TOTAL - 1)) * (WIDTH - PAD * 2);
+    TRACK_PAD + (clamped / (TOTAL - 1)) * (TRACK_W - TRACK_PAD * 2);
 
   return (
     <WidgetShell
@@ -160,21 +159,21 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
         </div>
       }
     >
+      {/* Time track — mobile-first, scales fluidly */}
       <svg
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        viewBox={`0 0 ${TRACK_W} ${TRACK_TOTAL_H}`}
         width="100%"
         style={{
-          maxWidth: WIDTH,
+          maxWidth: TRACK_W,
           height: "auto",
           display: "block",
           margin: "0 auto",
         }}
         role="img"
-        aria-label={`Creation vs execution scrubber. Stop ${clamped + 1} of ${TOTAL}, ${current.phase} phase.`}
+        aria-label={`Time track. Stop ${clamped + 1} of ${TOTAL}, ${current.phase} phase.`}
       >
-        {/* Time-track band with creation/execution labels */}
         <text
-          x={PAD + (BOUNDARY_X - PAD) / 2}
+          x={TRACK_PAD + (BOUNDARY_X - TRACK_PAD) / 2}
           y={TRACK_Y - 6}
           textAnchor="middle"
           fontFamily="var(--font-sans)"
@@ -189,7 +188,7 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
           CREATION
         </text>
         <text
-          x={BOUNDARY_X + (WIDTH - PAD - BOUNDARY_X) / 2}
+          x={BOUNDARY_X + (TRACK_W - TRACK_PAD - BOUNDARY_X) / 2}
           y={TRACK_Y - 6}
           textAnchor="middle"
           fontFamily="var(--font-sans)"
@@ -205,17 +204,15 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
         </text>
 
         <rect
-          x={PAD}
+          x={TRACK_PAD}
           y={TRACK_Y}
-          width={WIDTH - PAD * 2}
+          width={TRACK_W - TRACK_PAD * 2}
           height={TRACK_H}
           rx={3}
           fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
           stroke="var(--color-rule)"
           strokeWidth={1}
         />
-
-        {/* Boundary divider */}
         <line
           x1={BOUNDARY_X}
           y1={TRACK_Y - 2}
@@ -225,8 +222,6 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
           strokeWidth={1}
           strokeDasharray="3 3"
         />
-
-        {/* Cursor on the track */}
         <motion.g
           initial={false}
           animate={{ x: CURSOR_X - 5 }}
@@ -241,148 +236,197 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
             fill="var(--color-accent)"
           />
         </motion.g>
-
-        {/* Source pane */}
-        <rect
-          x={SOURCE_X}
-          y={PANE_Y}
-          width={SOURCE_W}
-          height={PANE_H}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-        <text
-          x={SOURCE_X + 8}
-          y={PANE_Y + 14}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          SOURCE
-        </text>
-        {SOURCE_LINES.map((line, i) => {
-          const isActive = current.activeLine === line.n;
-          const y = PANE_Y + 34 + i * 24;
-          return (
-            <motion.g
-              key={line.n}
-              initial={false}
-              animate={{ opacity: isActive ? 1 : 0.55 }}
-              transition={SPRING.smooth}
-            >
-              {isActive ? (
-                <rect
-                  x={SOURCE_X + 4}
-                  y={y - 13}
-                  width={SOURCE_W - 8}
-                  height={20}
-                  rx={2}
-                  fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                />
-              ) : null}
-              <text
-                x={SOURCE_X + 12}
-                y={y}
-                fontFamily="var(--font-mono)"
-                fontSize={11}
-                fill="var(--color-text-muted)"
-              >
-                {line.n}
-              </text>
-              <text
-                x={SOURCE_X + 28}
-                y={y}
-                fontFamily="var(--font-mono)"
-                fontSize={12}
-                fill={isActive ? "var(--color-accent)" : "var(--color-text)"}
-              >
-                {line.text}
-              </text>
-            </motion.g>
-          );
-        })}
-
-        {/* Memory pane */}
-        <rect
-          x={MEM_X}
-          y={PANE_Y}
-          width={MEM_W}
-          height={PANE_H}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke={
-            current.phase === "creation"
-              ? "var(--color-accent)"
-              : "var(--color-rule)"
-          }
-          strokeWidth={current.phase === "creation" ? 1.4 : 1}
-        />
-        <text
-          x={MEM_X + 8}
-          y={PANE_Y + 14}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          MEMORY
-        </text>
-        {/* The single binding row — geometry never changes. */}
-        <rect
-          x={MEM_X + 6}
-          y={PANE_Y + 28}
-          width={MEM_W - 12}
-          height={28}
-          rx={2}
-          fill="transparent"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-        <text
-          x={MEM_X + 14}
-          y={PANE_Y + 46}
-          fontFamily="var(--font-mono)"
-          fontSize={12}
-          fill="var(--color-text)"
-        >
-          x
-        </text>
-        <text
-          x={MEM_X + MEM_W - 14}
-          y={PANE_Y + 46}
-          textAnchor="end"
-          fontFamily="var(--font-mono)"
-          fontSize={11}
-          fill="var(--color-accent)"
-        >
-          <motion.tspan
-            key={`mem-${current.memory.value}`}
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={SPRING.smooth}
-          >
-            {current.memory.value}
-          </motion.tspan>
-        </text>
-
-        {/* Beat tag inside memory pane — crossfade per stop */}
-        <motion.text
-          key={`beat-${current.beat}`}
-          x={MEM_X + 8}
-          y={PANE_Y + PANE_H - 10}
-          fontFamily="var(--font-sans)"
-          fontSize={10}
-          fill="var(--color-text-muted)"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={SPRING.smooth}
-        >
-          {current.beat}
-        </motion.text>
       </svg>
+
+      {/* Source + memory panes — HTML rows, mobile-first stack, side-by-side at >=480 container */}
+      <div
+        className="bs-cve-panes"
+        style={{
+          display: "grid",
+          gap: "var(--spacing-sm)",
+          marginTop: "var(--spacing-sm)",
+          maxWidth: TRACK_W,
+          marginInline: "auto",
+        }}
+      >
+        {/* SOURCE pane */}
+        <div
+          className="bs-cve-pane"
+          style={{
+            background: "color-mix(in oklab, var(--color-surface) 35%, transparent)",
+            border: "1px solid var(--color-rule)",
+            borderRadius: 3,
+            padding: "10px 12px",
+            minHeight: 96,
+            minWidth: 0,
+          }}
+        >
+          <div
+            className="font-sans"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.08em",
+              color: "var(--color-text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            SOURCE
+          </div>
+          <ol
+            className="font-mono"
+            style={{
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+              fontSize: 12,
+            }}
+          >
+            {SOURCE_LINES.map((line) => {
+              const isActive = current.activeLine === line.n;
+              return (
+                <motion.li
+                  key={line.n}
+                  initial={false}
+                  animate={{ opacity: isActive ? 1 : 0.55 }}
+                  transition={SPRING.smooth}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1.5em minmax(0, 1fr)",
+                    alignItems: "center",
+                    columnGap: 8,
+                    padding: "3px 6px",
+                    borderRadius: 2,
+                    background: isActive
+                      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                      : "transparent",
+                    color: isActive
+                      ? "var(--color-accent)"
+                      : "var(--color-text)",
+                  }}
+                >
+                  <span style={{ color: "var(--color-text-muted)" }}>
+                    {line.n}
+                  </span>
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {line.text}
+                  </span>
+                </motion.li>
+              );
+            })}
+          </ol>
+        </div>
+
+        {/* MEMORY pane */}
+        <div
+          className="bs-cve-pane"
+          style={{
+            background: "color-mix(in oklab, var(--color-surface) 35%, transparent)",
+            border: `${current.phase === "creation" ? 1.4 : 1}px solid ${
+              current.phase === "creation"
+                ? "var(--color-accent)"
+                : "var(--color-rule)"
+            }`,
+            borderRadius: 3,
+            padding: "10px 12px",
+            minHeight: 96,
+            minWidth: 0,
+            transition: "border-color 200ms ease",
+          }}
+        >
+          <div
+            className="font-sans"
+            style={{
+              fontSize: 9,
+              letterSpacing: "0.08em",
+              color: "var(--color-text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            MEMORY
+          </div>
+          {/* The single binding row — geometry never changes */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0, auto) minmax(0, 1fr)",
+              alignItems: "center",
+              columnGap: 8,
+              padding: "5px 8px",
+              border: "1px solid var(--color-rule)",
+              borderRadius: 2,
+              minHeight: 28,
+            }}
+          >
+            <span
+              className="font-mono"
+              style={{
+                fontSize: 12,
+                color: "var(--color-text)",
+                minWidth: 0,
+              }}
+            >
+              x
+            </span>
+            <motion.span
+              key={`mem-${current.memory.value}`}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={SPRING.smooth}
+              className="font-mono"
+              title={current.memory.value}
+              style={{
+                fontSize: 11,
+                color: "var(--color-accent)",
+                textAlign: "right",
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {current.memory.value}
+            </motion.span>
+          </div>
+
+          <motion.div
+            key={`beat-${current.beat}`}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={SPRING.smooth}
+            className="font-sans"
+            style={{
+              marginTop: 10,
+              fontSize: 10,
+              color: "var(--color-text-muted)",
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            title={current.beat}
+          >
+            {current.beat}
+          </motion.div>
+        </div>
+
+        <style jsx>{`
+          @container widget (min-width: 480px) {
+            .bs-cve-panes {
+              grid-template-columns: 1fr 1fr;
+            }
+          }
+        `}</style>
+      </div>
     </WidgetShell>
   );
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { Scrubber } from "@/components/viz/Scrubber";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+
+/**
+ * CreationVsExecution — W1 of "how JavaScript reads its own future".
+ *
+ * Single verb: scrub. The reader drags a position across a labelled
+ * creation→execution boundary. On the creation side, the memory column is
+ * already populated (`x: undefined`). On the execution side, code lines
+ * highlight as the cursor advances.
+ *
+ * Frame-stability R6: 360 wide, fixed canvas height, every stop reserves the
+ * same memory-column geometry.
+ */
+
+type Stop = {
+  /** 0..3 = creation phase progress; 4..7 = execution phase progress. */
+  phase: "creation" | "execution";
+  /** Active source line (1 or 2) on the right pane, or null on creation. */
+  activeLine: 1 | 2 | null;
+  /** Memory column at this stop. */
+  memory: { name: "x"; value: "undefined" | "5" };
+  /** Caption noun (the verb cue lives in the caption template). */
+  beat: string;
+};
+
+const STOPS: Stop[] = [
+  {
+    phase: "creation",
+    activeLine: null,
+    memory: { name: "x", value: "undefined" },
+    beat: "scanning the body",
+  },
+  {
+    phase: "creation",
+    activeLine: null,
+    memory: { name: "x", value: "undefined" },
+    beat: "found var x",
+  },
+  {
+    phase: "creation",
+    activeLine: null,
+    memory: { name: "x", value: "undefined" },
+    beat: "binding installed",
+  },
+  {
+    phase: "creation",
+    activeLine: null,
+    memory: { name: "x", value: "undefined" },
+    beat: "ready to run line 1",
+  },
+  {
+    phase: "execution",
+    activeLine: 1,
+    memory: { name: "x", value: "undefined" },
+    beat: "line 1 reads x",
+  },
+  {
+    phase: "execution",
+    activeLine: 1,
+    memory: { name: "x", value: "undefined" },
+    beat: "console prints undefined",
+  },
+  {
+    phase: "execution",
+    activeLine: 2,
+    memory: { name: "x", value: "5" },
+    beat: "line 2 assigns 5",
+  },
+  {
+    phase: "execution",
+    activeLine: 2,
+    memory: { name: "x", value: "5" },
+    beat: "execution complete",
+  },
+];
+
+const TOTAL = STOPS.length;
+const BOUNDARY_INDEX = 4; // first execution stop
+
+const SOURCE_LINES = [
+  { n: 1, text: "console.log(x)" },
+  { n: 2, text: "var x = 5" },
+];
+
+type Props = { initialStop?: number };
+
+export function CreationVsExecution({ initialStop = 0 }: Props) {
+  const [stop, setStop] = useState(initialStop);
+  const clamped = Math.max(0, Math.min(stop, TOTAL - 1));
+  const current = STOPS[clamped];
+
+  const caption = useMemo(() => {
+    const phaseLabel =
+      current.phase === "creation" ? "creation phase" : "execution phase";
+    const detail =
+      current.phase === "creation"
+        ? `The engine has not run a single line yet — it is ${current.beat}. The binding for `
+        : `${current.beat}. Memory holds `;
+    return (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          {phaseLabel}.
+        </span>{" "}
+        {detail}
+        <span style={{ fontFamily: "var(--font-mono)" }}>x</span>{" "}
+        {current.phase === "creation"
+          ? "is already installed with value "
+          : "with value "}
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            color: "var(--color-accent)",
+          }}
+        >
+          {current.memory.value}
+        </span>
+        .
+      </>
+    );
+  }, [current]);
+
+  // Geometry — 360 wide, mobile-first.
+  const WIDTH = 360;
+  const PAD = 14;
+  const SOURCE_X = PAD;
+  const SOURCE_W = 200;
+  const MEM_X = SOURCE_X + SOURCE_W + 12;
+  const MEM_W = WIDTH - MEM_X - PAD;
+  const TRACK_Y = 22;
+  const TRACK_H = 28;
+  const PANE_Y = TRACK_Y + TRACK_H + 22;
+  const PANE_H = 92;
+  const HEIGHT = PANE_Y + PANE_H + 14;
+
+  // Boundary x in the time-track band.
+  const BOUNDARY_X =
+    PAD + ((BOUNDARY_INDEX - 0.5) / (TOTAL - 1)) * (WIDTH - PAD * 2);
+  const CURSOR_X =
+    PAD + (clamped / (TOTAL - 1)) * (WIDTH - PAD * 2);
+
+  return (
+    <WidgetShell
+      title="creation vs execution · var x = 5"
+      caption={caption}
+      captionTone="prominent"
+      controls={
+        <div className="w-full max-w-[420px]">
+          <Scrubber
+            label="t"
+            value={clamped}
+            min={0}
+            max={TOTAL - 1}
+            onChange={setStop}
+            format={(v) => `${v}/${TOTAL - 1}`}
+          />
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{
+          maxWidth: WIDTH,
+          height: "auto",
+          display: "block",
+          margin: "0 auto",
+        }}
+        role="img"
+        aria-label={`Creation vs execution scrubber. Stop ${clamped + 1} of ${TOTAL}, ${current.phase} phase.`}
+      >
+        {/* Time-track band with creation/execution labels */}
+        <text
+          x={PAD + (BOUNDARY_X - PAD) / 2}
+          y={TRACK_Y - 6}
+          textAnchor="middle"
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill={
+            current.phase === "creation"
+              ? "var(--color-accent)"
+              : "var(--color-text-muted)"
+          }
+        >
+          CREATION
+        </text>
+        <text
+          x={BOUNDARY_X + (WIDTH - PAD - BOUNDARY_X) / 2}
+          y={TRACK_Y - 6}
+          textAnchor="middle"
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill={
+            current.phase === "execution"
+              ? "var(--color-accent)"
+              : "var(--color-text-muted)"
+          }
+        >
+          EXECUTION
+        </text>
+
+        <rect
+          x={PAD}
+          y={TRACK_Y}
+          width={WIDTH - PAD * 2}
+          height={TRACK_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+
+        {/* Boundary divider */}
+        <line
+          x1={BOUNDARY_X}
+          y1={TRACK_Y - 2}
+          x2={BOUNDARY_X}
+          y2={TRACK_Y + TRACK_H + 2}
+          stroke="var(--color-text-muted)"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+
+        {/* Cursor on the track */}
+        <motion.g
+          initial={false}
+          animate={{ x: CURSOR_X - 5 }}
+          transition={SPRING.snappy}
+        >
+          <rect
+            x={0}
+            y={TRACK_Y + 4}
+            width={10}
+            height={TRACK_H - 8}
+            rx={2}
+            fill="var(--color-accent)"
+          />
+        </motion.g>
+
+        {/* Source pane */}
+        <rect
+          x={SOURCE_X}
+          y={PANE_Y}
+          width={SOURCE_W}
+          height={PANE_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={SOURCE_X + 8}
+          y={PANE_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          SOURCE
+        </text>
+        {SOURCE_LINES.map((line, i) => {
+          const isActive = current.activeLine === line.n;
+          const y = PANE_Y + 34 + i * 24;
+          return (
+            <motion.g
+              key={line.n}
+              initial={false}
+              animate={{ opacity: isActive ? 1 : 0.55 }}
+              transition={SPRING.smooth}
+            >
+              {isActive ? (
+                <rect
+                  x={SOURCE_X + 4}
+                  y={y - 13}
+                  width={SOURCE_W - 8}
+                  height={20}
+                  rx={2}
+                  fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                />
+              ) : null}
+              <text
+                x={SOURCE_X + 12}
+                y={y}
+                fontFamily="var(--font-mono)"
+                fontSize={11}
+                fill="var(--color-text-muted)"
+              >
+                {line.n}
+              </text>
+              <text
+                x={SOURCE_X + 28}
+                y={y}
+                fontFamily="var(--font-mono)"
+                fontSize={12}
+                fill={isActive ? "var(--color-accent)" : "var(--color-text)"}
+              >
+                {line.text}
+              </text>
+            </motion.g>
+          );
+        })}
+
+        {/* Memory pane */}
+        <rect
+          x={MEM_X}
+          y={PANE_Y}
+          width={MEM_W}
+          height={PANE_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke={
+            current.phase === "creation"
+              ? "var(--color-accent)"
+              : "var(--color-rule)"
+          }
+          strokeWidth={current.phase === "creation" ? 1.4 : 1}
+        />
+        <text
+          x={MEM_X + 8}
+          y={PANE_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          MEMORY
+        </text>
+        {/* The single binding row — geometry never changes. */}
+        <rect
+          x={MEM_X + 6}
+          y={PANE_Y + 28}
+          width={MEM_W - 12}
+          height={28}
+          rx={2}
+          fill="transparent"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={MEM_X + 14}
+          y={PANE_Y + 46}
+          fontFamily="var(--font-mono)"
+          fontSize={12}
+          fill="var(--color-text)"
+        >
+          x
+        </text>
+        <text
+          x={MEM_X + MEM_W - 14}
+          y={PANE_Y + 46}
+          textAnchor="end"
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-accent)"
+        >
+          <motion.tspan
+            key={`mem-${current.memory.value}`}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={SPRING.smooth}
+          >
+            {current.memory.value}
+          </motion.tspan>
+        </text>
+
+        {/* Beat tag inside memory pane */}
+        <text
+          x={MEM_X + 8}
+          y={PANE_Y + PANE_H - 10}
+          fontFamily="var(--font-sans)"
+          fontSize={10}
+          fill="var(--color-text-muted)"
+        >
+          {current.beat}
+        </text>
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { PRESS, SPRING } from "@/lib/motion";
+
+/**
+ * DeclarationStates — W2 of "how JavaScript reads its own future".
+ *
+ * Single verb: click-toggle (segmented control × 4). Each branch shows what
+ * the named binding looks like at the *moment line 1 is about to run*.
+ * Uninitialized cells (TDZ) use a hatched fill pattern — shape conveys state,
+ * not just colour.
+ *
+ * Frame-stability R6: 360 wide, fixed canvas height across all four states.
+ * Caption uses identical sentence template per state.
+ */
+
+type Kind = "var" | "let" | "fnDecl" | "varFnExpr";
+
+type State = {
+  id: Kind;
+  label: string;
+  /** ≤ 18 chars per line; two lines max. */
+  snippet: [string, string];
+  binding: {
+    name: string;
+    /** "value" | "uninitialized" | "fn-bound" | "value-undefined". */
+    shape: "value" | "uninitialized" | "fn-bound";
+    /** Right-cell text. */
+    valueText: string;
+  };
+  caption: React.ReactNode;
+};
+
+const STATES: State[] = [
+  {
+    id: "var",
+    label: "var",
+    snippet: ["console.log(x)", "var x = 5"],
+    binding: {
+      name: "x",
+      shape: "value",
+      valueText: "undefined",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          var
+        </span>{" "}
+        — binding installed, value{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>undefined</span>.
+        Reading it returns{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>undefined</span> — no
+        error.
+      </>
+    ),
+  },
+  {
+    id: "let",
+    label: "let / const / class",
+    snippet: ["console.log(x)", "let x = 5"],
+    binding: {
+      name: "x",
+      shape: "uninitialized",
+      valueText: "<uninit>",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          let / const / class
+        </span>{" "}
+        — binding exists, but reading it throws. The TDZ:{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>
+          ReferenceError
+        </span>
+        .
+      </>
+    ),
+  },
+  {
+    id: "fnDecl",
+    label: "function f()",
+    snippet: ["f()", "function f(){}"],
+    binding: {
+      name: "f",
+      shape: "fn-bound",
+      valueText: "[fn ƒ]",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          function declaration
+        </span>{" "}
+        — binding installed and already pointing at the function value.
+        Calling it from above the declaration line just works.
+      </>
+    ),
+  },
+  {
+    id: "varFnExpr",
+    label: "var f = function",
+    snippet: ["f()", "var f = function(){}"],
+    binding: {
+      name: "f",
+      shape: "value",
+      valueText: "undefined",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          var with a function expression
+        </span>{" "}
+        — only the{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>var</span> binding
+        survives the pre-walk. Calling it throws{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>TypeError</span> — not
+        a function (yet).
+      </>
+    ),
+  },
+];
+
+type Props = { initialKind?: Kind };
+
+export function DeclarationStates({ initialKind = "var" }: Props) {
+  const [kindId, setKindId] = useState<Kind>(initialKind);
+  const state = useMemo(
+    () => STATES.find((s) => s.id === kindId) ?? STATES[0],
+    [kindId],
+  );
+  const hatchId = useId();
+  const hatchPattern = `bs-tdz-hatch-${hatchId.replace(/:/g, "")}`;
+
+  // Geometry — 360 wide.
+  const WIDTH = 360;
+  const PAD = 14;
+  const SNIPPET_Y = 18;
+  const SNIPPET_H = 60;
+  const MEM_Y = SNIPPET_Y + SNIPPET_H + 18;
+  const MEM_H = 76;
+  const HEIGHT = MEM_Y + MEM_H + 14;
+
+  return (
+    <WidgetShell
+      title="declarations · at line 1"
+      caption={state.caption}
+      captionTone="prominent"
+      controls={
+        <div
+          role="group"
+          aria-label="Declaration kind"
+          className="flex flex-wrap items-center gap-[var(--spacing-2xs)] font-sans"
+          style={{ fontSize: "var(--text-ui)" }}
+        >
+          {STATES.map((s) => {
+            const active = s.id === kindId;
+            return (
+              <motion.button
+                key={s.id}
+                type="button"
+                onClick={() => setKindId(s.id)}
+                aria-pressed={active}
+                aria-label={`Declaration kind: ${s.label}`}
+                style={{
+                  minHeight: 44,
+                  padding: "0 var(--spacing-sm)",
+                  borderRadius: "var(--radius-sm)",
+                  border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+                  background: active
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "transparent",
+                  color: active
+                    ? "var(--color-accent)"
+                    : "var(--color-text)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 12,
+                  cursor: "pointer",
+                }}
+                {...PRESS}
+              >
+                {s.label}
+              </motion.button>
+            );
+          })}
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{
+          maxWidth: WIDTH,
+          height: "auto",
+          display: "block",
+          margin: "0 auto",
+        }}
+        role="img"
+        aria-label={`Declaration state. Kind: ${state.label}. Binding ${state.binding.name} = ${state.binding.valueText}.`}
+      >
+        <defs>
+          <pattern
+            id={hatchPattern}
+            patternUnits="userSpaceOnUse"
+            width="6"
+            height="6"
+            patternTransform="rotate(45)"
+          >
+            <line
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="6"
+              stroke="var(--color-text-muted)"
+              strokeWidth="1.4"
+            />
+          </pattern>
+        </defs>
+
+        {/* Snippet pane */}
+        <rect
+          x={PAD}
+          y={SNIPPET_Y}
+          width={WIDTH - PAD * 2}
+          height={SNIPPET_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={PAD + 8}
+          y={SNIPPET_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          AT LINE 1
+        </text>
+
+        <motion.g
+          key={`snip-${state.id}`}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={SPRING.smooth}
+        >
+          {state.snippet.map((line, i) => (
+            <text
+              key={i}
+              x={PAD + 12}
+              y={SNIPPET_Y + 32 + i * 18}
+              fontFamily="var(--font-mono)"
+              fontSize={12}
+              fill={i === 0 ? "var(--color-accent)" : "var(--color-text)"}
+            >
+              <tspan
+                fontFamily="var(--font-mono)"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+              >
+                {i + 1}
+              </tspan>
+              <tspan dx={10}>{line}</tspan>
+            </text>
+          ))}
+        </motion.g>
+
+        {/* Memory pane */}
+        <rect
+          x={PAD}
+          y={MEM_Y}
+          width={WIDTH - PAD * 2}
+          height={MEM_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+        />
+        <text
+          x={PAD + 8}
+          y={MEM_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          MEMORY · CREATION-PHASE STATE
+        </text>
+
+        {/* Binding row — name + state cell */}
+        <motion.g
+          key={`mem-${state.id}`}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={SPRING.smooth}
+        >
+          <text
+            x={PAD + 14}
+            y={MEM_Y + 44}
+            fontFamily="var(--font-mono)"
+            fontSize={13}
+            fill="var(--color-text)"
+          >
+            {state.binding.name}
+          </text>
+
+          {/* The state cell — shape conveys state, not just colour. */}
+          {state.binding.shape === "value" ? (
+            <rect
+              x={WIDTH / 2 - 4}
+              y={MEM_Y + 30}
+              width={WIDTH / 2 - PAD - 4}
+              height={28}
+              rx={2}
+              fill="color-mix(in oklab, var(--color-accent) 18%, transparent)"
+              stroke="var(--color-accent)"
+              strokeWidth={1}
+            />
+          ) : state.binding.shape === "uninitialized" ? (
+            <g>
+              <rect
+                x={WIDTH / 2 - 4}
+                y={MEM_Y + 30}
+                width={WIDTH / 2 - PAD - 4}
+                height={28}
+                rx={2}
+                fill={`url(#${hatchPattern})`}
+                stroke="var(--color-text-muted)"
+                strokeWidth={1.4}
+                strokeDasharray="3 2"
+              />
+            </g>
+          ) : (
+            // fn-bound — rounded pill (different shape)
+            <rect
+              x={WIDTH / 2 - 4}
+              y={MEM_Y + 30}
+              width={WIDTH / 2 - PAD - 4}
+              height={28}
+              rx={14}
+              fill="color-mix(in oklab, var(--color-accent) 26%, transparent)"
+              stroke="var(--color-accent)"
+              strokeWidth={1.4}
+            />
+          )}
+
+          <text
+            x={WIDTH / 2 - 4 + (WIDTH / 2 - PAD - 4) / 2}
+            y={MEM_Y + 48}
+            textAnchor="middle"
+            fontFamily="var(--font-mono)"
+            fontSize={11}
+            fill={
+              state.binding.shape === "uninitialized"
+                ? "var(--color-text)"
+                : "var(--color-text)"
+            }
+            fontWeight={state.binding.shape === "fn-bound" ? 600 : 400}
+          >
+            {state.binding.valueText}
+          </text>
+        </motion.g>
+      </svg>
+    </WidgetShell>
+  );
+}

--- a/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
@@ -71,11 +71,11 @@ const STATES: State[] = [
         <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
           let / const / class
         </span>{" "}
-        — binding exists, but reading it throws. The TDZ:{" "}
+        — binding exists, but reading it throws a{" "}
         <span style={{ fontFamily: "var(--font-mono)" }}>
           ReferenceError
         </span>
-        .
+        . That&apos;s the TDZ.
       </>
     ),
   },
@@ -162,7 +162,6 @@ export function DeclarationStates({ initialKind = "var" }: Props) {
                 type="button"
                 onClick={() => setKindId(s.id)}
                 aria-pressed={active}
-                aria-label={`Declaration kind: ${s.label}`}
                 style={{
                   minHeight: 44,
                   padding: "0 var(--spacing-sm)",

--- a/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
@@ -64,7 +64,7 @@ const REASONS: Reason[] = [
     snippet: ["let x = 1", "let x = 2"],
     without: {
       label: "without pre-walk",
-      body: "Line 1 runs, x = 1. Line 2 also runs.",
+      body: "Line 1 runs, x = 1. Then line 2 runs too.",
     },
     withIt: {
       label: "with pre-walk",
@@ -148,7 +148,6 @@ export function WhyTwoPasses({ initialReason = "callable" }: Props) {
                 type="button"
                 onClick={() => setReasonId(r.id)}
                 aria-pressed={active}
-                aria-label={`Reason: ${r.label}`}
                 style={{
                   minHeight: 44,
                   padding: "0 var(--spacing-sm)",

--- a/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { PRESS, SPRING } from "@/lib/motion";
+
+/**
+ * WhyTwoPasses — W4 of "how JavaScript reads its own future".
+ *
+ * Single verb: click-toggle (segmented control × 3). Each branch is a tiny
+ * "without the pre-walk, this would..." counterfactual. Shows the spec-forced
+ * rationale that's buried in the spec and never surfaced pedagogically.
+ *
+ * Frame-stability R6: 360 wide, fixed canvas height across all three states.
+ */
+
+type ReasonId = "callable" | "duplicate" | "const";
+
+type Reason = {
+  id: ReasonId;
+  label: string;
+  /** Tiny snippet, two lines. */
+  snippet: [string, string];
+  /** Without-prewalk counterfactual outcome. */
+  without: {
+    label: string;
+    body: string;
+  };
+  /** What actually happens, thanks to the pre-walk. */
+  withIt: {
+    label: string;
+    body: string;
+  };
+  caption: React.ReactNode;
+};
+
+const REASONS: Reason[] = [
+  {
+    id: "callable",
+    label: "callable from above",
+    snippet: ["f()", "function f(){}"],
+    without: {
+      label: "without pre-walk",
+      body: "ReferenceError: f is not defined.",
+    },
+    withIt: {
+      label: "with pre-walk",
+      body: "f is bound at creation. The call works.",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          Function declarations must be callable from anywhere in scope.
+        </span>{" "}
+        That guarantee is the spec — and it forces the engine to install all
+        function bindings before line 1.
+      </>
+    ),
+  },
+  {
+    id: "duplicate",
+    label: "duplicate let",
+    snippet: ["let x = 1", "let x = 2"],
+    without: {
+      label: "without pre-walk",
+      body: "Line 1 runs, x = 1. Line 2 also runs.",
+    },
+    withIt: {
+      label: "with pre-walk",
+      body: "SyntaxError detected before any line executes.",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          Duplicate let / const declarations must be a SyntaxError, not a
+          runtime surprise.
+        </span>{" "}
+        The only way to enforce that is to scan every binding in the scope
+        first, then refuse to start.
+      </>
+    ),
+  },
+  {
+    id: "const",
+    label: "const semantics",
+    snippet: ["console.log(x)", "const x = 1"],
+    without: {
+      label: "without pre-walk",
+      body: "x reads as undefined — a const that already had a value before its initializer.",
+    },
+    withIt: {
+      label: "with pre-walk",
+      body: "x is uninitialized (TDZ). Reading it throws.",
+    },
+    caption: (
+      <>
+        <span style={{ color: "var(--color-accent)", fontWeight: 600 }}>
+          const semantics need a pre-binding.
+        </span>{" "}
+        If a{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>const</span> read as{" "}
+        <span style={{ fontFamily: "var(--font-mono)" }}>undefined</span>{" "}
+        before its initializer, immutability would be incoherent. The TDZ is
+        the resolution.
+      </>
+    ),
+  },
+];
+
+type Props = { initialReason?: ReasonId };
+
+export function WhyTwoPasses({ initialReason = "callable" }: Props) {
+  const [reasonId, setReasonId] = useState<ReasonId>(initialReason);
+  const reason = useMemo(
+    () => REASONS.find((r) => r.id === reasonId) ?? REASONS[0],
+    [reasonId],
+  );
+
+  // Geometry — 360 wide.
+  const WIDTH = 360;
+  const PAD = 14;
+  const SNIPPET_Y = 18;
+  const SNIPPET_H = 56;
+  const OUTCOME_Y = SNIPPET_Y + SNIPPET_H + 14;
+  const OUTCOME_H = 56;
+  const OUTCOME_GAP = 10;
+  const OUTCOME_TOTAL_H = OUTCOME_H * 2 + OUTCOME_GAP;
+  const HEIGHT = OUTCOME_Y + OUTCOME_TOTAL_H + 14;
+
+  return (
+    <WidgetShell
+      title="two passes · why"
+      caption={reason.caption}
+      captionTone="prominent"
+      controls={
+        <div
+          role="group"
+          aria-label="Reason"
+          className="flex flex-wrap items-center gap-[var(--spacing-2xs)] font-sans"
+          style={{ fontSize: "var(--text-ui)" }}
+        >
+          {REASONS.map((r) => {
+            const active = r.id === reasonId;
+            return (
+              <motion.button
+                key={r.id}
+                type="button"
+                onClick={() => setReasonId(r.id)}
+                aria-pressed={active}
+                aria-label={`Reason: ${r.label}`}
+                style={{
+                  minHeight: 44,
+                  padding: "0 var(--spacing-sm)",
+                  borderRadius: "var(--radius-sm)",
+                  border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+                  background: active
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "transparent",
+                  color: active
+                    ? "var(--color-accent)"
+                    : "var(--color-text)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 12,
+                  cursor: "pointer",
+                }}
+                {...PRESS}
+              >
+                {r.label}
+              </motion.button>
+            );
+          })}
+        </div>
+      }
+    >
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width="100%"
+        style={{
+          maxWidth: WIDTH,
+          height: "auto",
+          display: "block",
+          margin: "0 auto",
+        }}
+        role="img"
+        aria-label={`Reason: ${reason.label}. Counterfactual: ${reason.without.body} With pre-walk: ${reason.withIt.body}`}
+      >
+        {/* Snippet pane */}
+        <rect
+          x={PAD}
+          y={SNIPPET_Y}
+          width={WIDTH - PAD * 2}
+          height={SNIPPET_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+          stroke="var(--color-rule)"
+          strokeWidth={1}
+        />
+        <text
+          x={PAD + 8}
+          y={SNIPPET_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          SNIPPET
+        </text>
+        <motion.g
+          key={`snip-${reason.id}`}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={SPRING.smooth}
+        >
+          {reason.snippet.map((line, i) => (
+            <text
+              key={i}
+              x={PAD + 12}
+              y={SNIPPET_Y + 30 + i * 16}
+              fontFamily="var(--font-mono)"
+              fontSize={12}
+              fill="var(--color-text)"
+            >
+              <tspan
+                fontFamily="var(--font-mono)"
+                fontSize={10}
+                fill="var(--color-text-muted)"
+              >
+                {i + 1}
+              </tspan>
+              <tspan dx={10}>{line}</tspan>
+            </text>
+          ))}
+        </motion.g>
+
+        {/* "Without" outcome — drawn first, dimmer */}
+        <motion.g
+          key={`without-${reason.id}`}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={SPRING.smooth}
+        >
+          <rect
+            x={PAD}
+            y={OUTCOME_Y}
+            width={WIDTH - PAD * 2}
+            height={OUTCOME_H}
+            rx={3}
+            fill="transparent"
+            stroke="var(--color-text-muted)"
+            strokeWidth={1}
+            strokeDasharray="3 3"
+          />
+          <text
+            x={PAD + 8}
+            y={OUTCOME_Y + 14}
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            letterSpacing="0.08em"
+            fill="var(--color-text-muted)"
+          >
+            {reason.without.label.toUpperCase()}
+          </text>
+          <text
+            x={PAD + 12}
+            y={OUTCOME_Y + 36}
+            fontFamily="var(--font-sans)"
+            fontSize={11}
+            fill="var(--color-text-muted)"
+          >
+            {wrapText(reason.without.body, 44).map((line, i) => (
+              <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
+                {line}
+              </tspan>
+            ))}
+          </text>
+        </motion.g>
+
+        {/* "With" outcome — drawn second, accented */}
+        <motion.g
+          key={`with-${reason.id}`}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...SPRING.smooth, delay: 0.06 }}
+        >
+          <rect
+            x={PAD}
+            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP}
+            width={WIDTH - PAD * 2}
+            height={OUTCOME_H}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-accent) 12%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={1.4}
+          />
+          <text
+            x={PAD + 8}
+            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 14}
+            fontFamily="var(--font-sans)"
+            fontSize={9}
+            letterSpacing="0.08em"
+            fill="var(--color-accent)"
+          >
+            {reason.withIt.label.toUpperCase()}
+          </text>
+          <text
+            x={PAD + 12}
+            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 36}
+            fontFamily="var(--font-sans)"
+            fontSize={11}
+            fill="var(--color-text)"
+          >
+            {wrapText(reason.withIt.body, 44).map((line, i) => (
+              <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
+                {line}
+              </tspan>
+            ))}
+          </text>
+        </motion.g>
+      </svg>
+    </WidgetShell>
+  );
+}
+
+/** Tiny word-wrap for SVG <text> at a fixed character column. */
+function wrapText(text: string, max: number): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let line = "";
+  for (const w of words) {
+    if ((line + " " + w).trim().length > max) {
+      if (line) lines.push(line);
+      line = w;
+    } else {
+      line = (line + " " + w).trim();
+    }
+  }
+  if (line) lines.push(line);
+  return lines.slice(0, 2);
+}

--- a/app/posts/how-javascript-reads-its-own-future/widgets/index.ts
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/index.ts
@@ -1,0 +1,4 @@
+export { CreationVsExecution } from "./CreationVsExecution";
+export { DeclarationStates } from "./DeclarationStates";
+export { CallStackECs } from "./CallStackECs";
+export { WhyTwoPasses } from "./WhyTwoPasses";

--- a/app/posts/how-javascript-reads-its-own-future/widgets/index.ts
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/index.ts
@@ -2,3 +2,4 @@ export { CreationVsExecution } from "./CreationVsExecution";
 export { DeclarationStates } from "./DeclarationStates";
 export { CallStackECs } from "./CallStackECs";
 export { WhyTwoPasses } from "./WhyTwoPasses";
+export { ClosingDot } from "./ClosingDot";

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -27,6 +27,14 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "how-javascript-reads-its-own-future",
+    title: "JavaScript Hoisting, the TDZ, and the Call Stack Explained",
+    date: "2026-04-25",
+    hook: "before line 1 runs, the engine has already walked your file — and that walk is why hoisting, the TDZ, and the call stack are one mechanism, not three quirks.",
+    readingMinutes: 15,
+    tags: ["javascript", "language-internals"],
+  },
+  {
     slug: "the-line-that-waits-its-turn",
     title:
       "How the JavaScript event loop, microtasks, and the call stack work",


### PR DESCRIPTION
## Summary

New post on the JS engine's two-pass model — execution context, variable environment, hoisting taxonomy, call stack as ECs. Pedagogy-first: the reader walks in confused by `console.log(x); var x = 5; // undefined` and leaves having built the mental model that explains hoisting, the TDZ, and the call stack as one mechanism.

Four widgets carry structural weight (one verb each, per `interactive-components.md` §4.5):

- **CreationVsExecution** (scrub) — 8-stop dual-pane scrubber crossing the creation/execution boundary; left pane shows engine state, right pane shows source-line execution.
- **DeclarationStates** (toggle) — 4-state segmented control showing the four memory shapes at line 1 (`var` / `let‧const‧class` (TDZ) / `function f()` / `var f = function`). TDZ cell uses hatched fill — shape + colour, not colour alone.
- **CallStackECs** (step) — **SPINE / differentiation lane**: dual-pane stepper showing call-stack growth + variable-environment of the running EC in lock-step on a shared cursor. Two columns, one cursor.
- **WhyTwoPasses** (toggle) — 3-state segmented control naming the three categories (Semantic / Syntactic / Immutability) the two-pass model is required to satisfy.

Sister-post crosslink to **the-line-that-waits-its-turn** (event loop / queues post) is wired through `PostNavCards`.

## Word + widget budget

- Words: **≈ 1170 / 1500 cap**.
- Widgets: 4.
- HL devices: 5 (one per section §1–§4) + 1 VerticalCutReveal climax in the closer.
- Reading time: 14–17 min (15 min posted in the byline).

## What changed (per commit)

| Commit | Scope |
|---|---|
| `c0a1901` | Initial scaffold + draft + 4 widgets + manifest entry. |
| `2aa86b0` | Round 1 mechanical batch (16 items): aria-label de-noise, microcopy, hero block alignment, `<Em>` → `<Term>` semantic upgrades, closer stagger duration, runningName parens, `CreationVsExecution` aria-label rewrite, P0.5 opening-scene microcopy. |
| `28c410c` | Round 2 voice-diffs (4 user-approved verbatim): A · drop §5 closer "is-a-different-post" paragraph; B · recast closer recap (kicker first); C · collapse §4 after-widget 3 paragraphs → 1 (~190-word trim, names the three categories); D · subtitle inversion-first. |
| `cfcbff0` | Round 4 delight polish: P1.21 `CreationVsExecution` beat crossfade; P1.24 `ClosingDot` whileInView reveal; P1.23 verified `Scrubber` already uses tabular-nums. |

Round 3 (caption trim + 360vw audit) yielded no substantive changes — flex-wrap was already in place on `DeclarationStates`, and remaining P1 microcopy items had been absorbed in Round 1.

## DESIGN.md ban enforcement

Eight reviewer suggestions rejected with explicit ban citations in `research/how-javascript-reads-its-own-future/action-items.md` § "Rejected with bans cited":

1. Two-accent scheme (TDZ button blue tint) — rejected per §3 + §12 one-accent.
2. Glow on stack-top frame — rejected per §12 + interactive-components §5.
3. `<HL>` on H1 — rejected per voice-profile §9 + §1 principle 4.
4. Animated `<Dots />` ornament — rejected per §1 principle 5.
5. Autoplay `CallStackECs` on mount — rejected per interactive-components §3 (state-0-on-arrival).
6. Stagger-in `DeclarationStates` segmented buttons — rejected per §3 + §7.
7. Literal mid-sentence pause-mark in VerticalCutReveal — rejected per §1 principle 5.
8. Two adjacent `<HL>`s in §1 lede — rejected per interactive-components §2.

`/animate` review found 0 P0 items in §9; R6 frame-stability re-verified across all four widgets post-diff (see `validation.md` §6).

## IP

Original writing throughout. Citations via `<A>` to:

- MDN Hoisting glossary (https://developer.mozilla.org/en-US/docs/Glossary/Hoisting)
- ECMA-262 §10.2.11 `FunctionDeclarationInstantiation` (https://tc39.es/ecma262/multipage/...)
- V8 preparser blog (https://v8.dev/blog/preparser, cited twice — once in §4 prose, once in the V8 Aside)

No verbatim or close-paraphrase from Hallie Kassan, "You Don't Know JS", or any source material. Mechanism descriptions re-explained from first principles.

## Validation results (`research/how-javascript-reads-its-own-future/validation.md`)

| Check | Status |
|---|---|
| Technical correctness | ✓ PASS — every numeric claim + spec citation traces to a tier-1 source; no uncited claims |
| Code correctness (`tsc --noEmit` + `pnpm build`) | ✓ PASS — clean typecheck, 14/14 static pages green |
| A11y (keyboard nav × 4 widgets, prefers-reduced-motion, color-only-info, focus rings) | ✓ PASS |
| Build + Lighthouse | ✓ Build PASS · Lighthouse DEFERRED to Vercel preview (per Phase H pragma) |
| Reading-sanity (voice drift, undefined terms, flow-breaks) | ✓ PASS — voice steady; HL cadence 5; closer cadence 4-beat |
| Frame-stability R6 | ✓ PASS — fixed canvas across all branches/stops in all 4 widgets |
| DESIGN.md compliance | ✓ PASS — re-verified post Round 4 |

## Test plan

- [ ] Open Vercel preview URL once it lands in PR comments.
- [ ] Read the post end-to-end at normal pace; confirm voice cadence holds and the §4 collapse + closer recap land.
- [ ] Exercise each widget:
  - [ ] **CreationVsExecution** — drag scrubber across the boundary; verify beat tag crossfades smoothly per stop; verify scrubber has tabular-nums on the stop count.
  - [ ] **DeclarationStates** — click each of the 4 segmented buttons; verify TDZ uses hatched fill (not colour alone); verify segmented control wraps gracefully at 360vw.
  - [ ] **CallStackECs** — step through; verify call-stack column + variable-env column move in lock-step on the shared cursor; verify "RUNNING" label tracks the stack-top frame.
  - [ ] **WhyTwoPasses** — toggle the 3 reasons; verify caption text matches the category named.
- [ ] Toggle theme (light ↔ dark); verify accent + hatched-fill remain legible in both.
- [ ] Keyboard-only nav: Tab through every widget; verify focus rings visible; verify `aria-pressed` reflects state on segmented controls.
- [ ] Simulate `prefers-reduced-motion`; verify all motion collapses to instant transitions.
- [ ] Lighthouse on the post page targets ≥ 95 perf / a11y / SEO.
- [ ] Verify `ClosingDot` reveal fires once on viewport entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>