### PR TITLE
feat(og): compose per-post SVG cover into Satori share-preview PNG

### DIFF
--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -1,37 +1,169 @@
 import { ImageResponse } from "next/og";
 import { POSTS } from "@/content/posts-manifest";
 import { SITE_NAME } from "@/lib/site";
+import { STATIC_COVERS } from "@/components/covers/static-registry";
 
 export const runtime = "edge";
 
 const SIZE = { width: 1200, height: 630 };
 
-// OKLCH values resolved to RGB for the OG image (Satori supports limited CSS).
+// OKLCH design tokens resolved to hex for the OG image (Satori has limited
+// CSS-variable support). Mirror this set in static cover exports — keep them
+// in sync with components/covers/static-registry.ts.
 const BG = "#0e1114";
 const TEXT = "#f8f5f0";
 const MUTED = "#7a7570";
-const ACCENT = "#d97341"; // terracotta
+const ACCENT = "#d97341";
 
 type RouteContext = { params: Promise<{ slug: string }> };
+
+function formatDate(iso?: string) {
+  if (!iso) return "";
+  return new Date(iso + "T00:00:00Z")
+    .toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+      timeZone: "UTC",
+    })
+    .toLowerCase();
+}
 
 export async function GET(_req: Request, ctx: RouteContext) {
   const { slug } = await ctx.params;
   const post = POSTS.find((p) => p.slug === slug);
+  const StaticCover = STATIC_COVERS[slug];
 
+  // Composed two-up tile (cover left, copy right) for known posts.
+  if (StaticCover && post) {
+    const date = formatDate(post.date);
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            background: BG,
+            color: TEXT,
+            display: "flex",
+            flexDirection: "column",
+            padding: "60px",
+            fontFamily: "'IBM Plex Sans', sans-serif",
+          }}
+        >
+          {/* Top row: wordmark + accent swatch */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 22,
+                fontFamily: "'IBM Plex Mono', monospace",
+                letterSpacing: "0.04em",
+                color: MUTED,
+              }}
+            >
+              {SITE_NAME}
+            </div>
+            <div style={{ width: 16, height: 16, background: ACCENT }} />
+          </div>
+
+          {/* Two-up body: cover (left) + copy (right) */}
+          <div
+            style={{
+              display: "flex",
+              flex: 1,
+              alignItems: "center",
+              gap: 60,
+              marginTop: 24,
+              marginBottom: 24,
+            }}
+          >
+            {/* Cover art — fills the left half */}
+            <div
+              style={{
+                display: "flex",
+                width: 480,
+                height: 480,
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <StaticCover />
+            </div>
+
+            {/* Copy column — title + hook */}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: 1,
+                justifyContent: "center",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 56,
+                  fontWeight: 600,
+                  lineHeight: 1.15,
+                  letterSpacing: "-0.02em",
+                  color: TEXT,
+                  // Clamp at 3 lines via overflow + max height roughly = 3*56*1.15
+                  display: "flex",
+                }}
+              >
+                {post.title}
+              </div>
+              <div
+                style={{
+                  marginTop: 24,
+                  fontSize: 24,
+                  lineHeight: 1.4,
+                  color: MUTED,
+                  fontFamily: "'IBM Plex Serif', serif",
+                  display: "flex",
+                }}
+              >
+                {post.hook}
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom row: date pill */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              fontSize: 18,
+              fontFamily: "'IBM Plex Mono', monospace",
+              color: ACCENT,
+            }}
+          >
+            {date ? (
+              <span>{date}</span>
+            ) : (
+              <span>explainers · widgets · craft</span>
+            )}
+          </div>
+        </div>
+      ),
+      SIZE,
+    );
+  }
+
+  // Fallback: typographic-only design for unknown slugs (_default, /about, etc).
   const title = post?.title ?? SITE_NAME;
   const hook =
     post?.hook ??
     "engineering essays with interactive widgets that show how the thing actually works.";
-  const date = post?.date
-    ? new Date(post.date + "T00:00:00Z")
-        .toLocaleDateString("en-US", {
-          year: "numeric",
-          month: "short",
-          day: "2-digit",
-          timeZone: "UTC",
-        })
-        .toLowerCase()
-    : "";
+  const date = formatDate(post?.date);
 
   return new ImageResponse(
     (
@@ -47,7 +179,6 @@ export async function GET(_req: Request, ctx: RouteContext) {
           fontFamily: "'IBM Plex Sans', sans-serif",
         }}
       >
-        {/* top row: wordmark + accent swatch */}
         <div
           style={{
             display: "flex",
@@ -66,16 +197,9 @@ export async function GET(_req: Request, ctx: RouteContext) {
           >
             {SITE_NAME}
           </div>
-          <div
-            style={{
-              width: 16,
-              height: 16,
-              background: ACCENT,
-            }}
-          />
+          <div style={{ width: 16, height: 16, background: ACCENT }} />
         </div>
 
-        {/* title */}
         <div
           style={{
             display: "flex",
@@ -110,7 +234,6 @@ export async function GET(_req: Request, ctx: RouteContext) {
           </div>
         </div>
 
-        {/* bottom row: date */}
         <div
           style={{
             display: "flex",

--- a/components/covers/BrowserStoppedAskingCover.tsx
+++ b/components/covers/BrowserStoppedAskingCover.tsx
@@ -195,3 +195,51 @@ export function BrowserStoppedAskingCover() {
     </g>
   );
 }
+
+/**
+ * BrowserStoppedAskingCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: beam fully drawn, two packets sit at midpoint,
+ * endpoint pulse-rings at rest scale.
+ */
+export function BrowserStoppedAskingCoverStatic() {
+  const ACCENT = "#d97341";
+  const TEXT = "#f8f5f0";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+
+  const beamY = 100;
+  const leftX = 56;
+  const rightX = 144;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Client tile */}
+      <rect x={20} y={76} width={48} height={48} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
+      <circle cx={32} cy={88} r={2} fill={MUTED} opacity={0.7} />
+      <rect x={28} y={104} width={32} height={2} rx={1} fill={MUTED} opacity={0.5} />
+      <rect x={28} y={110} width={20} height={2} rx={1} fill={MUTED} opacity={0.5} />
+
+      {/* Server tile */}
+      <rect x={132} y={76} width={48} height={48} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
+      <line x1={142} y1={88} x2={170} y2={88} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
+      <line x1={142} y1={100} x2={170} y2={100} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
+      <line x1={142} y1={112} x2={170} y2={112} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
+
+      {/* Endpoint pulse rings (at rest) */}
+      <circle cx={leftX - 12} cy={beamY} r={28} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.25} />
+      <circle cx={rightX + 12} cy={beamY} r={28} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.25} />
+
+      {/* Beam */}
+      <line x1={leftX} y1={beamY} x2={rightX} y2={beamY} stroke={ACCENT} strokeWidth={5} strokeLinecap="round" opacity={0.9} />
+
+      {/* Packets at midpoint — show one going each direction, both visible */}
+      <circle cx={88} cy={beamY} r={5} fill={TEXT} stroke={ACCENT} strokeWidth={2.5} />
+      <circle cx={112} cy={beamY} r={5} fill={TEXT} stroke={ACCENT} strokeWidth={2.5} />
+    </svg>
+  );
+}

--- a/components/covers/FunctionRememberedCover.tsx
+++ b/components/covers/FunctionRememberedCover.tsx
@@ -193,3 +193,62 @@ export function FunctionRememberedCover() {
     </g>
   );
 }
+
+/**
+ * FunctionRememberedCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: outer scope at 0.3 opacity (faded), inner scope
+ * solid, tether fully drawn from captured value upward.
+ */
+export function FunctionRememberedCoverStatic() {
+  const ACCENT = "#d97341";
+  const TEXT = "#f8f5f0";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Outer scope — faded (the dying scope) */}
+      <g opacity={0.3} transform="translate(8 8) scale(0.92)">
+        <rect x={20} y={28} width={160} height={144} rx={10} fill="none" stroke={TEXT} strokeWidth={3} />
+        <path
+          d="M 36 56 Q 30 56, 30 64 L 30 96 Q 30 104, 24 104 Q 30 104, 30 112 L 30 144 Q 30 152, 36 152"
+          fill="none"
+          stroke={MUTED}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M 164 56 Q 170 56, 170 64 L 170 96 Q 170 104, 176 104 Q 170 104, 170 112 L 170 144 Q 170 152, 164 152"
+          fill="none"
+          stroke={MUTED}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
+
+      {/* Tether line — fully drawn */}
+      <line x1={100} y1={92} x2={100} y2={20} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" strokeDasharray="3 4" opacity={0.85} />
+
+      {/* Memory anchor */}
+      <circle cx={100} cy={20} r={3.5} fill={ACCENT} opacity={0.95} />
+
+      {/* Inner scope — bright, solid */}
+      <rect x={62} y={84} width={76} height={68} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={3} />
+      <rect x={70} y={94} width={12} height={2.4} rx={1.2} fill={MUTED} opacity={0.75} />
+      <rect x={86} y={94} width={20} height={2.4} rx={1.2} fill={MUTED} opacity={0.75} />
+
+      {/* Captured value pulse ring */}
+      <circle cx={100} cy={124} r={12} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.6} />
+
+      {/* Captured value dot */}
+      <circle cx={100} cy={124} r={6} fill={ACCENT} />
+    </svg>
+  );
+}

--- a/components/covers/HowGmailCover.tsx
+++ b/components/covers/HowGmailCover.tsx
@@ -310,3 +310,114 @@ export function HowGmailCover() {
     </g>
   );
 }
+
+/**
+ * HowGmailCoverStatic — Satori-safe pure-JSX export of the reduced-motion
+ * end-state. Bit-array fully resolved with 3 cells lit terracotta and the
+ * verdict tick visible. Used by the /og share-preview route.
+ *
+ * Hex constants inline because Satori has limited CSS-variable support;
+ * see components/covers/static-registry.ts for the canonical palette.
+ */
+export function HowGmailCoverStatic() {
+  const ACCENT = "#d97341";
+  const TEXT = "#f8f5f0";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+
+  const cellCount = 12;
+  const cellW = 12;
+  const cellH = 16;
+  const cellGap = 2;
+  const arrayW = cellCount * cellW + (cellCount - 1) * cellGap;
+  const arrayX = (200 - arrayW) / 2;
+  const arrayY = 140;
+
+  const cells = Array.from({ length: cellCount }, (_, i) => ({
+    x: arrayX + i * (cellW + cellGap),
+    y: arrayY,
+    lit: i === 1 || i === 5 || i === 9,
+  }));
+
+  const litCenters = cells.filter((c) => c.lit).map((c) => c.x + cellW / 2);
+
+  const inputCx = 100;
+  const inputCy = 56;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Input bubble */}
+      <rect x={56} y={36} width={88} height={28} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
+      <rect x={64} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
+      <rect x={72} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
+      <rect x={80} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
+      <rect x={88} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
+      <rect x={96} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
+      <rect x={104} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
+      <rect x={112} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
+      <circle cx={124} cy={50} r={2.4} fill="none" stroke={MUTED} strokeWidth={1.4} />
+
+      {/* 3 hash arcs (fully drawn) */}
+      {litCenters.map((endX, i) => {
+        const startX = inputCx;
+        const startY = inputCy + 12;
+        const endY = arrayY - 2;
+        const midX = (startX + endX) / 2;
+        const midY = startY + 30 + i * 4;
+        const d = `M ${startX} ${startY} Q ${midX} ${midY}, ${endX} ${endY}`;
+        return (
+          <path
+            key={`arc-${i}`}
+            d={d}
+            fill="none"
+            stroke={ACCENT}
+            strokeWidth={2.2}
+            strokeLinecap="round"
+            opacity={0.85}
+          />
+        );
+      })}
+
+      {/* Bit-array cells */}
+      {cells.map((c, i) => (
+        <g key={`cell-${i}`}>
+          <rect
+            x={c.x}
+            y={c.y}
+            width={cellW}
+            height={cellH}
+            rx={2}
+            fill={SURFACE}
+            stroke={TEXT}
+            strokeWidth={2}
+          />
+          {c.lit && (
+            <rect
+              x={c.x}
+              y={c.y}
+              width={cellW}
+              height={cellH}
+              rx={2}
+              fill={ACCENT}
+            />
+          )}
+        </g>
+      ))}
+
+      {/* Verdict tick */}
+      <path
+        d="M 154 92 L 162 100 L 178 84"
+        fill="none"
+        stroke={ACCENT}
+        strokeWidth={3.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/covers/HowJavascriptReadsItsOwnFutureCover.tsx
+++ b/components/covers/HowJavascriptReadsItsOwnFutureCover.tsx
@@ -485,3 +485,117 @@ export function HowJavascriptReadsItsOwnFutureCover() {
     </motion.g>
   );
 }
+
+/**
+ * HowJavascriptReadsItsOwnFutureCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state per playbook §8: creation-pass wave at bottom
+ * (complete, faded), all 4 declaration glyphs activated, execution caret
+ * at midpoint over line 2, with line-2 wash highlighted.
+ *
+ * color-mix() values replaced with hex approximations for Satori.
+ */
+export function HowJavascriptReadsItsOwnFutureCoverStatic() {
+  const ACCENT = "#d97341";
+  const TEXT = "#f8f5f0";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+  const RULE = "#2a2622";
+  // color-mix(accent 22% + transparent) ~= low-alpha terracotta
+  const ACCENT_WASH = "#3b2620";
+  // color-mix(accent 35% + transparent) — glyph fill
+  const ACCENT_FILL_LIGHT = "#4a2a22";
+
+  const stripX = 36;
+  const stripY = 48;
+  const stripW = 128;
+  const stripH = 132;
+
+  const lines = [
+    { y: stripY + 18, w: 88 },
+    { y: stripY + 40, w: 70 },
+    { y: stripY + 62, w: 76 },
+    { y: stripY + 84, w: 64 },
+    { y: stripY + 106, w: 92 },
+  ];
+
+  const lineX = stripX + 14;
+  const glyphX = stripX + stripW - 16;
+
+  // Caret midpoint between caretYStart=stripY+4 and caretYEnd=stripY+stripH-8
+  const caretMidY = (stripY + 4 + stripY + stripH - 8) / 2;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Engine-eye */}
+      <circle cx={100} cy={28} r={9} fill="none" stroke={ACCENT} strokeWidth={1.8} opacity={0.95} />
+      <circle cx={100} cy={28} r={3} fill={ACCENT} />
+
+      {/* Code strip */}
+      <rect x={stripX} y={stripY} width={stripW} height={stripH} rx={6} fill={SURFACE} stroke={TEXT} strokeWidth={2} />
+      {/* Gutter rule */}
+      <line x1={stripX + 8} y1={stripY + 6} x2={stripX + 8} y2={stripY + stripH - 6} stroke={RULE} strokeWidth={0.8} opacity={0.6} />
+
+      {/* Line wash on line 2 (midpoint, where caret sits) */}
+      <rect x={stripX + 4} y={lines[2].y - 6} width={stripW - 8} height={12} rx={3} fill={ACCENT_WASH} opacity={0.7} />
+
+      {/* Code-line stubs */}
+      {lines.map((ln, i) => (
+        <rect
+          key={`line-${i}`}
+          x={lineX}
+          y={ln.y - 1.5}
+          width={ln.w}
+          height={3}
+          rx={1.5}
+          fill={MUTED}
+          opacity={0.78}
+        />
+      ))}
+
+      {/* Declaration glyphs — all 4 activated */}
+      {/* Line 0: function ƒ */}
+      <g opacity={0.85}>
+        <circle cx={glyphX} cy={lines[0].y} r={5.5} fill={ACCENT_FILL_LIGHT} stroke={ACCENT} strokeWidth={1.4} />
+        <path d={`M ${glyphX - 1} ${lines[0].y + 3} L ${glyphX + 1} ${lines[0].y - 3}`} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" />
+        <line x1={glyphX - 2.5} y1={lines[0].y - 0.5} x2={glyphX + 1.5} y2={lines[0].y - 0.5} stroke={ACCENT} strokeWidth={1.2} strokeLinecap="round" />
+      </g>
+
+      {/* Line 1: let TDZ */}
+      <g opacity={0.85}>
+        <rect x={glyphX - 5.5} y={lines[1].y - 5} width={11} height={10} rx={1.5} fill="none" stroke={ACCENT} strokeWidth={1.4} />
+        <line x1={glyphX - 4} y1={lines[1].y + 4} x2={glyphX + 4} y2={lines[1].y - 4} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={glyphX - 4} y1={lines[1].y - 1} x2={glyphX + 1} y2={lines[1].y - 5} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" opacity={0.7} />
+      </g>
+
+      {/* Line 2: const TDZ */}
+      <g opacity={0.85}>
+        <rect x={glyphX - 5.5} y={lines[2].y - 5} width={11} height={10} rx={1.5} fill="none" stroke={ACCENT} strokeWidth={1.4} />
+        <line x1={glyphX - 4} y1={lines[2].y + 4} x2={glyphX + 4} y2={lines[2].y - 4} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={glyphX - 1} y1={lines[2].y + 4} x2={glyphX + 4} y2={lines[2].y} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" opacity={0.7} />
+      </g>
+
+      {/* Line 3: var undefined-dot */}
+      <g opacity={0.85}>
+        <circle cx={glyphX} cy={lines[3].y} r={4} fill="none" stroke={MUTED} strokeWidth={1.4} strokeDasharray="2 2" />
+        <circle cx={glyphX} cy={lines[3].y} r={1.4} fill={MUTED} />
+      </g>
+
+      {/* Creation-pass wave at bottom — visible-but-fading position */}
+      <g opacity={0.4} transform={`translate(0 ${stripY + stripH + 8})`}>
+        <line x1={stripX + 2} y1={0} x2={stripX + stripW - 2} y2={0} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" />
+        <line x1={stripX + 6} y1={-3} x2={stripX + stripW - 6} y2={-3} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={0.45} />
+      </g>
+
+      {/* Execution caret at midpoint */}
+      <g transform={`translate(0 ${caretMidY})`}>
+        <path d={`M ${stripX - 6} -4 L ${stripX - 1} 0 L ${stripX - 6} 4 Z`} fill={ACCENT} />
+        <line x1={stripX - 14} y1={0} x2={stripX - 7} y2={0} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" opacity={0.7} />
+      </g>
+    </svg>
+  );
+}

--- a/components/covers/LineThatWaitsItsTurnCover.tsx
+++ b/components/covers/LineThatWaitsItsTurnCover.tsx
@@ -334,3 +334,131 @@ export function LineThatWaitsItsTurnCover() {
     </motion.g>
   );
 }
+
+/**
+ * LineThatWaitsItsTurnCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: indicator at far right of micro lane, all 4
+ * micros faded (drained — the article's thesis), one macro chip in
+ * fade-state.
+ *
+ * Note: color-mix() is replaced with hex equivalents because Satori
+ * doesn't resolve color-mix. Tinted lane is approximated as a low-alpha
+ * accent layered over the canvas.
+ */
+export function LineThatWaitsItsTurnCoverStatic() {
+  const ACCENT = "#d97341";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+  const RULE = "#2a2622";
+  // Approximation of color-mix(accent 12% + transparent) over BG #0e1114
+  const ACCENT_TINT = "#23191b";
+  const ACCENT_TINT_STROKE = "#56342a";
+  const ACCENT_WASH = "#3b2620";
+
+  const laneX = 24;
+  const laneW = 152;
+  const microY = 64;
+  const macroY = 124;
+  const laneH = 36;
+
+  const microChips = [
+    { x: laneX + 8 },
+    { x: laneX + 38 },
+    { x: laneX + 68 },
+    { x: laneX + 98 },
+  ];
+  const macroChips = [
+    { x: laneX + 18 },
+    { x: laneX + 78 },
+  ];
+  const chipW = 22;
+  const chipH = 18;
+
+  // Indicator parks at the rightmost micro chip's center (drained position).
+  const indicatorX = microChips[3].x + chipW / 2;
+  const indicatorY = microY + laneH / 2 - 2;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Micro lane (terracotta-tinted) */}
+      <rect x={laneX} y={microY} width={laneW} height={laneH} rx={8} fill={ACCENT_TINT} stroke={ACCENT_TINT_STROKE} strokeWidth={1.4} />
+      {/* Macro lane (muted) */}
+      <rect x={laneX} y={macroY} width={laneW} height={laneH} rx={8} fill={SURFACE} stroke={RULE} strokeWidth={1.4} />
+
+      {/* Lane label dots */}
+      <circle cx={laneX - 10} cy={microY + laneH / 2} r={2.4} fill={ACCENT} />
+      <circle cx={laneX - 10} cy={macroY + laneH / 2} r={2.4} fill={MUTED} />
+
+      {/* Loop track curve */}
+      <path
+        d={`M ${laneX + laneW + 4} ${microY + laneH / 2} C ${laneX + laneW + 22} ${microY + laneH / 2}, ${laneX + laneW + 22} ${macroY + laneH / 2}, ${laneX + laneW + 4} ${macroY + laneH / 2}`}
+        fill="none"
+        stroke={RULE}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        opacity={0.6}
+      />
+      {/* Tail back to left */}
+      <path
+        d={`M ${laneX + laneW + 4} ${macroY + laneH / 2} L ${laneX + laneW + 14} ${macroY + laneH / 2} L ${laneX + laneW + 14} ${microY - 18} L ${laneX - 10} ${microY - 18} L ${laneX - 10} ${microY + laneH / 2 - 14}`}
+        fill="none"
+        stroke={RULE}
+        strokeWidth={1.2}
+        strokeLinecap="round"
+        strokeDasharray="3 3"
+        opacity={0.55}
+      />
+
+      {/* Micro chips — all drained (faded) */}
+      {microChips.map((c, i) => (
+        <rect
+          key={`micro-${i}`}
+          x={c.x}
+          y={microY + (laneH - chipH) / 2}
+          width={chipW}
+          height={chipH}
+          rx={3}
+          fill={ACCENT}
+          stroke={ACCENT}
+          strokeWidth={1.4}
+          opacity={0}
+        />
+      ))}
+
+      {/* Macro chip 0 — in fade-state (firing) */}
+      <rect
+        x={macroChips[0].x}
+        y={macroY + (laneH - chipH) / 2}
+        width={chipW}
+        height={chipH}
+        rx={3}
+        fill={SURFACE}
+        stroke={MUTED}
+        strokeWidth={1.6}
+        opacity={0.2}
+      />
+      {/* Macro chip 1 — static, waiting */}
+      <rect
+        x={macroChips[1].x}
+        y={macroY + (laneH - chipH) / 2}
+        width={chipW}
+        height={chipH}
+        rx={3}
+        fill={SURFACE}
+        stroke={MUTED}
+        strokeWidth={1.6}
+      />
+
+      {/* Indicator at far right of micro lane */}
+      <g transform={`translate(${indicatorX} ${indicatorY})`}>
+        <circle cx={0} cy={0} r={16} fill={ACCENT_WASH} opacity={0.7} />
+        <path d="M -5 -16 L 5 -16 L 0 -8 Z" fill={ACCENT} />
+      </g>
+    </svg>
+  );
+}

--- a/components/covers/WebpageReadsAgentCover.tsx
+++ b/components/covers/WebpageReadsAgentCover.tsx
@@ -375,3 +375,159 @@ export function WebpageReadsAgentCover() {
     </g>
   );
 }
+
+/**
+ * WebpageReadsAgentCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: scanner ring near right edge (~150), all 3
+ * hidden ×-glyphs revealed at full opacity (the metaphor: scan complete,
+ * hidden instructions exposed).
+ */
+export function WebpageReadsAgentCoverStatic() {
+  const ACCENT = "#d97341";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+
+  // Scanner parked near right edge.
+  const scannerX = 150;
+
+  const noiseGlyphs = [
+    { type: "tri" as const, cx: 28, cy: 40 },
+    { type: "circ" as const, cx: 175, cy: 38 },
+    { type: "x" as const, cx: 50, cy: 175 },
+    { type: "tri" as const, cx: 168, cy: 168 },
+    { type: "circ" as const, cx: 30, cy: 110 },
+    { type: "x" as const, cx: 180, cy: 100 },
+    { type: "circ" as const, cx: 22, cy: 80 },
+    { type: "tri" as const, cx: 178, cy: 130 },
+    { type: "x" as const, cx: 170, cy: 60 },
+  ];
+
+  const textStubs = [
+    { x: 36, y: 60, w: 80 },
+    { x: 36, y: 80, w: 110 },
+    { x: 36, y: 100, w: 70 },
+    { x: 36, y: 120, w: 100 },
+    { x: 36, y: 140, w: 60 },
+  ];
+
+  const headerStubs = [
+    { x: 36, y: 42, w: 18 },
+    { x: 58, y: 42, w: 22 },
+    { x: 84, y: 42, w: 14 },
+  ];
+
+  const corners = [
+    { x: 16, y: 16, dx: 6, dy: 6 },
+    { x: 184, y: 16, dx: -6, dy: 6 },
+    { x: 16, y: 184, dx: 6, dy: -6 },
+    { x: 184, y: 184, dx: -6, dy: -6 },
+  ];
+
+  const hiddenGlyphs = [
+    { gx: 70, gy: 80 },
+    { gx: 110, gy: 120 },
+    { gx: 145, gy: 100 },
+  ];
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Background noise glyphs */}
+      {noiseGlyphs.map((g, i) => {
+        if (g.type === "tri") {
+          return (
+            <path
+              key={`noise-${i}`}
+              d={`M ${g.cx} ${g.cy - 3} L ${g.cx + 3} ${g.cy + 2} L ${g.cx - 3} ${g.cy + 2} Z`}
+              fill="none"
+              stroke={MUTED}
+              strokeWidth={0.8}
+              opacity={0.13}
+            />
+          );
+        }
+        if (g.type === "circ") {
+          return (
+            <circle
+              key={`noise-${i}`}
+              cx={g.cx}
+              cy={g.cy}
+              r={2.5}
+              fill="none"
+              stroke={MUTED}
+              strokeWidth={0.8}
+              opacity={0.13}
+            />
+          );
+        }
+        return (
+          <g key={`noise-${i}`} opacity={0.13}>
+            <line x1={g.cx - 2.5} y1={g.cy - 2.5} x2={g.cx + 2.5} y2={g.cy + 2.5} stroke={MUTED} strokeWidth={0.8} />
+            <line x1={g.cx - 2.5} y1={g.cy + 2.5} x2={g.cx + 2.5} y2={g.cy - 2.5} stroke={MUTED} strokeWidth={0.8} />
+          </g>
+        );
+      })}
+
+      {/* Viewfinder corners */}
+      {corners.map((c, i) => (
+        <g key={`corner-${i}`} opacity={0.45}>
+          <line x1={c.x} y1={c.y} x2={c.x + c.dx} y2={c.y} stroke={MUTED} strokeWidth={1.2} strokeLinecap="round" />
+          <line x1={c.x} y1={c.y} x2={c.x} y2={c.y + c.dy} stroke={MUTED} strokeWidth={1.2} strokeLinecap="round" />
+        </g>
+      ))}
+
+      {/* Page outline */}
+      <rect x={28} y={32} width={144} height={130} rx={4} fill={SURFACE} stroke={MUTED} strokeWidth={1.6} />
+
+      {/* Header stubs */}
+      {headerStubs.map((s, i) => (
+        <rect key={`hdr-${i}`} x={s.x} y={s.y} width={s.w} height={2.4} rx={1.2} fill={MUTED} opacity={0.7} />
+      ))}
+      <line x1={32} y1={48} x2={168} y2={48} stroke={MUTED} strokeWidth={0.6} opacity={0.3} />
+
+      {/* Text stubs */}
+      {textStubs.map((s, i) => (
+        <rect key={`stub-${i}`} x={s.x} y={s.y} width={s.w} height={1.8} rx={0.9} fill={MUTED} opacity={0.7} />
+      ))}
+
+      {/* Invisibility-grid */}
+      {[40, 60, 80, 100, 120, 140].map((x) => (
+        <circle key={`grid-${x}`} cx={x} cy={54} r={0.5} fill={MUTED} opacity={0.3} />
+      ))}
+
+      {/* Hidden ×-glyphs — fully revealed */}
+      {hiddenGlyphs.map((g, i) => (
+        <g key={`hidden-${i}`}>
+          <line x1={g.gx - 3} y1={g.gy - 3} x2={g.gx + 3} y2={g.gy + 3} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" />
+          <line x1={g.gx - 3} y1={g.gy + 3} x2={g.gx + 3} y2={g.gy - 3} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" />
+          <line x1={g.gx} y1={g.gy - 6} x2={g.gx} y2={g.gy - 4.5} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+          <line x1={g.gx} y1={g.gy + 6} x2={g.gx} y2={g.gy + 4.5} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+          <line x1={g.gx - 6} y1={g.gy} x2={g.gx - 4.5} y2={g.gy} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+          <line x1={g.gx + 6} y1={g.gy} x2={g.gx + 4.5} y2={g.gy} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        </g>
+      ))}
+
+      {/* Comet trail behind scanner */}
+      <circle cx={scannerX - 6} cy={100} r={1.6} fill={ACCENT} opacity={0.5} />
+      <circle cx={scannerX - 12} cy={100} r={1.4} fill={ACCENT} opacity={0.4} />
+      <circle cx={scannerX - 18} cy={100} r={1.2} fill={ACCENT} opacity={0.3} />
+      <circle cx={scannerX - 24} cy={100} r={1} fill={ACCENT} opacity={0.22} />
+      <circle cx={scannerX - 30} cy={100} r={0.9} fill={ACCENT} opacity={0.15} />
+
+      {/* Scanner ring + handle + reticle */}
+      <g transform={`translate(${scannerX} 0)`}>
+        <circle cx={0} cy={100} r={13} fill="none" stroke={ACCENT} strokeWidth={1.8} />
+        <circle cx={0} cy={100} r={1.6} fill={ACCENT} />
+        <line x1={-3} y1={100} x2={-1.5} y2={100} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={1.5} y1={100} x2={3} y2={100} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={0} y1={97} x2={0} y2={98.5} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={0} y1={101.5} x2={0} y2={103} stroke={ACCENT} strokeWidth={1} strokeLinecap="round" />
+        <line x1={9} y1={109} x2={16} y2={116} stroke={ACCENT} strokeWidth={2.2} strokeLinecap="round" />
+      </g>
+    </svg>
+  );
+}

--- a/components/covers/WhyFetchFailsCover.tsx
+++ b/components/covers/WhyFetchFailsCover.tsx
@@ -240,3 +240,53 @@ export function WhyFetchFailsCover() {
     </g>
   );
 }
+
+/**
+ * WhyFetchFailsCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: comet bounced back at far-left, wall solid,
+ * ✕ visible, 2 echo-rings frozen at mid-expansion (the "impact moment").
+ */
+export function WhyFetchFailsCoverStatic() {
+  const ACCENT = "#d97341";
+  const TEXT = "#f8f5f0";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+
+  const wallX = 122;
+  const impactX = 116;
+  const beamY = 100;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Browser silhouette */}
+      <rect x={140} y={56} width={48} height={88} rx={5} fill={SURFACE} stroke={MUTED} strokeWidth={1.6} opacity={0.55} />
+      <line x1={140} y1={68} x2={188} y2={68} stroke={MUTED} strokeWidth={1.2} opacity={0.5} />
+      <circle cx={146} cy={62} r={1.6} fill={MUTED} opacity={0.55} />
+      <circle cx={152} cy={62} r={1.6} fill={MUTED} opacity={0.45} />
+      <circle cx={158} cy={62} r={1.6} fill={MUTED} opacity={0.4} />
+
+      {/* Wall */}
+      <rect x={wallX - 4} y={36} width={8} height={128} rx={3} fill={TEXT} />
+
+      {/* ✕ on wall */}
+      <line x1={wallX - 6} y1={beamY - 6} x2={wallX + 6} y2={beamY + 6} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" />
+      <line x1={wallX - 6} y1={beamY + 6} x2={wallX + 6} y2={beamY - 6} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" />
+
+      {/* Echo rings — frozen mid-expansion */}
+      <circle cx={impactX} cy={beamY} r={12} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.7} />
+      <circle cx={impactX} cy={beamY} r={20} fill="none" stroke={ACCENT} strokeWidth={1.6} opacity={0.45} />
+
+      {/* Comet bounced back to far-left */}
+      <rect x={16} y={beamY - 8} width={16} height={16} rx={4} fill={ACCENT} />
+      {/* Trail dots leading from bounce */}
+      <circle cx={40} cy={beamY} r={2.5} fill={ACCENT} opacity={0.4} />
+      <circle cx={52} cy={beamY} r={2} fill={ACCENT} opacity={0.28} />
+      <circle cx={64} cy={beamY} r={1.5} fill={ACCENT} opacity={0.18} />
+    </svg>
+  );
+}

--- a/components/covers/static-registry.ts
+++ b/components/covers/static-registry.ts
@@ -1,0 +1,43 @@
+import type { JSX } from "react";
+import { HowGmailCoverStatic } from "./HowGmailCover";
+import { WhyFetchFailsCoverStatic } from "./WhyFetchFailsCover";
+import { BrowserStoppedAskingCoverStatic } from "./BrowserStoppedAskingCover";
+import { FunctionRememberedCoverStatic } from "./FunctionRememberedCover";
+import { WebpageReadsAgentCoverStatic } from "./WebpageReadsAgentCover";
+import { LineThatWaitsItsTurnCoverStatic } from "./LineThatWaitsItsTurnCover";
+import { HowJavascriptReadsItsOwnFutureCoverStatic } from "./HowJavascriptReadsItsOwnFutureCover";
+
+/**
+ * Server-safe registry of pure-JSX static cover components, keyed by post slug.
+ *
+ * Why this exists: Satori (`next/og`) renders pure JSX → PNG and does not
+ * execute React hooks or `motion/react`. Each animated cover therefore has a
+ * sibling `<Name>CoverStatic` export that matches the cover's reduced-motion
+ * end-state (per `docs/svg-cover-playbook.md §8`). The OG route looks up by
+ * slug and composes the static cover into the share-preview tile.
+ *
+ * Hex palette used inside every static export (Satori has limited
+ * CSS-variable support, so tokens are inlined as hex):
+ *
+ *   BG       = "#0e1114"  (the OG canvas background)
+ *   SURFACE  = "#1a1714"
+ *   RULE     = "#2a2622"
+ *   TEXT     = "#f8f5f0"
+ *   MUTED    = "#7a7570"
+ *   ACCENT   = "#d97341"  (terracotta — the load-bearing accent)
+ *
+ * Where the animated cover used `color-mix()` (also unsupported by Satori),
+ * the static export approximates with a hex value composited over BG.
+ *
+ * Keep this file `"use client"`-free — it must be importable from edge
+ * runtime contexts (the `/og/[slug]` route).
+ */
+export const STATIC_COVERS: Record<string, () => JSX.Element> = {
+  "how-gmail-knows-your-email-is-taken": HowGmailCoverStatic,
+  "why-fetch-fails-only-in-browser": WhyFetchFailsCoverStatic,
+  "the-browser-stopped-asking": BrowserStoppedAskingCoverStatic,
+  "the-function-that-remembered": FunctionRememberedCoverStatic,
+  "the-webpage-that-reads-the-agent": WebpageReadsAgentCoverStatic,
+  "the-line-that-waits-its-turn": LineThatWaitsItsTurnCoverStatic,
+  "how-javascript-reads-its-own-future": HowJavascriptReadsItsOwnFutureCoverStatic,
+};


### PR DESCRIPTION
## Summary
Each post's share-preview tile now uses the same artwork as the home-list thumbnail and post hero — left half is the cover's meaningful end-state, right half is title + hook + date. Previously the share-preview was typography-only and didn't visually match anywhere else on the site.

### What changed
- Every cover component now exports a sibling \`<Name>CoverStatic\` — pure JSX matching the cover's reduced-motion end-state per \`docs/svg-cover-playbook.md §8\`. No hooks, no \`motion.*\`, no \`useId\` — Satori is a pure JSX→PNG renderer.
- \`components/covers/static-registry.ts\` maps slug → static-cover function.
- \`app/og/[slug]/route.tsx\` is now a 2-up composition: cover (480×480) on the left, title + hook + date on the right. Unknown slugs (\`_default\`, \`/about\`, etc.) fall through to the previous typographic design — homepage still gets a tile.
- Hex palette inlined in static exports (Satori doesn't resolve CSS variables); matches the existing OG route palette.

## Test plan
- [ ] Build green; \`tsc --noEmit\` clean.
- [ ] Vercel preview URL — hit \`/og/the-line-that-waits-its-turn\`, \`/og/how-javascript-reads-its-own-future\`, and one older slug (\`/og/how-gmail-knows-your-email-is-taken\`). Confirm each renders 1200×630 with cover art on the left.
- [ ] Hit \`/og/_default\` — confirms the typographic fallback still renders for the homepage tile.
- [ ] After merge + deploy, force-rescrape via Facebook debugger / LinkedIn post inspector / Telegram \`@WebpageBot\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)