### PR TITLE
feat(covers): animated SVG covers for event-loop + hoisting articles

### DIFF
--- a/components/covers/HowJavascriptReadsItsOwnFutureCover.tsx
+++ b/components/covers/HowJavascriptReadsItsOwnFutureCover.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useCoverInView } from "./_CoverFrame";
+
+/**
+ * HowJavascriptReadsItsOwnFutureCover — dual-pass scan over a code file.
+ *
+ * One sentence:
+ *   The engine pre-walks your file (creation pass) so declarations are alive
+ *   from line 1, then the execution caret follows behind line by line.
+ *
+ * Composition (~14 load-bearing elements):
+ *  1.  Code-page strip outline (rounded rect, the "file")
+ *  2.  Engine-eye outer ring (the engine "reading ahead")
+ *  3.  Engine-eye pupil dot (terracotta)
+ *  4-8. 5 code-line stubs inside the strip (function / let / const / var / call)
+ *  9.  function ƒ glyph (lights during creation pass at line 1)
+ *  10. let TDZ hatch glyph (lights at line 2)
+ *  11. const TDZ hatch glyph (lights at line 3)
+ *  12. var undefined-dot glyph (lights at line 4)
+ *  13. Creation-pass wave (thin terracotta horizontal bar, top→bottom sweep)
+ *  14. Execution-pass caret (terracotta caret + wash, follows behind)
+ *
+ * Motion (DESIGN.md §9 / playbook §3, §4):
+ *  - 6s continuous loop, no idle gap > 600ms.
+ *  - Phase A (0–35%): engine-eye scale-pulses; creation-pass wave sweeps
+ *    top→bottom across the strip (translateY ≈ 110); declaration glyphs
+ *    activate in sequence (opacity 0 → 1 + small scale pop) as the wave passes.
+ *  - Phase B (35–88%): execution-pass caret travels top→bottom, slower
+ *    (translateY ≈ 100); a wash highlights each line as the caret arrives.
+ *  - Phase C (88–100%): glyphs DIM but stay visible (the article's point —
+ *    "they're still in the VE"); brief idle, then reset.
+ *  - Hover amplifies via whileHover on the wrapping motion.g.
+ *
+ * Frame-stability R6: only transform / opacity / pathLength animate.
+ *
+ * Reduced-motion end-state: creation-pass wave at the bottom (complete);
+ * all 4 declaration glyphs activated; execution caret at midpoint over line 3.
+ * The reader sees: declarations are live, the engine is mid-execution.
+ */
+export function HowJavascriptReadsItsOwnFutureCover() {
+  const inView = useCoverInView();
+  const reduced = useReducedMotion();
+  const animate = inView && !reduced;
+
+  // Code-page geometry. Vertical strip taking ~70% of viewBox height.
+  const stripX = 36;
+  const stripY = 48;
+  const stripW = 128;
+  const stripH = 132;
+
+  // 5 code lines spaced inside the strip.
+  const lines = [
+    { y: stripY + 18, w: 88, kind: "fn" as const },     // function foo() { ... }
+    { y: stripY + 40, w: 70, kind: "let" as const },    // let x
+    { y: stripY + 62, w: 76, kind: "const" as const },  // const y
+    { y: stripY + 84, w: 64, kind: "var" as const },    // var z
+    { y: stripY + 106, w: 92, kind: "call" as const },  // foo()
+  ];
+
+  const lineX = stripX + 14;
+
+  // Glyph positions (right-side gutter of each declaration line).
+  const glyphX = stripX + stripW - 16;
+
+  // Creation-pass wave: translateY from above the strip to below it.
+  const waveYStart = stripY - 8;
+  const waveYEnd = stripY + stripH + 8;
+
+  // Execution caret: follows behind the wave.
+  const caretYStart = stripY + 4;
+  const caretYEnd = stripY + stripH - 8;
+
+  // Glyph activation times (within 0..1 of 6s loop) — match wave sweep 0..0.35.
+  // Wave passes line[i] at time ~ 0.04 + i * 0.06.
+  const glyphActivate: number[][] = [
+    [0, 0.04, 0.10, 0.94, 1],   // line 0 (fn ƒ)
+    [0, 0.10, 0.16, 0.94, 1],   // line 1 (let TDZ)
+    [0, 0.16, 0.22, 0.94, 1],   // line 2 (const TDZ)
+    [0, 0.22, 0.28, 0.94, 1],   // line 3 (var undefined-dot)
+  ];
+
+  // Line wash schedule for execution pass (caret reaches line[i] at ~ 0.40 + i * 0.10).
+  const lineWashSchedule: number[][] = [
+    [0, 0.4, 0.46, 0.5, 0.94, 1],
+    [0, 0.5, 0.56, 0.6, 0.94, 1],
+    [0, 0.6, 0.66, 0.7, 0.94, 1],
+    [0, 0.7, 0.76, 0.8, 0.94, 1],
+    [0, 0.8, 0.86, 0.88, 0.94, 1],
+  ];
+
+  return (
+    <motion.g initial={false} whileHover="hover">
+      {/* ─── Engine-eye (top-center, "reading ahead") ───────── */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { scale: [0.8, 1.1, 1, 1, 0.95, 0.8], opacity: [0.7, 1, 1, 0.85, 0.7, 0.7] }
+            : { scale: 1, opacity: 0.95 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.06, 0.18, 0.6, 0.92, 1],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: "100px 28px",
+          transformBox: "fill-box" as const,
+        }}
+      >
+        <circle
+          cx={100}
+          cy={28}
+          r={9}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth={1.8}
+          vectorEffect="non-scaling-stroke"
+        />
+        <circle cx={100} cy={28} r={3} fill="var(--color-accent)" />
+      </motion.g>
+
+      {/* ─── Code-page strip outline ────────────────────────── */}
+      <rect
+        x={stripX}
+        y={stripY}
+        width={stripW}
+        height={stripH}
+        rx={6}
+        fill="var(--color-surface)"
+        stroke="var(--color-text)"
+        strokeWidth={2}
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Left margin rule — code-editor gutter */}
+      <line
+        x1={stripX + 8}
+        y1={stripY + 6}
+        x2={stripX + 8}
+        y2={stripY + stripH - 6}
+        stroke="var(--color-rule)"
+        strokeWidth={0.8}
+        vectorEffect="non-scaling-stroke"
+        opacity={0.6}
+      />
+
+      {/* ─── Line wash (execution highlight) ────────────────── */}
+      {/* One translucent wash per line; opacity ramps as caret arrives. */}
+      {lines.map((ln, i) => (
+        <motion.rect
+          key={`wash-${i}`}
+          x={stripX + 4}
+          y={ln.y - 6}
+          width={stripW - 8}
+          height={12}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-accent) 22%, transparent)"
+          initial={{ opacity: 0 }}
+          animate={
+            animate
+              ? { opacity: [0, 0, 0.85, 0.5, 0.2, 0] }
+              : { opacity: i === 2 ? 0.7 : 0 } // reduced-motion: line 2 highlighted (caret at midpoint)
+          }
+          transition={
+            animate
+              ? {
+                  duration: 6,
+                  repeat: Infinity,
+                  ease: [0.4, 0, 0.2, 1],
+                  times: lineWashSchedule[i],
+                }
+              : undefined
+          }
+        />
+      ))}
+
+      {/* ─── Code-line stubs ────────────────────────────────── */}
+      {lines.map((ln, i) => (
+        <rect
+          key={`line-${i}`}
+          x={lineX}
+          y={ln.y - 1.5}
+          width={ln.w}
+          height={3}
+          rx={1.5}
+          fill="var(--color-text-muted)"
+          opacity={0.78}
+        />
+      ))}
+
+      {/* ─── Declaration glyphs ─────────────────────────────── */}
+      {/* Line 0: function ƒ — circle with f inside */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0, 0, 1, 0.55, 0], scale: [0.6, 0.6, 1.2, 1, 0.6] }
+            : { opacity: 0.85, scale: 1 } // reduced-motion: visible
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: glyphActivate[0],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: `${glyphX}px ${lines[0].y}px`,
+          transformBox: "fill-box" as const,
+        }}
+      >
+        <circle
+          cx={glyphX}
+          cy={lines[0].y}
+          r={5.5}
+          fill="color-mix(in oklab, var(--color-accent) 35%, transparent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          vectorEffect="non-scaling-stroke"
+        />
+        {/* italic-ish ƒ stem */}
+        <path
+          d={`M ${glyphX - 1} ${lines[0].y + 3} L ${glyphX + 1} ${lines[0].y - 3}`}
+          stroke="var(--color-accent)"
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        <line
+          x1={glyphX - 2.5}
+          y1={lines[0].y - 0.5}
+          x2={glyphX + 1.5}
+          y2={lines[0].y - 0.5}
+          stroke="var(--color-accent)"
+          strokeWidth={1.2}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </motion.g>
+
+      {/* Line 1: let — TDZ hatch (rect with diagonal stripes) */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0, 0, 1, 0.55, 0], scale: [0.6, 0.6, 1.18, 1, 0.6] }
+            : { opacity: 0.85, scale: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: glyphActivate[1],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: `${glyphX}px ${lines[1].y}px`,
+          transformBox: "fill-box" as const,
+        }}
+      >
+        <rect
+          x={glyphX - 5.5}
+          y={lines[1].y - 5}
+          width={11}
+          height={10}
+          rx={1.5}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          vectorEffect="non-scaling-stroke"
+        />
+        {/* Diagonal hatch lines */}
+        <line
+          x1={glyphX - 4}
+          y1={lines[1].y + 4}
+          x2={glyphX + 4}
+          y2={lines[1].y - 4}
+          stroke="var(--color-accent)"
+          strokeWidth={1}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        <line
+          x1={glyphX - 4}
+          y1={lines[1].y - 1}
+          x2={glyphX + 1}
+          y2={lines[1].y - 5}
+          stroke="var(--color-accent)"
+          strokeWidth={1}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          opacity={0.7}
+        />
+      </motion.g>
+
+      {/* Line 2: const — TDZ hatch (same pattern; sibling) */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0, 0, 1, 0.55, 0], scale: [0.6, 0.6, 1.18, 1, 0.6] }
+            : { opacity: 0.85, scale: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: glyphActivate[2],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: `${glyphX}px ${lines[2].y}px`,
+          transformBox: "fill-box" as const,
+        }}
+      >
+        <rect
+          x={glyphX - 5.5}
+          y={lines[2].y - 5}
+          width={11}
+          height={10}
+          rx={1.5}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          vectorEffect="non-scaling-stroke"
+        />
+        <line
+          x1={glyphX - 4}
+          y1={lines[2].y + 4}
+          x2={glyphX + 4}
+          y2={lines[2].y - 4}
+          stroke="var(--color-accent)"
+          strokeWidth={1}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        <line
+          x1={glyphX - 1}
+          y1={lines[2].y + 4}
+          x2={glyphX + 4}
+          y2={lines[2].y}
+          stroke="var(--color-accent)"
+          strokeWidth={1}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          opacity={0.7}
+        />
+      </motion.g>
+
+      {/* Line 3: var — undefined dot (small muted dot) */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0, 0, 1, 0.6, 0], scale: [0.6, 0.6, 1.3, 1, 0.6] }
+            : { opacity: 0.85, scale: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: glyphActivate[3],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: `${glyphX}px ${lines[3].y}px`,
+          transformBox: "fill-box" as const,
+        }}
+      >
+        <circle
+          cx={glyphX}
+          cy={lines[3].y}
+          r={4}
+          fill="none"
+          stroke="var(--color-text-muted)"
+          strokeWidth={1.4}
+          strokeDasharray="2 2"
+          vectorEffect="non-scaling-stroke"
+        />
+        <circle cx={glyphX} cy={lines[3].y} r={1.4} fill="var(--color-text-muted)" />
+      </motion.g>
+
+      {/* ─── Creation-pass wave (top→bottom sweep) ──────────── */}
+      {/* Thin terracotta bar that traverses the strip vertically. */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { y: [waveYStart, waveYEnd, waveYEnd, waveYStart], opacity: [1, 1, 0, 0] }
+            : { y: waveYEnd, opacity: 0 } // reduced-motion: at bottom (complete)
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.34, 0.36, 1],
+              }
+            : undefined
+        }
+      >
+        <line
+          x1={stripX + 2}
+          y1={0}
+          x2={stripX + stripW - 2}
+          y2={0}
+          stroke="var(--color-accent)"
+          strokeWidth={2.4}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        {/* Trailing fade — a second softer line just above */}
+        <line
+          x1={stripX + 6}
+          y1={-3}
+          x2={stripX + stripW - 6}
+          y2={-3}
+          stroke="color-mix(in oklab, var(--color-accent) 45%, transparent)"
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </motion.g>
+
+      {/* ─── Execution-pass caret (follows behind, slower) ──── */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? {
+                y: [caretYStart, caretYStart, caretYEnd, caretYStart],
+                opacity: [0, 1, 1, 0],
+              }
+            : { y: (caretYStart + caretYEnd) / 2, opacity: 1 } // reduced-motion: midpoint
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.4, 0.86, 1],
+              }
+            : undefined
+        }
+      >
+        {/* Caret triangle (right-pointing, in the gutter) */}
+        <path
+          d={`M ${stripX - 6} -4 L ${stripX - 1} 0 L ${stripX - 6} 4 Z`}
+          fill="var(--color-accent)"
+        />
+        {/* Tail line — short stem behind caret */}
+        <line
+          x1={stripX - 14}
+          y1={0}
+          x2={stripX - 7}
+          y2={0}
+          stroke="var(--color-accent)"
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          opacity={0.7}
+        />
+      </motion.g>
+    </motion.g>
+  );
+}

--- a/components/covers/LineThatWaitsItsTurnCover.tsx
+++ b/components/covers/LineThatWaitsItsTurnCover.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useCoverInView } from "./_CoverFrame";
+
+/**
+ * LineThatWaitsItsTurnCover — two-lane queue race for the event loop article.
+ *
+ * One sentence:
+ *   The microtask queue drains completely before a single macrotask fires.
+ *
+ * Composition (~12 load-bearing elements):
+ *  1.  Top-lane track (microtask lane, terracotta-tinted background)
+ *  2.  Bottom-lane track (macrotask lane, muted background)
+ *  3-6. 4 microtask chips on the top lane
+ *  7-8. 2 macrotask chips on the bottom lane
+ *  9.  "Now firing" indicator caret (terracotta triangle + glow)
+ *  10. Loop track (curve from right edges back to left, suggests the loop topology)
+ *  11. "μ" label dot for the micro lane
+ *  12. "M" label dot for the macro lane
+ *
+ * Motion (DESIGN.md §9 / playbook §3, §4):
+ *  - 5s continuous loop, no idle gap > 600ms.
+ *  - Phase A (0–60%): indicator translateX sweeps ~110 across the micro lane;
+ *    chip opacities ramp 1 → 0 in sequence as the indicator reaches each.
+ *  - Phase B (60–78%): indicator translateY drops to the macro lane and the
+ *    leftmost macro chip pulses + fades.
+ *  - Phase C (78–100%): chips re-enter from offscreen-left; indicator resets.
+ *  - Loop track: pathLength shimmer once per cycle (subtle).
+ *  - Hover amplifies idle motion via whileHover on the wrapping motion.g.
+ *
+ * Frame-stability R6: only transform / opacity / pathLength animate.
+ *
+ * Reduced-motion end-state: indicator at right edge of micro lane; all 4 micros
+ * faded; one macro chip in fade-state. The "drained" look — the article's thesis.
+ */
+export function LineThatWaitsItsTurnCover() {
+  const inView = useCoverInView();
+  const reduced = useReducedMotion();
+  const animate = inView && !reduced;
+
+  // Lane geometry. Both lanes are horizontal bands centered around the viewBox.
+  const laneX = 24;
+  const laneW = 152;
+  const microY = 64;
+  const macroY = 124;
+  const laneH = 36;
+
+  // 4 microtask chips spread across the micro lane.
+  const microChips = [
+    { x: laneX + 8 },
+    { x: laneX + 38 },
+    { x: laneX + 68 },
+    { x: laneX + 98 },
+  ];
+  // 2 macrotask chips spread across the macro lane.
+  const macroChips = [
+    { x: laneX + 18 },
+    { x: laneX + 78 },
+  ];
+
+  const chipW = 22;
+  const chipH = 18;
+
+  // Indicator position keyframes within the 5s loop.
+  // It sweeps the 4 micro chips (idx 0..3), drops to macro lane and fires chip 0.
+  const microCenters = microChips.map((c) => c.x + chipW / 2);
+  const macroCenter0 = macroChips[0].x + chipW / 2;
+
+  // Indicator translateX keyframes (relative to viewBox), then drops Y.
+  const indicatorX = [
+    microCenters[0],
+    microCenters[0],
+    microCenters[1],
+    microCenters[2],
+    microCenters[3],
+    macroCenter0,
+    macroCenter0,
+    microCenters[0],
+  ];
+  const indicatorY = [
+    microY + laneH / 2 - 2,
+    microY + laneH / 2 - 2,
+    microY + laneH / 2 - 2,
+    microY + laneH / 2 - 2,
+    microY + laneH / 2 - 2,
+    macroY + laneH / 2 - 2,
+    macroY + laneH / 2 - 2,
+    microY + laneH / 2 - 2,
+  ];
+  const indicatorTimes = [0, 0.06, 0.22, 0.38, 0.54, 0.66, 0.78, 1];
+
+  // Each micro chip's opacity schedule — full opacity until indicator reaches it,
+  // then it fades. Re-enters at end of cycle.
+  const microFadeTimes: number[][] = [
+    [0, 0.08, 0.18, 0.86, 0.94, 1],
+    [0, 0.24, 0.34, 0.86, 0.94, 1],
+    [0, 0.4, 0.5, 0.86, 0.94, 1],
+    [0, 0.56, 0.66, 0.86, 0.94, 1],
+  ];
+
+  return (
+    <motion.g initial={false} whileHover="hover">
+      {/* ─── Lane backgrounds ─────────────────────────────────── */}
+      {/* Micro lane (terracotta-tinted) */}
+      <rect
+        x={laneX}
+        y={microY}
+        width={laneW}
+        height={laneH}
+        rx={8}
+        fill="color-mix(in oklab, var(--color-accent) 12%, transparent)"
+        stroke="color-mix(in oklab, var(--color-accent) 35%, transparent)"
+        strokeWidth={1.4}
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Macro lane (muted) */}
+      <rect
+        x={laneX}
+        y={macroY}
+        width={laneW}
+        height={laneH}
+        rx={8}
+        fill="var(--color-surface)"
+        stroke="var(--color-rule)"
+        strokeWidth={1.4}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* Lane label dots — left of each lane */}
+      <circle
+        cx={laneX - 10}
+        cy={microY + laneH / 2}
+        r={2.4}
+        fill="var(--color-accent)"
+      />
+      <circle
+        cx={laneX - 10}
+        cy={macroY + laneH / 2}
+        r={2.4}
+        fill="var(--color-text-muted)"
+      />
+
+      {/* ─── Loop track (right edge → arc back to left) ──────── */}
+      {/* Subtle curve suggesting the event-loop topology. */}
+      <motion.path
+        d={`
+          M ${laneX + laneW + 4} ${microY + laneH / 2}
+          C ${laneX + laneW + 22} ${microY + laneH / 2},
+            ${laneX + laneW + 22} ${macroY + laneH / 2},
+            ${laneX + laneW + 4} ${macroY + laneH / 2}
+        `}
+        fill="none"
+        stroke="var(--color-rule)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        initial={{ pathLength: 1, opacity: 0.5 }}
+        animate={
+          animate
+            ? { pathLength: [1, 1, 1], opacity: [0.4, 0.85, 0.4] }
+            : { pathLength: 1, opacity: 0.5 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: "easeInOut",
+                times: [0, 0.7, 1],
+              }
+            : undefined
+        }
+      />
+      {/* Tail back to left edge — arrow stub, draws on every cycle */}
+      <motion.path
+        d={`
+          M ${laneX + laneW + 4} ${macroY + laneH / 2}
+          L ${laneX + laneW + 14} ${macroY + laneH / 2}
+          L ${laneX + laneW + 14} ${microY - 18}
+          L ${laneX - 10} ${microY - 18}
+          L ${laneX - 10} ${microY + laneH / 2 - 14}
+        `}
+        fill="none"
+        stroke="var(--color-rule)"
+        strokeWidth={1.2}
+        strokeLinecap="round"
+        strokeDasharray="3 3"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.55}
+      />
+
+      {/* ─── Microtask chips ──────────────────────────────────── */}
+      {microChips.map((c, i) => (
+        <motion.rect
+          key={`micro-${i}`}
+          x={c.x}
+          y={microY + (laneH - chipH) / 2}
+          width={chipW}
+          height={chipH}
+          rx={3}
+          fill="var(--color-accent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          vectorEffect="non-scaling-stroke"
+          initial={{ opacity: 1, scale: 1 }}
+          animate={
+            animate
+              ? {
+                  opacity: [1, 1, 0, 0, 1, 1],
+                  scale: [1, 1.18, 0.92, 0.92, 1, 1],
+                }
+              : i === 3
+                ? { opacity: 0, scale: 0.92 } // reduced-motion: rightmost just fading
+                : { opacity: 0, scale: 0.92 } // all drained
+          }
+          transition={
+            animate
+              ? {
+                  duration: 5,
+                  repeat: Infinity,
+                  ease: [0.4, 0, 0.2, 1],
+                  times: microFadeTimes[i],
+                }
+              : undefined
+          }
+          style={{
+            transformOrigin: `${c.x + chipW / 2}px ${microY + laneH / 2}px`,
+            transformBox: "fill-box" as const,
+          }}
+        />
+      ))}
+
+      {/* ─── Macrotask chips ──────────────────────────────────── */}
+      {/* Chip 0 — fires once per cycle */}
+      <motion.rect
+        x={macroChips[0].x}
+        y={macroY + (laneH - chipH) / 2}
+        width={chipW}
+        height={chipH}
+        rx={3}
+        fill="var(--color-surface)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.6}
+        vectorEffect="non-scaling-stroke"
+        initial={{ opacity: 1, scale: 1 }}
+        animate={
+          animate
+            ? {
+                opacity: [1, 1, 1, 0.2, 1, 1],
+                scale: [1, 1, 1.22, 0.92, 1, 1],
+              }
+            : { opacity: 0.2, scale: 0.92 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.6, 0.7, 0.78, 0.92, 1],
+              }
+            : undefined
+        }
+        style={{
+          transformOrigin: `${macroChips[0].x + chipW / 2}px ${macroY + laneH / 2}px`,
+          transformBox: "fill-box" as const,
+        }}
+      />
+      {/* Chip 1 — static, sits in queue waiting */}
+      <rect
+        x={macroChips[1].x}
+        y={macroY + (laneH - chipH) / 2}
+        width={chipW}
+        height={chipH}
+        rx={3}
+        fill="var(--color-surface)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.6}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── "Now firing" indicator (caret + wash) ───────────── */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? { x: indicatorX, y: indicatorY }
+            : {
+                x: indicatorX[indicatorTimes.length - 2], // settled at macro chip
+                y: indicatorY[indicatorTimes.length - 2],
+              }
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: indicatorTimes,
+              }
+            : undefined
+        }
+      >
+        {/* Soft wash beneath the chip the indicator is on */}
+        <motion.circle
+          cx={0}
+          cy={0}
+          r={16}
+          fill="color-mix(in oklab, var(--color-accent) 22%, transparent)"
+          initial={{ opacity: 0.6, scale: 1 }}
+          animate={
+            animate
+              ? { opacity: [0.5, 0.95, 0.5], scale: [1, 1.15, 1] }
+              : { opacity: 0.7, scale: 1 }
+          }
+          transition={
+            animate
+              ? {
+                  duration: 1.1,
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                }
+              : undefined
+          }
+          style={{ transformBox: "fill-box" as const, transformOrigin: "center" }}
+        />
+        {/* Caret triangle pointing at chip from above */}
+        <path
+          d={`M -5 -16 L 5 -16 L 0 -8 Z`}
+          fill="var(--color-accent)"
+        />
+      </motion.g>
+    </motion.g>
+  );
+}

--- a/components/covers/PostCover.tsx
+++ b/components/covers/PostCover.tsx
@@ -6,6 +6,8 @@ import { WhyFetchFailsCover } from "./WhyFetchFailsCover";
 import { BrowserStoppedAskingCover } from "./BrowserStoppedAskingCover";
 import { FunctionRememberedCover } from "./FunctionRememberedCover";
 import { WebpageReadsAgentCover } from "./WebpageReadsAgentCover";
+import { LineThatWaitsItsTurnCover } from "./LineThatWaitsItsTurnCover";
+import { HowJavascriptReadsItsOwnFutureCover } from "./HowJavascriptReadsItsOwnFutureCover";
 
 /**
  * Slug → cover-component registry.
@@ -20,6 +22,8 @@ const REGISTRY: Record<string, () => React.ReactNode> = {
   "the-browser-stopped-asking": BrowserStoppedAskingCover,
   "the-function-that-remembered": FunctionRememberedCover,
   "the-webpage-that-reads-the-agent": WebpageReadsAgentCover,
+  "the-line-that-waits-its-turn": LineThatWaitsItsTurnCover,
+  "how-javascript-reads-its-own-future": HowJavascriptReadsItsOwnFutureCover,
 };
 
 type Size = "thumb" | "hero";


### PR DESCRIPTION
## Summary
- Two new bespoke animated covers matching the v4 design language for the two articles that just shipped (PRs #45 + #46).
- Authored against `docs/svg-cover-playbook.md` — element budget ≤ 14, large-amplitude continuous motion, tokens-only, R6 frame-stable, `useInView` paused, `useReducedMotion` end-states.

### LineThatWaitsItsTurnCover (`the-line-that-waits-its-turn`)
Two-lane queue race: microtask lane drains all chips, then a single macrotask fires. Continuous 5 s loop. The article's whole thesis ("micros drain before any macro") rendered as one moving image.

### HowJavascriptReadsItsOwnFutureCover (`how-javascript-reads-its-own-future`)
Dual-pass scan over a code strip: a creation-pass wave activates declaration glyphs (function ƒ, TDZ hatch, var undefined-dot) BEFORE the execution caret follows behind. 6 s loop.

## Test plan
- [ ] Home list — both covers visible at 64 px (mobile) and 80 px (lg) thumbnail; metaphors readable
- [ ] Post pages — hero tile renders the same component at hero size; legibility holds
- [ ] Reduced-motion — Chrome DevTools rendering > prefers-reduced-motion:reduce — both covers render meaningful end-states (drained queues / completed creation pass)
- [ ] Off-screen scroll — `useInView` pauses both covers when scrolled out of view
- [ ] No layout shift between mobile/desktop on the home list

🤖 Generated with [Claude Code](https://claude.com/claude-code)