### PR TITLE
fix(seo): point SITE_URL at byte-size.xyz; add root OG/Twitter fallback

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,6 +47,15 @@ export const metadata: Metadata = {
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
     type: "website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    images: [{ url: "/og/_default", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    images: ["/og/_default"],
   },
 };
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,7 +4,7 @@
  * changes, change it in exactly one place.
  */
 
-export const SITE_URL = "https://bytesize.vercel.app";
+export const SITE_URL = "https://www.byte-size.xyz";
 
 export const SITE_NAME = "bytesize";
 


### PR DESCRIPTION
## Summary

The site deploys to **https://www.byte-size.xyz** but \`SITE_URL\` was set to \`https://bytesize.vercel.app\` — which is a different unrelated project (a community-events org with the same Vercel subdomain). Every absolute URL emitted by article metadata (canonical, \`og:url\`, \`og:image\`, \`twitter:image\`) was therefore pointing at the wrong host and 404-ing on social-platform scrapers — no preview tile ever rendered on X / WhatsApp / LinkedIn / Telegram / etc.

### Changes
- \`lib/site.ts\`: \`SITE_URL\` → \`https://www.byte-size.xyz\`.
- \`app/layout.tsx\`: added \`openGraph.images\` + a full \`twitter\` card config to the root metadata so the homepage and any non-post page produces a preview tile too. Both fall through to \`/og/_default\`, which the existing Satori route at \`app/og/[slug]/route.tsx\` already renders as a typographic site tile when no post matches the slug.

## Test plan

After deploy, validate via the platform debug tools — social caches stick on stale OG metadata for ~7 days and won't refresh on their own:

- [ ] Facebook debugger (covers WhatsApp + Facebook): https://developers.facebook.com/tools/debug/ — paste any \`https://www.byte-size.xyz/posts/<slug>\` and click \"Scrape Again\". Confirm preview renders.
- [ ] LinkedIn post inspector: https://www.linkedin.com/post-inspector/ — paste a post URL.
- [ ] Telegram: send the URL to \`@WebpageBot\` and reply \`/debug\`.
- [ ] X / Twitter: tweet a post URL with \`?v=2\` cache-buster appended; confirm preview tile renders.
- [ ] Homepage share — confirm \`/og/_default\` renders the typographic site tile.

## Follow-up

A separate PR (queued behind PR #47) will replace the typographic Satori OG with a Satori composition that includes each post's animated-cover static end-state, so the share-preview tile uses the same artwork as the home-list thumbnail and post hero. That requires every cover component to expose a pure-JSX static export (no hooks; Satori doesn't run React state) and the \`/og/[slug]\` route to import them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)