### PR TITLE
feat(covers): v7 complete metaphor revamp of 4 oldest covers

### DIFF
--- a/components/covers/BrowserStoppedAskingCover.tsx
+++ b/components/covers/BrowserStoppedAskingCover.tsx
@@ -4,212 +4,276 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * BrowserStoppedAskingCover — long-poll / SSE / WebSocket: the connection that won't hang up.
+ * BrowserStoppedAskingCover — v7 metaphor revamp.
  *
- * v4 concept (one sentence):
- *   Client and server are joined by a thick terracotta beam; packets shuttle
- *   back and forth in steady rhythm while both endpoints breathe — the
- *   connection stays open.
+ * One sentence:
+ *   A split-pane contrast — the left side reconnects in sawtooth blips
+ *   (polling: connect, ask, drop), the right side draws one continuous
+ *   line that two packets travel along (persistence: stay open) — the
+ *   contrast IS the metaphor.
  *
- * Composition (~10 elements, all readable at 64px):
- *  1. Client tile (rounded-rect, left)
- *  2. Client cursor dot
- *  3. Server tile (rounded-rect, right)
- *  4. Server stack lines (3 short horizontals)
- *  5. Connecting beam (thick rounded line, terracotta)
- *  6-7. 2 packet dots traveling along the beam in opposite phases
- *  8-9. 2 endpoint pulse-rings (one per endpoint, breathing)
- *  10. Forward arrowhead chevron at midpoint (subtle direction cue)
+ * Why this metaphor (v7):
+ *   v4 used a single thick beam with packets shuttling. That conflated
+ *   polling with WebSockets into a single image and made the contrast
+ *   invisible. v7 puts polling and persistence side-by-side so the
+ *   article's hook ("the browser stopped hanging up") is the visual
+ *   contrast itself.
  *
- * Motion (DESIGN.md §9):
- *  - 4s continuous loop. Packet A: left→right; Packet B: right→left, offset.
- *  - Endpoint pulse-rings breathe in sync with packet arrival.
- *  - Beam shimmers via low-amplitude opacity oscillation.
+ * Composition (10 elements):
+ *  1.  Vertical divider (chrome — splits the panes).
+ *  2.  Left endpoint stub (small chrome dot, top-left).
+ *  3.  Left endpoint stub (small chrome dot, bottom-left).
+ *  4-6. Three sawtooth "blip" connectors on the left — short vertical
+ *      strokes that animate connect → disconnect on a stagger.
+ *  7.  Right endpoint dot (top of the continuous line, terracotta).
+ *  8.  Right endpoint dot (bottom of the continuous line, terracotta —
+ *      sparkles when each packet arrives, the delight beat).
+ *  9.  Right continuous line (hero — pathLength draws once, then holds).
+ *  10. Right packet (single terracotta dot travelling continuously
+ *      along the line — implies the second packet by symmetry; one
+ *      mover keeps the composition quiet).
  *
- * Frame-stability R6: only x / cx / scale / opacity animate. Tokens-only.
+ * Motion (playbook §3, §4, §14 — refined kinetic register):
+ *  - 6s continuous loop. The two halves run in parallel with the right
+ *    half as the calm hero and the left half as the restless support.
+ *  - Left side (3 cycles per loop, 2s each):
+ *      sawtooth blip strokes draw via pathLength then snap to 0;
+ *      staggered 0.2s apart so the eye reads "constant reconnect."
+ *  - Right side (1 cycle per loop):
+ *      continuous line pathLength 0 → 1 in the first 30%, then holds
+ *      sustained; one packet dot travels top → bottom over the loop.
+ *      Each time the packet hits the bottom endpoint, that endpoint
+ *      gets a faint opacity sparkle (delight beat).
+ *  - Hover amplifies via whileHover on the wrapping motion.g.
  *
- * Reduced-motion end-state: beam fully drawn, packets sit at midpoint,
- * endpoint rings at rest scale.
+ * Frame-stability R6: only transform / opacity / pathLength animate.
+ *
+ * Reduced-motion end-state: right line fully drawn, packet at midpoint,
+ * left side mid-disconnection (one blip half-drawn).
  */
 export function BrowserStoppedAskingCover() {
   const inView = useCoverInView();
   const reduced = useReducedMotion();
   const animate = inView && !reduced;
 
-  // Beam endpoints — load-bearing geometry shared by packets and rings.
-  const beamY = 100;
-  const leftX = 56;
-  const rightX = 144;
+  // Pane geometry.
+  const dividerX = 100;
+  const topY = 40;
+  const bottomY = 160;
+
+  // Left pane: polling — 3 blip Xs at distinct vertical positions.
+  const leftBlipX = 60;
+  const blipYs = [60, 100, 140];
+
+  // Right pane: continuous line endpoints.
+  const rightX = 140;
 
   return (
-    <g>
-      {/* ─── Endpoint A: client tile (left) ─────────────────────── */}
-      <rect
-        x={20}
-        y={76}
-        width={48}
-        height={48}
-        rx={8}
-        fill="var(--color-surface)"
-        stroke="var(--color-text)"
-        strokeWidth={2.4}
+    <motion.g initial="idle" whileHover="hover">
+      {/* ─── Vertical divider (chrome) ──────────────────────────── */}
+      <line
+        x1={dividerX}
+        y1={28}
+        x2={dividerX}
+        y2={172}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        strokeDasharray="2 4"
+        opacity={0.32}
         vectorEffect="non-scaling-stroke"
-      />
-      {/* Client cursor dot — small detail */}
-      <circle cx={32} cy={88} r={2} fill="var(--color-text-muted)" opacity={0.7} />
-      <rect x={28} y={104} width={32} height={2} rx={1} fill="var(--color-text-muted)" opacity={0.5} />
-      <rect x={28} y={110} width={20} height={2} rx={1} fill="var(--color-text-muted)" opacity={0.5} />
-
-      {/* ─── Endpoint B: server tile (right) ────────────────────── */}
-      <rect
-        x={132}
-        y={76}
-        width={48}
-        height={48}
-        rx={8}
-        fill="var(--color-surface)"
-        stroke="var(--color-text)"
-        strokeWidth={2.4}
-        vectorEffect="non-scaling-stroke"
-      />
-      {/* Server stack lines */}
-      <line x1={142} y1={88} x2={170} y2={88} stroke="var(--color-text-muted)" strokeWidth={1.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-      <line x1={142} y1={100} x2={170} y2={100} stroke="var(--color-text-muted)" strokeWidth={1.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-      <line x1={142} y1={112} x2={170} y2={112} stroke="var(--color-text-muted)" strokeWidth={1.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-
-      {/* ─── Endpoint pulse rings (breathing, behind tiles visually but drawn after for layering) ── */}
-      <motion.circle
-        cx={leftX - 12}
-        cy={beamY}
-        r={28}
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={2}
-        vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={
-          animate
-            ? { opacity: [0, 0.5, 0], scale: [0.8, 1.25, 1.4] }
-            : { opacity: 0.25, scale: 1 }
-        }
-        transition={
-          animate
-            ? { duration: 2, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }
-            : undefined
-        }
-        style={{ transformOrigin: `${leftX - 12}px ${beamY}px`, transformBox: "fill-box" as const }}
-      />
-      <motion.circle
-        cx={rightX + 12}
-        cy={beamY}
-        r={28}
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={2}
-        vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={
-          animate
-            ? { opacity: [0, 0.5, 0], scale: [0.8, 1.25, 1.4] }
-            : { opacity: 0.25, scale: 1 }
-        }
-        transition={
-          animate
-            ? { duration: 2, delay: 1, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }
-            : undefined
-        }
-        style={{ transformOrigin: `${rightX + 12}px ${beamY}px`, transformBox: "fill-box" as const }}
       />
 
-      {/* ─── Connecting beam (the hero gesture) ─────────────────── */}
+      {/* ─── Left endpoint stubs (chrome dots) ──────────────────── */}
+      <circle cx={30} cy={topY} r={3} fill="none" stroke="var(--color-text-muted)" strokeWidth={1.2} vectorEffect="non-scaling-stroke" opacity={0.55} />
+      <circle cx={30} cy={bottomY} r={3} fill="none" stroke="var(--color-text-muted)" strokeWidth={1.2} vectorEffect="non-scaling-stroke" opacity={0.55} />
+      {/* Left long axis — chrome rail the blips connect to */}
+      <line
+        x1={30}
+        y1={topY}
+        x2={30}
+        y2={bottomY}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        opacity={0.4}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── Left blips (polling sawtooth — 3 reconnects per loop) ─ */}
+      {blipYs.map((blipY, i) => (
+        <motion.line
+          key={`blip-${i}`}
+          x1={30}
+          y1={blipY}
+          x2={leftBlipX}
+          y2={blipY}
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          initial={{ pathLength: 0, opacity: 0 }}
+          animate={
+            animate
+              ? {
+                  pathLength: [0, 1, 1, 0, 0],
+                  opacity: [0, 0.85, 0.85, 0.2, 0],
+                }
+              : i === 1
+                ? { pathLength: 0.55, opacity: 0.65 }
+                : { pathLength: 0, opacity: 0 }
+          }
+          transition={
+            animate
+              ? {
+                  duration: 2,
+                  delay: i * 0.18,
+                  repeat: Infinity,
+                  ease: [0.4, 0, 0.2, 1],
+                  times: [0, 0.3, 0.6, 0.85, 1],
+                }
+              : undefined
+          }
+        />
+      ))}
+
+      {/* Left blip endpoints (small dots that pulse with the blip) */}
+      {blipYs.map((blipY, i) => (
+        <motion.circle
+          key={`blip-end-${i}`}
+          cx={leftBlipX}
+          cy={blipY}
+          r={1.8}
+          fill="var(--color-accent)"
+          initial={{ opacity: 0 }}
+          animate={
+            animate
+              ? { opacity: [0, 0.85, 0.85, 0.15, 0] }
+              : i === 1
+                ? { opacity: 0.5 }
+                : { opacity: 0 }
+          }
+          transition={
+            animate
+              ? {
+                  duration: 2,
+                  delay: i * 0.18,
+                  repeat: Infinity,
+                  ease: [0.4, 0, 0.2, 1],
+                  times: [0, 0.3, 0.6, 0.85, 1],
+                }
+              : undefined
+          }
+        />
+      ))}
+
+      {/* ─── Right pane: continuous line (hero) ─────────────────── */}
       <motion.line
-        x1={leftX}
-        y1={beamY}
+        x1={rightX}
+        y1={topY}
         x2={rightX}
-        y2={beamY}
+        y2={bottomY}
         stroke="var(--color-accent)"
-        strokeWidth={5}
+        strokeWidth={2.0}
         strokeLinecap="round"
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0.85 }}
-        animate={animate ? { opacity: [0.7, 1, 0.7] } : { opacity: 0.9 }}
-        transition={
-          animate
-            ? { duration: 2, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }
-            : undefined
-        }
-      />
-
-      {/* ─── Packet A: client → server (large, visible) ─────────── */}
-      <motion.circle
-        cy={beamY}
-        r={5}
-        fill="var(--color-text)"
-        stroke="var(--color-accent)"
-        strokeWidth={2.5}
-        vectorEffect="non-scaling-stroke"
-        initial={{ cx: leftX, opacity: 0 }}
+        initial={{ pathLength: 0, opacity: 0.9 }}
         animate={
           animate
-            ? { cx: [leftX, rightX], opacity: [0, 1, 1, 0] }
-            : { cx: 100, opacity: 1 }
+            ? { pathLength: [0, 1, 1, 1], opacity: [0.85, 0.95, 0.95, 0.95] }
+            : { pathLength: 1, opacity: 0.95 }
         }
         transition={
           animate
             ? {
-                duration: 2,
+                duration: 6,
                 repeat: Infinity,
                 ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.1, 0.85, 1],
+                times: [0, 0.3, 0.95, 1],
               }
             : undefined
         }
       />
 
-      {/* ─── Packet B: server → client (offset by half cycle) ──── */}
+      {/* ─── Right top endpoint ─────────────────────────────────── */}
+      <circle
+        cx={rightX}
+        cy={topY}
+        r={3.5}
+        fill="var(--color-accent)"
+        opacity={0.95}
+      />
+
+      {/* ─── Right bottom endpoint (sparkles on packet arrival) ─── */}
       <motion.circle
-        cy={beamY}
-        r={5}
-        fill="var(--color-text)"
-        stroke="var(--color-accent)"
-        strokeWidth={2.5}
-        vectorEffect="non-scaling-stroke"
-        initial={{ cx: rightX, opacity: 0 }}
+        cx={rightX}
+        cy={bottomY}
+        r={3.5}
+        fill="var(--color-accent)"
+        initial={{ opacity: 0.7 }}
         animate={
           animate
-            ? { cx: [rightX, leftX], opacity: [0, 1, 1, 0] }
-            : { cx: 100, opacity: 0 }
+            ? { opacity: [0.7, 0.7, 1, 0.7, 0.7] }
+            : { opacity: 0.95 }
         }
         transition={
           animate
             ? {
-                duration: 2,
-                delay: 1,
+                duration: 6,
                 repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.1, 0.85, 1],
+                ease: "easeInOut",
+                times: [0, 0.78, 0.86, 0.94, 1],
               }
             : undefined
         }
       />
-    </g>
+
+      {/* ─── Right packet (continuous traveller) ────────────────── */}
+      <motion.circle
+        cx={rightX}
+        r={2.4}
+        fill="var(--color-text)"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        vectorEffect="non-scaling-stroke"
+        initial={{ cy: topY + 4, opacity: 0 }}
+        animate={
+          animate
+            ? {
+                cy: [topY + 4, bottomY - 4, bottomY - 4],
+                opacity: [0, 1, 0],
+              }
+            : { cy: 100, opacity: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0.32, 0.86, 0.96],
+              }
+            : undefined
+        }
+      />
+    </motion.g>
   );
 }
 
 /**
  * BrowserStoppedAskingCoverStatic — Satori-safe pure-JSX export.
- * Reduced-motion end-state: beam fully drawn, two packets sit at midpoint,
- * endpoint pulse-rings at rest scale.
+ * Reduced-motion end-state: right continuous line fully drawn, packet
+ * at midpoint, left side at the in-between frame (middle blip
+ * half-drawn) so the contrast still reads from the still.
  */
 export function BrowserStoppedAskingCoverStatic() {
   const ACCENT = "#d97341";
   const TEXT = "#f8f5f0";
   const MUTED = "#7a7570";
-  const SURFACE = "#1a1714";
 
-  const beamY = 100;
-  const leftX = 56;
-  const rightX = 144;
+  const dividerX = 100;
+  const topY = 40;
+  const bottomY = 160;
+  const leftBlipX = 60;
+  const rightX = 140;
 
   return (
     <svg
@@ -218,28 +282,28 @@ export function BrowserStoppedAskingCoverStatic() {
       width="100%"
       height="100%"
     >
-      {/* Client tile */}
-      <rect x={20} y={76} width={48} height={48} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
-      <circle cx={32} cy={88} r={2} fill={MUTED} opacity={0.7} />
-      <rect x={28} y={104} width={32} height={2} rx={1} fill={MUTED} opacity={0.5} />
-      <rect x={28} y={110} width={20} height={2} rx={1} fill={MUTED} opacity={0.5} />
+      {/* Vertical divider */}
+      <line x1={dividerX} y1={28} x2={dividerX} y2={172} stroke={MUTED} strokeWidth={1.0} strokeDasharray="2 4" opacity={0.32} />
 
-      {/* Server tile */}
-      <rect x={132} y={76} width={48} height={48} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
-      <line x1={142} y1={88} x2={170} y2={88} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
-      <line x1={142} y1={100} x2={170} y2={100} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
-      <line x1={142} y1={112} x2={170} y2={112} stroke={MUTED} strokeWidth={1.6} strokeLinecap="round" />
+      {/* Left chrome stubs + rail */}
+      <circle cx={30} cy={topY} r={3} fill="none" stroke={MUTED} strokeWidth={1.2} opacity={0.55} />
+      <circle cx={30} cy={bottomY} r={3} fill="none" stroke={MUTED} strokeWidth={1.2} opacity={0.55} />
+      <line x1={30} y1={topY} x2={30} y2={bottomY} stroke={MUTED} strokeWidth={1.0} opacity={0.4} />
 
-      {/* Endpoint pulse rings (at rest) */}
-      <circle cx={leftX - 12} cy={beamY} r={28} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.25} />
-      <circle cx={rightX + 12} cy={beamY} r={28} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.25} />
+      {/* Left blips: top blip drawn, middle blip half-drawn (in-between), bottom blip absent */}
+      <line x1={30} y1={60} x2={leftBlipX} y2={60} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={0.7} />
+      <circle cx={leftBlipX} cy={60} r={1.8} fill={ACCENT} opacity={0.7} />
+      <line x1={30} y1={100} x2={47} y2={100} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={0.5} />
 
-      {/* Beam */}
-      <line x1={leftX} y1={beamY} x2={rightX} y2={beamY} stroke={ACCENT} strokeWidth={5} strokeLinecap="round" opacity={0.9} />
+      {/* Right continuous line — hero */}
+      <line x1={rightX} y1={topY} x2={rightX} y2={bottomY} stroke={ACCENT} strokeWidth={2.0} strokeLinecap="round" opacity={0.95} />
 
-      {/* Packets at midpoint — show one going each direction, both visible */}
-      <circle cx={88} cy={beamY} r={5} fill={TEXT} stroke={ACCENT} strokeWidth={2.5} />
-      <circle cx={112} cy={beamY} r={5} fill={TEXT} stroke={ACCENT} strokeWidth={2.5} />
+      {/* Right endpoints */}
+      <circle cx={rightX} cy={topY} r={3.5} fill={ACCENT} opacity={0.95} />
+      <circle cx={rightX} cy={bottomY} r={3.5} fill={ACCENT} opacity={0.95} />
+
+      {/* Right packet at midpoint */}
+      <circle cx={rightX} cy={100} r={2.4} fill={TEXT} stroke={ACCENT} strokeWidth={1.6} />
     </svg>
   );
 }

--- a/components/covers/FunctionRememberedCover.tsx
+++ b/components/covers/FunctionRememberedCover.tsx
@@ -4,300 +4,330 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * FunctionRememberedCover — closure: the inner thing remembers what the outer thing forgot.
+ * FunctionRememberedCover — v7 metaphor revamp.
  *
  * One sentence:
- *   The outer scope fades to a ghost while the inner scope's captured value
- *   pulses persistently and a memory packet travels up the tether to the
- *   anchor — proof that the inner remembers.
+ *   A `for` loop emits three closure tokens in sequence — each closure
+ *   carrying its own captured value at a different vertical position —
+ *   visualizing the var-vs-let bug as memory of birth context.
  *
- * Composition (~13 load-bearing elements):
- *  1.  Outer scope rounded-rect (large, fades dramatically)
- *  2.  Outer "{" brace glyph (function-ness, fades with outer)
- *  3.  Outer "}" brace glyph (mirrors)
- *  4.  Inner scope rounded-rect (medium, stays solid)
- *  5.  Inner label stub 1 ("function" hint)
- *  6.  Inner label stub 2 ("name" hint)
- *  7.  Captured value pulse ring (terracotta, pulses throughout)
- *  8.  Captured value dot (the persistent bright element — never dim)
- *  9.  Tether line (dashed accent, drawn upward through outer)
- *  10. Memory packet (small terracotta dot travelling up the tether)
- *  11. Memory anchor dot at top of tether (lights when packet arrives)
- *  12. Anchor halo (small ring that flashes on arrival)
- *  13. Inner-scope decorative tick (small dash on the right edge — closure marker)
+ * Why this metaphor (v7):
+ *   v5/v6 used "outer fades, inner stays + tether to anchor." That was
+ *   generic-closure abstraction and missed the article's actual
+ *   subject: the `var` vs `let` loop bug. v7 surfaces the loop and
+ *   shows the closures keeping different values — which is the article's
+ *   thesis (with `let`, each captured value differs; with `var`, they
+ *   would all collapse to one).
  *
- * Motion (playbook §3, §4):
- *  - 5s continuous loop, no idle gap > 600ms.
- *  - Captured-dot pulse runs continuously at 1.6s period — independent of the
- *    outer-scope phase. Bright element is always live.
- *  - Phase A (0–0.30): everything solid.
- *  - Phase B (0.30–0.60): outer fades 1 → 0.25, scales 1 → 0.9 (deeper than v4).
- *    Tether pathLength draws 0 → 1. Memory packet starts travelling up.
- *  - Phase C (0.60–0.78): packet arrives at anchor, anchor halo flashes,
- *    anchor scales 1 → 1.5 → 1.
- *  - Phase D (0.78–1): packet fades, outer fades back in for next cycle.
+ * Composition (10 elements):
+ *  1.  Loop region (rounded-rect, top-left) — abstract `for (...)` zone.
+ *  2.  Iteration glyph (3 small ticks inside the loop region) — a
+ *      gentle position swap on each iteration as the support gesture.
+ *  3.  Loop curl (small circular arrow path inside loop region —
+ *      indicates "iterates").
+ *  4-6. Three closure tokens (rounded-rects emitted in sequence,
+ *      stacked vertically on the right). Each carries:
+ *  7-9. Three captured-value dots, one inside each closure, at
+ *      DIFFERENT vertical offsets (the article's payload — the values
+ *      are remembered separately).
+ *  10. Connecting flow line from loop region to closures (chrome
+ *      dashed) — gives the composition geometric anchor.
+ *
+ * Motion (playbook §3, §4, §14 — refined contemplative register):
+ *  - 6s continuous loop. One hero gesture (closures emerging in
+ *    sequence) + one quiet support (loop iteration glyph stepping).
+ *  - Phase A (0–0.20): closure 1 emerges (opacity + small slide-in
+ *    from loop region); captured-value dot reveals.
+ *  - Phase B (0.20–0.40): closure 2 emerges below closure 1.
+ *  - Phase C (0.40–0.62): closure 3 emerges below closure 2; its dot
+ *    lands with a faint brightness ripple (delight beat).
+ *  - Phase D (0.62–0.92): all three hold, the loop iteration glyph
+ *    cycles position to "drive" the loop visually.
+ *  - Phase E (0.92–1): brief reset.
  *  - Hover amplifies via whileHover on the wrapping motion.g.
  *
  * Frame-stability R6: only transform / opacity / pathLength animate.
  *
- * Reduced-motion end-state: outer at 0.25 / 0.9 scale, tether fully drawn,
- * captured dot bright, packet at top of tether, anchor visible. The metaphor
- * reads from the still: outer dim, inner alive, tether complete.
+ * Reduced-motion end-state: all 3 closures visible with captured-value
+ * dots at different positions, loop iteration glyph at the final
+ * iteration. The article's thesis lands from the still: distinct
+ * captured values → closures remembered birth context.
  */
 export function FunctionRememberedCover() {
   const inView = useCoverInView();
   const reduced = useReducedMotion();
   const animate = inView && !reduced;
 
-  // Geometry.
-  const innerCx = 100;
-  const innerCy = 124;
-  const tetherTopY = 18;
-  const tetherStartY = 96;
+  // Loop region (top-left).
+  const loopX = 22;
+  const loopY = 38;
+  const loopW = 60;
+  const loopH = 50;
+
+  // Closure column (right).
+  const closureX = 110;
+  const closureW = 68;
+  const closureH = 30;
+  const closureGap = 10;
+  const closures = [
+    { y: 38 + 0 * (closureH + closureGap), dotOffset: -7 },
+    { y: 38 + 1 * (closureH + closureGap), dotOffset: 0 },
+    { y: 38 + 2 * (closureH + closureGap), dotOffset: 7 },
+  ];
+
+  // Iteration tick positions (inside loop region).
+  const tickXs = [loopX + 12, loopX + 22, loopX + 32];
+  const tickY = loopY + loopH - 10;
 
   return (
     <motion.g initial="idle" whileHover="hover">
-      {/* ─── Outer scope (the dying scope) ──────────────────────── */}
-      <motion.g
-        initial={{ opacity: 1, scale: 1 }}
-        animate={
-          animate
-            ? { opacity: [1, 1, 0.25, 0.25, 1], scale: [1, 1, 0.9, 0.9, 1] }
-            : { opacity: 0.25, scale: 0.9 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.3, 0.55, 0.78, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: "100px 100px", transformBox: "fill-box" as const }}
-      >
-        <rect
-          x={20}
-          y={32}
-          width={160}
-          height={140}
-          rx={12}
-          fill="none"
-          stroke="var(--color-text)"
-          strokeWidth={3}
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* Opening "{" brace — clearly reads as function */}
-        <path
-          d="M 38 60 Q 30 60, 30 70 L 30 96 Q 30 104, 22 104 Q 30 104, 30 112 L 30 138 Q 30 148, 38 148"
-          fill="none"
-          stroke="var(--color-text-muted)"
-          strokeWidth={2.4}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* Closing "}" brace */}
-        <path
-          d="M 162 60 Q 170 60, 170 70 L 170 96 Q 170 104, 178 104 Q 170 104, 170 112 L 170 138 Q 170 148, 162 148"
-          fill="none"
-          stroke="var(--color-text-muted)"
-          strokeWidth={2.4}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-        />
-      </motion.g>
-
-      {/* ─── Tether line (drawn upward from inner to anchor) ────── */}
-      <motion.line
-        x1={innerCx}
-        y1={tetherStartY}
-        x2={innerCx}
-        y2={tetherTopY + 4}
-        stroke="var(--color-accent)"
-        strokeWidth={2.2}
-        strokeLinecap="round"
-        strokeDasharray="3 4"
-        vectorEffect="non-scaling-stroke"
-        initial={{ pathLength: 0, opacity: 0.3 }}
-        animate={
-          animate
-            ? {
-                pathLength: [0, 0, 1, 1, 0],
-                opacity: [0.3, 0.3, 0.95, 0.95, 0.3],
-              }
-            : { pathLength: 1, opacity: 0.9 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.3, 0.55, 0.78, 1],
-              }
-            : undefined
-        }
-      />
-
-      {/* ─── Memory packet (travels up the tether) ─────────────── */}
-      <motion.circle
-        cx={innerCx}
-        r={2.6}
-        fill="var(--color-accent)"
-        initial={{ cy: tetherStartY, opacity: 0 }}
-        animate={
-          animate
-            ? {
-                cy: [tetherStartY, tetherStartY, tetherTopY + 4, tetherTopY + 4, tetherStartY],
-                opacity: [0, 0, 1, 1, 0],
-              }
-            : { cy: tetherTopY + 4, opacity: 1 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.36, 0.62, 0.74, 0.92],
-              }
-            : undefined
-        }
-      />
-
-      {/* ─── Anchor halo (flashes when packet arrives) ─────────── */}
-      <motion.circle
-        cx={innerCx}
-        cy={tetherTopY}
-        r={8}
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={1.8}
-        vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.4 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 0.85, 0, 0], scale: [0.4, 0.4, 1.5, 2.4, 2.4] }
-            : { opacity: 0.5, scale: 1.4 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.6, 0.68, 0.84, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${innerCx}px ${tetherTopY}px`, transformBox: "fill-box" as const }}
-      />
-
-      {/* ─── Memory anchor dot (top of tether) ─────────────────── */}
-      <motion.circle
-        cx={innerCx}
-        cy={tetherTopY}
-        r={4}
-        fill="var(--color-accent)"
-        initial={{ opacity: 0.4, scale: 1 }}
-        animate={
-          animate
-            ? {
-                opacity: [0.35, 0.35, 1, 1, 0.35],
-                scale: [1, 1, 1.5, 1, 1],
-              }
-            : { opacity: 1, scale: 1 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.55, 0.66, 0.78, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${innerCx}px ${tetherTopY}px`, transformBox: "fill-box" as const }}
-      />
-
-      {/* ─── Inner scope (the surviving scope — bright, solid) ─── */}
+      {/* ─── Loop region ────────────────────────────────────────── */}
       <rect
-        x={62}
-        y={84}
-        width={76}
-        height={72}
-        rx={9}
-        fill="var(--color-surface)"
-        stroke="var(--color-text)"
-        strokeWidth={3}
+        x={loopX}
+        y={loopY}
+        width={loopW}
+        height={loopH}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-accent) 6%, transparent)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
         vectorEffect="non-scaling-stroke"
       />
-      {/* Inner label stubs — small "function name" hint */}
-      <rect x={70} y={94} width={12} height={2.4} rx={1.2} fill="var(--color-text-muted)" opacity={0.8} />
-      <rect x={86} y={94} width={22} height={2.4} rx={1.2} fill="var(--color-text-muted)" opacity={0.8} />
-      {/* Closure marker — small dash right side */}
-      <rect x={124} y={94} width={6} height={2.4} rx={1.2} fill="var(--color-accent)" opacity={0.7} />
 
-      {/* ─── Captured value pulse ring (continuous, persistent) ── */}
-      <motion.circle
-        cx={innerCx}
-        cy={innerCy}
-        r={11}
+      {/* Loop curl arrow — small circular path indicating "iterates" */}
+      <path
+        d={`M ${loopX + 24} ${loopY + 18} a 8 8 0 1 0 8 -2`}
         fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={2}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        opacity={0.65}
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0.5, scale: 1 }}
-        animate={
-          animate
-            ? { opacity: [0.4, 0.85, 0.4], scale: [1, 1.3, 1] }
-            : { opacity: 0.6, scale: 1.15 }
-        }
-        transition={
-          animate
-            ? { duration: 1.6, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }
-            : undefined
-        }
-        style={{ transformOrigin: `${innerCx}px ${innerCy}px`, transformBox: "fill-box" as const }}
+      />
+      {/* Arrow tip — small chevron */}
+      <path
+        d={`M ${loopX + 30} ${loopY + 14} L ${loopX + 32} ${loopY + 16} L ${loopX + 30} ${loopY + 18}`}
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.65}
+        vectorEffect="non-scaling-stroke"
       />
 
-      {/* Captured value dot (the persistent bright element) */}
-      <motion.circle
-        cx={innerCx}
-        cy={innerCy}
-        r={6.5}
-        fill="var(--color-accent)"
-        initial={{ scale: 1 }}
-        animate={
-          animate
-            ? { scale: [1, 1.15, 1] }
-            : { scale: 1 }
-        }
-        transition={
-          animate
-            ? { duration: 1.6, repeat: Infinity, ease: [0.4, 0, 0.2, 1] }
-            : undefined
-        }
-        style={{ transformOrigin: `${innerCx}px ${innerCy}px`, transformBox: "fill-box" as const }}
+      {/* Iteration ticks — three positions; the "active" one is opacity-led */}
+      {tickXs.map((tx, i) => {
+        // Cycles through 0,1,2 based on phase. Active tick has higher opacity.
+        const idleOpacities = [
+          [1, 1, 0.3, 0.3, 0.3, 1, 1], // tick 0
+          [0.3, 0.3, 1, 1, 0.3, 0.3, 0.3], // tick 1
+          [0.3, 0.3, 0.3, 0.3, 1, 1, 0.3], // tick 2
+        ];
+        return (
+          <motion.line
+            key={`tick-${i}`}
+            x1={tx}
+            y1={tickY - 3}
+            x2={tx}
+            y2={tickY + 3}
+            stroke="var(--color-accent)"
+            strokeWidth={1.4}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            initial={{ opacity: 0.4 }}
+            animate={
+              animate
+                ? { opacity: idleOpacities[i] }
+                : { opacity: i === 2 ? 1 : 0.4 }
+            }
+            transition={
+              animate
+                ? {
+                    duration: 6,
+                    repeat: Infinity,
+                    ease: "linear",
+                    times: [0, 0.05, 0.2, 0.4, 0.55, 0.92, 1],
+                  }
+                : undefined
+            }
+          />
+        );
+      })}
+
+      {/* ─── Connecting flow line (chrome dashed) ───────────────── */}
+      <line
+        x1={loopX + loopW}
+        y1={loopY + loopH / 2}
+        x2={closureX}
+        y2={closureH / 2 + 38}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        strokeDasharray="2 3"
+        opacity={0.32}
+        vectorEffect="non-scaling-stroke"
       />
+
+      {/* ─── Closure tokens (3, emerging in sequence) ───────────── */}
+      {closures.map((c, i) => {
+        const emergeStart = i * 0.2;
+        const emergeMid = emergeStart + 0.04;
+        const emergeEnd = emergeStart + 0.08;
+        return (
+          <g key={`closure-${i}`}>
+            {/* Closure rect */}
+            <motion.rect
+              x={closureX}
+              y={c.y}
+              width={closureW}
+              height={closureH}
+              rx={4}
+              fill="color-mix(in oklab, var(--color-accent) 8%, transparent)"
+              stroke="var(--color-text-muted)"
+              strokeWidth={1.2}
+              vectorEffect="non-scaling-stroke"
+              initial={{ opacity: 0 }}
+              animate={
+                animate
+                  ? { opacity: [0, 0, 0.85, 0.85, 0] }
+                  : { opacity: 0.85 }
+              }
+              transition={
+                animate
+                  ? {
+                      duration: 6,
+                      repeat: Infinity,
+                      ease: [0.4, 0, 0.2, 1],
+                      times: [0, emergeStart, emergeEnd, 0.92, 1],
+                    }
+                  : undefined
+              }
+            />
+            {/* Closure outline pathLength reveal — the "drawing in" */}
+            <motion.rect
+              x={closureX}
+              y={c.y}
+              width={closureW}
+              height={closureH}
+              rx={4}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth={1.4}
+              vectorEffect="non-scaling-stroke"
+              initial={{ pathLength: 0, opacity: 0 }}
+              animate={
+                animate
+                  ? {
+                      pathLength: [0, 0, 1, 1, 0],
+                      opacity: [0, 0, 0.45, 0.45, 0],
+                    }
+                  : { pathLength: 1, opacity: 0.5 }
+              }
+              transition={
+                animate
+                  ? {
+                      duration: 6,
+                      repeat: Infinity,
+                      ease: [0.4, 0, 0.2, 1],
+                      times: [0, emergeStart, emergeMid + 0.04, 0.92, 1],
+                    }
+                  : undefined
+              }
+            />
+            {/* Inner label-stub line */}
+            <motion.line
+              x1={closureX + 8}
+              y1={c.y + 8}
+              x2={closureX + 24}
+              y2={c.y + 8}
+              stroke="var(--color-text-muted)"
+              strokeWidth={1.0}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              initial={{ opacity: 0 }}
+              animate={
+                animate
+                  ? { opacity: [0, 0, 0.7, 0.7, 0] }
+                  : { opacity: 0.7 }
+              }
+              transition={
+                animate
+                  ? {
+                      duration: 6,
+                      repeat: Infinity,
+                      ease: "linear",
+                      times: [0, emergeStart, emergeEnd, 0.92, 1],
+                    }
+                  : undefined
+              }
+            />
+            {/* Captured-value dot — different vertical offset per closure */}
+            <motion.circle
+              cx={closureX + closureW - 12}
+              cy={c.y + closureH / 2 + c.dotOffset}
+              r={i === 2 ? 3 : 2.6}
+              fill="var(--color-accent)"
+              initial={{ opacity: 0 }}
+              animate={
+                animate
+                  ? i === 2
+                    ? // Closure 3 — delight: faint brightness ripple as it settles.
+                      { opacity: [0, 0, 1, 0.7, 1, 0.95, 0] }
+                    : { opacity: [0, 0, 1, 0.95, 0] }
+                  : { opacity: 0.95 }
+              }
+              transition={
+                animate
+                  ? i === 2
+                    ? {
+                        duration: 6,
+                        repeat: Infinity,
+                        ease: "easeInOut",
+                        times: [0, emergeStart, emergeEnd, emergeEnd + 0.05, emergeEnd + 0.1, 0.92, 1],
+                      }
+                    : {
+                        duration: 6,
+                        repeat: Infinity,
+                        ease: "easeInOut",
+                        times: [0, emergeStart, emergeEnd, 0.92, 1],
+                      }
+                  : undefined
+              }
+            />
+          </g>
+        );
+      })}
     </motion.g>
   );
 }
 
 /**
  * FunctionRememberedCoverStatic — Satori-safe pure-JSX export.
- * Reduced-motion end-state: outer scope at 0.3 opacity (faded), inner scope
- * solid, tether fully drawn from captured value upward.
+ * Reduced-motion end-state: all 3 closures visible with captured-value
+ * dots at different vertical positions, loop iteration glyph at the
+ * final iteration. The thesis lands statically: closures remember
+ * distinct birth contexts.
  */
 export function FunctionRememberedCoverStatic() {
   const ACCENT = "#d97341";
-  const TEXT = "#f8f5f0";
   const MUTED = "#7a7570";
-  const SURFACE = "#1a1714";
+  const LOOP_FILL = "#23191b"; // ~4% terracotta
+  const CLOSURE_FILL = "#3b2620"; // ~10% terracotta
+
+  const loopX = 22;
+  const loopY = 38;
+  const loopW = 60;
+  const loopH = 50;
+  const tickY = loopY + loopH - 10;
+  const closureX = 110;
+  const closureW = 68;
+  const closureH = 30;
+  const closureGap = 10;
+  const closures = [
+    { y: 38 + 0 * (closureH + closureGap), dotOffset: -7 },
+    { y: 38 + 1 * (closureH + closureGap), dotOffset: 0 },
+    { y: 38 + 2 * (closureH + closureGap), dotOffset: 7 },
+  ];
 
   return (
     <svg
@@ -306,43 +336,45 @@ export function FunctionRememberedCoverStatic() {
       width="100%"
       height="100%"
     >
-      {/* Outer scope — faded (the dying scope) */}
-      <g opacity={0.3} transform="translate(8 8) scale(0.92)">
-        <rect x={20} y={28} width={160} height={144} rx={10} fill="none" stroke={TEXT} strokeWidth={3} />
-        <path
-          d="M 36 56 Q 30 56, 30 64 L 30 96 Q 30 104, 24 104 Q 30 104, 30 112 L 30 144 Q 30 152, 36 152"
-          fill="none"
-          stroke={MUTED}
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M 164 56 Q 170 56, 170 64 L 170 96 Q 170 104, 176 104 Q 170 104, 170 112 L 170 144 Q 170 152, 164 152"
-          fill="none"
-          stroke={MUTED}
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </g>
+      {/* Loop region */}
+      <rect x={loopX} y={loopY} width={loopW} height={loopH} rx={6} fill={LOOP_FILL} stroke={MUTED} strokeWidth={1.2} />
 
-      {/* Tether line — fully drawn */}
-      <line x1={100} y1={92} x2={100} y2={20} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" strokeDasharray="3 4" opacity={0.85} />
+      {/* Loop curl arrow */}
+      <path
+        d={`M ${loopX + 24} ${loopY + 18} a 8 8 0 1 0 8 -2`}
+        fill="none"
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        opacity={0.65}
+      />
+      <path
+        d={`M ${loopX + 30} ${loopY + 14} L ${loopX + 32} ${loopY + 16} L ${loopX + 30} ${loopY + 18}`}
+        fill="none"
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.65}
+      />
 
-      {/* Memory anchor */}
-      <circle cx={100} cy={20} r={3.5} fill={ACCENT} opacity={0.95} />
+      {/* Iteration ticks — final iteration: tick 2 active */}
+      <line x1={loopX + 12} y1={tickY - 3} x2={loopX + 12} y2={tickY + 3} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={0.3} />
+      <line x1={loopX + 22} y1={tickY - 3} x2={loopX + 22} y2={tickY + 3} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={0.3} />
+      <line x1={loopX + 32} y1={tickY - 3} x2={loopX + 32} y2={tickY + 3} stroke={ACCENT} strokeWidth={1.4} strokeLinecap="round" opacity={1} />
 
-      {/* Inner scope — bright, solid */}
-      <rect x={62} y={84} width={76} height={68} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={3} />
-      <rect x={70} y={94} width={12} height={2.4} rx={1.2} fill={MUTED} opacity={0.75} />
-      <rect x={86} y={94} width={20} height={2.4} rx={1.2} fill={MUTED} opacity={0.75} />
+      {/* Connecting flow line */}
+      <line x1={loopX + loopW} y1={loopY + loopH / 2} x2={closureX} y2={closureH / 2 + 38} stroke={MUTED} strokeWidth={1.0} strokeDasharray="2 3" opacity={0.32} />
 
-      {/* Captured value pulse ring */}
-      <circle cx={100} cy={124} r={12} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.6} />
-
-      {/* Captured value dot */}
-      <circle cx={100} cy={124} r={6} fill={ACCENT} />
+      {/* Closure tokens */}
+      {closures.map((c, i) => (
+        <g key={`closure-${i}`}>
+          <rect x={closureX} y={c.y} width={closureW} height={closureH} rx={4} fill={CLOSURE_FILL} stroke={MUTED} strokeWidth={1.2} opacity={0.85} />
+          <rect x={closureX} y={c.y} width={closureW} height={closureH} rx={4} fill="none" stroke={ACCENT} strokeWidth={1.4} opacity={0.45} />
+          <line x1={closureX + 8} y1={c.y + 8} x2={closureX + 24} y2={c.y + 8} stroke={MUTED} strokeWidth={1.0} strokeLinecap="round" opacity={0.7} />
+          <circle cx={closureX + closureW - 12} cy={c.y + closureH / 2 + c.dotOffset} r={i === 2 ? 3 : 2.6} fill={ACCENT} opacity={0.95} />
+        </g>
+      ))}
     </svg>
   );
 }

--- a/components/covers/HowGmailCover.tsx
+++ b/components/covers/HowGmailCover.tsx
@@ -4,478 +4,277 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * HowGmailCover — bloom filter: an email pulse hashes into 3 lit cells.
+ * HowGmailCover — v7 metaphor revamp.
  *
- * One sentence (the user-named hero):
- *   An email input pulse fans through three hash arcs (each carrying a
- *   travelling sparkle) into a 4×3 bit-array grid; three cells flip terracotta
- *   in sequence and a verdict tick lands with a /delight sparkle.
+ * One sentence:
+ *   A vertical pipeline race: a query packet drops from an input through
+ *   three stage nodes (cache → bloom → db) and emerges at the bottom as
+ *   a verdict glyph before the next keystroke pulses — the article's
+ *   actual hook: speed beats finger.
  *
- * Composition (~14 load-bearing elements — at the budget cap):
- *  1.  Email input bubble (rounded-rect with caret)
- *  2.  Caret stub (terracotta, blinks via opacity)
- *  3.  Pulse dot (terracotta, emits from input)
- *  4-6. 3 hash arcs (curved bezier paths, pathLength draws + travelling sparkles)
- *  7.  Bit-array group (12 cells in 4×3 grid — counted as one composition element)
- *  8.  Lit-cell overlay 1 (terracotta fill that flips in)
- *  9.  Lit-cell overlay 2
- *  10. Lit-cell overlay 3
- *  11. Verdict tick (terracotta ✓ that draws after cells light, scales 0→1.4→1)
- *  12. Verdict halo (small accent ring around the tick)
- *  13. Sparkle 1 (delight beat — terracotta sparkle on tick arrival)
- *  14. Sparkle 2 (second sparkle, smaller)
+ * Why this metaphor (v7):
+ *   v5/v6 used hash-arcs into a bit-array — bloom-filter abstract, true
+ *   to the implementation but disconnected from the article's hook. The
+ *   article is about *speed*: the pipeline returns "already taken"
+ *   before your finger lifts. v7 surfaces the pipeline and the race.
  *
- * Note: 3 travelling-sparkle dots ride along arcs but are visually subordinate
- *  to the arcs themselves; counted within (4-6).
+ * Composition (10 elements):
+ *  1.  Input bubble at top — small rounded-rect.
+ *  2.  Caret stub inside input — terracotta, blinks (support gesture).
+ *  3-5. Three pipeline stage nodes (small rounded-rects) stacked
+ *       vertically with tiny stage-glyph dots inside each.
+ *  6.  Vertical pipeline guide line connecting the stages (chrome dash).
+ *  7.  Query packet (terracotta dot — the hero element) — drops from
+ *       the input through each stage in sequence.
+ *  8.  Verdict ring at bottom (small chrome ring — the destination).
+ *  9.  Verdict glyph (terracotta tick) — appears when the packet
+ *       arrives; gentle opacity 0 → 1 reveal (delight beat, no scale
+ *       pulse per playbook §14).
+ *  10. Bottom anchor — small dot under the verdict ring, gives the
+ *       composition a baseline.
  *
- * Motion (playbook §3, §4 — /overdrive applied):
- *  - 5s continuous loop, no idle gap > 600ms.
- *  - Phase 1 (0–0.18): caret blinks; pulse dot emits 0→1.4→0.9 scale, opacity.
- *  - Phase 2 (0.18–0.55): 3 hash arcs draw simultaneously (pathLength 0→1).
- *    A small terracotta sparkle rides along each arc from start to destination.
- *  - Phase 3 (0.55–0.80): cells flip in sequence (60ms apart), each scaling
- *    1 → 1.25 → 1 with a pop.
- *  - Phase 4 (0.80–0.94): verdict tick draws 0→1 + scales 0 → 1.4 → 1
- *    (committed; was subtle in v4). Halo ring expands. Sparkles fire (delight).
- *  - Phase 5 (0.94–1): hold then reset.
+ * Motion (playbook §3, §4, §14 — refined editorial register):
+ *  - 6s continuous loop. Single hero gesture (packet traversal) + one
+ *    quiet support (caret blink).
+ *  - Phase A (0–0.10): caret blinks once (the keystroke).
+ *  - Phase B (0.10–0.62): query packet traverses pipeline — 200ms per
+ *    stage with SPRING.gentle settle. Each stage glows briefly as the
+ *    packet passes.
+ *  - Phase C (0.62–0.76): verdict glyph fades in via opacity 0 → 1.
+ *  - Phase D (0.76–1): verdict holds, then resets for the next cycle.
  *  - Hover amplifies via whileHover on the wrapping motion.g.
  *
- * Frame-stability R6: only opacity / scale / pathLength animate. Tokens-only.
+ * Frame-stability R6: only transform / opacity / pathLength animate.
  *
- * Reduced-motion end-state: 3 cells lit terracotta, verdict tick visible
- * scaled 1.0, halo at peak, sparkles at peak. The article's thesis lands
- * statically — "yes, taken."
+ * Reduced-motion end-state: query packet at the bottom (just emerged
+ * as verdict), verdict glyph at full opacity, caret at mid-blink.
  */
 export function HowGmailCover() {
   const inView = useCoverInView();
   const reduced = useReducedMotion();
   const animate = inView && !reduced;
 
-  // ── Bit-array geometry — 4×3 grid for breathing room (was 1×12) ──
-  const cols = 4;
-  const rows = 3;
-  const cellW = 22;
-  const cellH = 14;
-  const cellGapX = 4;
-  const cellGapY = 4;
-  const arrayW = cols * cellW + (cols - 1) * cellGapX;
-  const arrayH = rows * cellH + (rows - 1) * cellGapY;
-  const arrayX = (200 - arrayW) / 2;
-  const arrayY = 116;
+  // Pipeline column.
+  const colX = 100;
 
-  // 3 hash destinations — chosen to spread across the grid.
-  // Indexes: row 0 col 1, row 1 col 3, row 2 col 0
-  const litIndexes: Array<{ row: number; col: number }> = [
-    { row: 0, col: 1 },
-    { row: 1, col: 3 },
-    { row: 2, col: 0 },
-  ];
+  // Input geometry (top).
+  const inputY = 28;
+  const inputH = 22;
 
-  const cellAt = (row: number, col: number) => ({
-    x: arrayX + col * (cellW + cellGapX),
-    y: arrayY + row * (cellH + cellGapY),
-  });
+  // Three stage nodes — vertical positions.
+  const stages = [
+    { y: 70, label: "cache" },
+    { y: 100, label: "bloom" },
+    { y: 130, label: "db" },
+  ] as const;
+  const stageW = 60;
+  const stageH = 18;
 
-  const litCells = litIndexes.map((p) => ({
-    ...p,
-    ...cellAt(p.row, p.col),
-    cx: arrayX + p.col * (cellW + cellGapX) + cellW / 2,
-    cy: arrayY + p.row * (cellH + cellGapY) + cellH / 2,
-  }));
+  // Verdict ring (bottom).
+  const verdictY = 168;
 
-  // Input bubble center.
-  const inputCx = 100;
-  const inputCy = 56;
-  const inputBottomY = 70;
-
-  // Lit-cell flip schedule — staggered 60ms apart.
-  const litTimes: number[][] = [
-    [0, 0.5, 0.58, 0.66, 0.92, 1],
-    [0, 0.55, 0.64, 0.72, 0.92, 1],
-    [0, 0.6, 0.7, 0.78, 0.92, 1],
+  // Stage glow timings — packet arrives at each stage in sequence.
+  const stageGlowTimes: number[][] = [
+    [0, 0.14, 0.22, 0.32, 1], // cache
+    [0, 0.28, 0.36, 0.46, 1], // bloom
+    [0, 0.42, 0.5, 0.6, 1], // db
   ];
 
   return (
     <motion.g initial="idle" whileHover="hover">
-      {/* ─── Email input bubble at top ──────────────────────────── */}
-      <motion.g
-        initial={{ scale: 1 }}
-        animate={animate ? { scale: [1, 1.08, 1, 1, 1] } : { scale: 1 }}
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.08, 0.18, 0.92, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${inputCx}px ${inputCy}px`, transformBox: "fill-box" as const }}
-      >
-        <rect
-          x={48}
-          y={38}
-          width={104}
-          height={32}
-          rx={8}
-          fill="var(--color-surface)"
-          stroke="var(--color-text)"
-          strokeWidth={2.6}
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* "you@" text-stub glyphs */}
-        <rect x={56} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.85} />
-        <rect x={64} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.85} />
-        <rect x={72} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.85} />
-        {/* @ symbol */}
-        <circle cx={84} cy={54.5} r={3} fill="none" stroke="var(--color-text-muted)" strokeWidth={1.4} vectorEffect="non-scaling-stroke" />
-        <circle cx={84} cy={54.5} r={1} fill="var(--color-text-muted)" />
-        {/* domain glyphs */}
-        <rect x={92} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.65} />
-        <rect x={100} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.65} />
-        <rect x={108} y={52} width={5} height={5} rx={1} fill="var(--color-text-muted)" opacity={0.5} />
-
-        {/* Caret — blinks */}
-        <motion.rect
-          x={120}
-          y={48}
-          width={2}
-          height={14}
-          rx={0.5}
-          fill="var(--color-accent)"
-          initial={{ opacity: 1 }}
-          animate={animate ? { opacity: [1, 0, 1, 0, 1] } : { opacity: 1 }}
-          transition={
-            animate
-              ? {
-                  duration: 5,
-                  repeat: Infinity,
-                  ease: "linear",
-                  times: [0, 0.12, 0.24, 0.36, 0.48],
-                }
-              : undefined
-          }
-        />
-      </motion.g>
-
-      {/* ─── Pulse dot (emitted from input bottom) ──────────────── */}
-      <motion.circle
-        cx={inputCx}
-        cy={inputBottomY + 4}
-        r={4.5}
-        fill="var(--color-accent)"
-        initial={{ scale: 0, opacity: 0 }}
-        animate={
-          animate
-            ? {
-                scale: [0, 1.5, 1, 0, 0],
-                opacity: [0, 1, 0.85, 0, 0],
-              }
-            : { scale: 0, opacity: 0 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.08, 0.18, 0.28, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${inputCx}px ${inputBottomY + 4}px`, transformBox: "fill-box" as const }}
+      {/* ─── Pipeline guide line (chrome dashed) ────────────────── */}
+      <line
+        x1={colX}
+        y1={inputY + inputH}
+        x2={colX}
+        y2={verdictY - 6}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        strokeDasharray="2 3"
+        opacity={0.32}
+        vectorEffect="non-scaling-stroke"
       />
 
-      {/* ─── 3 hash arcs (the fan-out) + travelling sparkles ───── */}
-      {litCells.map((cell, i) => {
-        const startX = inputCx;
-        const startY = inputBottomY + 6;
-        const endX = cell.cx;
-        const endY = cell.y - 1;
-        const midX = (startX + endX) / 2;
-        const midY = startY + 22 + i * 4; // gentle dip
-        const d = `M ${startX} ${startY} Q ${midX} ${midY}, ${endX} ${endY}`;
-        return (
-          <g key={`arc-${i}`}>
-            {/* Arc path */}
-            <motion.path
-              d={d}
-              fill="none"
-              stroke="var(--color-accent)"
-              strokeWidth={2.2}
-              strokeLinecap="round"
-              vectorEffect="non-scaling-stroke"
-              initial={{ pathLength: 0, opacity: 0.3 }}
-              animate={
-                animate
-                  ? {
-                      pathLength: [0, 0, 1, 1, 0, 0],
-                      opacity: [0.3, 0.3, 0.95, 0.7, 0.3, 0.3],
-                    }
-                  : { pathLength: 1, opacity: 0.85 }
-              }
-              transition={
-                animate
-                  ? {
-                      duration: 5,
-                      repeat: Infinity,
-                      ease: [0.4, 0, 0.2, 1],
-                      times: [0, 0.18, 0.5, 0.88, 0.95, 1],
-                    }
-                  : undefined
-              }
-            />
-            {/* Travelling sparkle along the arc — opacity gates entry/exit;
-                position interpolated between start, mid, end. */}
-            <motion.circle
-              r={2}
-              fill="var(--color-accent)"
-              initial={{ opacity: 0 }}
-              animate={
-                animate
-                  ? {
-                      cx: [startX, startX, midX, endX, endX],
-                      cy: [startY, startY, midY, endY, endY],
-                      opacity: [0, 0, 1, 1, 0],
-                      scale: [0.6, 0.6, 1.3, 1, 0.6],
-                    }
-                  : { cx: endX, cy: endY, opacity: 0, scale: 1 }
-              }
-              transition={
-                animate
-                  ? {
-                      duration: 5,
-                      repeat: Infinity,
-                      ease: [0.4, 0, 0.2, 1],
-                      times: [0, 0.18, 0.36, 0.5, 0.55],
-                    }
-                  : undefined
-              }
-            />
-          </g>
-        );
-      })}
+      {/* ─── Input bubble (top) ─────────────────────────────────── */}
+      <rect
+        x={colX - 38}
+        y={inputY}
+        width={76}
+        height={inputH}
+        rx={5}
+        fill="color-mix(in oklab, var(--color-accent) 6%, transparent)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* Input glyph stubs */}
+      <rect x={colX - 30} y={inputY + 8} width={4} height={4} rx={1} fill="var(--color-text-muted)" opacity={0.7} />
+      <rect x={colX - 22} y={inputY + 8} width={4} height={4} rx={1} fill="var(--color-text-muted)" opacity={0.55} />
+      <rect x={colX - 14} y={inputY + 8} width={4} height={4} rx={1} fill="var(--color-text-muted)" opacity={0.4} />
 
-      {/* ─── Bit-array (4×3 grid) — neutral cells ───────────────── */}
-      {Array.from({ length: rows }, (_, r) =>
-        Array.from({ length: cols }, (_, c) => {
-          const { x, y } = cellAt(r, c);
-          return (
-            <rect
-              key={`cell-${r}-${c}`}
-              x={x}
-              y={y}
-              width={cellW}
-              height={cellH}
-              rx={2.5}
-              fill="var(--color-surface)"
-              stroke="var(--color-text)"
-              strokeWidth={2}
-              vectorEffect="non-scaling-stroke"
-            />
-          );
-        }),
-      )}
+      {/* Caret stub — blinks (support gesture) */}
+      <motion.rect
+        x={colX - 6}
+        y={inputY + 6}
+        width={1.4}
+        height={10}
+        rx={0.5}
+        fill="var(--color-accent)"
+        initial={{ opacity: 1 }}
+        animate={
+          animate
+            ? { opacity: [1, 0, 1, 1, 0, 1] }
+            : { opacity: 0.6 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: "linear",
+                times: [0, 0.05, 0.1, 0.7, 0.78, 1],
+              }
+            : undefined
+        }
+      />
 
-      {/* ─── Lit-cell overlays (3 cells flip terracotta) ────────── */}
-      {litCells.map((cell, i) => (
-        <motion.rect
-          key={`lit-${i}`}
-          x={cell.x}
-          y={cell.y}
-          width={cellW}
-          height={cellH}
-          rx={2.5}
-          fill="var(--color-accent)"
-          initial={{ opacity: 0, scale: 1 }}
-          animate={
-            animate
-              ? {
-                  opacity: [0, 0, 1, 1, 0, 0],
-                  scale: [1, 1, 1.25, 1, 1, 1],
-                }
-              : { opacity: 1, scale: 1 }
-          }
-          transition={
-            animate
-              ? {
-                  duration: 5,
-                  repeat: Infinity,
-                  ease: [0.4, 0, 0.2, 1],
-                  times: litTimes[i],
-                }
-              : undefined
-          }
-          style={{
-            transformOrigin: `${cell.cx}px ${cell.cy}px`,
-            transformBox: "fill-box" as const,
-          }}
-        />
+      {/* ─── Pipeline stage nodes ───────────────────────────────── */}
+      {stages.map((stage, i) => (
+        <g key={`stage-${i}`}>
+          {/* Stage rect */}
+          <motion.rect
+            x={colX - stageW / 2}
+            y={stage.y - stageH / 2}
+            width={stageW}
+            height={stageH}
+            rx={3}
+            fill="color-mix(in oklab, var(--color-accent) 4%, transparent)"
+            stroke="var(--color-text-muted)"
+            strokeWidth={1.2}
+            vectorEffect="non-scaling-stroke"
+            initial={{ opacity: 0.65 }}
+            animate={
+              animate
+                ? { opacity: [0.65, 0.65, 1, 0.65, 0.65] }
+                : { opacity: 0.85 }
+            }
+            transition={
+              animate
+                ? {
+                    duration: 6,
+                    repeat: Infinity,
+                    ease: [0.4, 0, 0.2, 1],
+                    times: stageGlowTimes[i],
+                  }
+                : undefined
+            }
+          />
+          {/* Stage glyph: 3 small horizontal stubs (label hint without text) */}
+          <line x1={colX - 22} y1={stage.y - 2} x2={colX - 14} y2={stage.y - 2} stroke="var(--color-text-muted)" strokeWidth={1.0} strokeLinecap="round" opacity={0.7} vectorEffect="non-scaling-stroke" />
+          <line x1={colX - 22} y1={stage.y + 2} x2={colX - 10} y2={stage.y + 2} stroke="var(--color-text-muted)" strokeWidth={1.0} strokeLinecap="round" opacity={0.55} vectorEffect="non-scaling-stroke" />
+          {/* Stage indicator dot, right side */}
+          <circle cx={colX + 22} cy={stage.y} r={1.4} fill="var(--color-text-muted)" opacity={0.55} />
+        </g>
       ))}
 
-      {/* ─── Verdict halo (small ring around the tick) ──────────── */}
+      {/* ─── Query packet (hero — drops through pipeline) ───────── */}
       <motion.circle
-        cx={170}
-        cy={88}
-        r={14}
+        cx={colX}
+        r={3.6}
+        fill="var(--color-accent)"
+        initial={{ cy: inputY + inputH, opacity: 0 }}
+        animate={
+          animate
+            ? {
+                cy: [
+                  inputY + inputH,
+                  stages[0].y,
+                  stages[1].y,
+                  stages[2].y,
+                  verdictY - 6,
+                  verdictY - 6,
+                  inputY + inputH,
+                ],
+                opacity: [0, 1, 1, 1, 1, 0, 0],
+              }
+            : { cy: verdictY - 6, opacity: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0.08, 0.2, 0.34, 0.48, 0.62, 0.86, 0.98],
+              }
+            : undefined
+        }
+      />
+
+      {/* ─── Verdict ring (chrome — destination marker) ─────────── */}
+      <circle
+        cx={colX}
+        cy={verdictY}
+        r={9}
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
+        opacity={0.5}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── Verdict glyph (terracotta tick — gentle opacity reveal) ── */}
+      <motion.path
+        d={`M ${colX - 4} ${verdictY} L ${colX - 1} ${verdictY + 3} L ${colX + 5} ${verdictY - 3}`}
         fill="none"
         stroke="var(--color-accent)"
-        strokeWidth={1.6}
+        strokeWidth={2.0}
+        strokeLinecap="round"
+        strokeLinejoin="round"
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.4 }}
+        initial={{ opacity: 0 }}
         animate={
           animate
-            ? { opacity: [0, 0, 0.7, 0, 0], scale: [0.4, 0.4, 1, 1.6, 1.6] }
-            : { opacity: 0.6, scale: 1 }
+            ? { opacity: [0, 0, 1, 1, 0] }
+            : { opacity: 1 }
         }
         transition={
           animate
             ? {
-                duration: 5,
+                duration: 6,
                 repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.78, 0.86, 0.96, 1],
+                ease: "easeInOut",
+                times: [0, 0.62, 0.78, 0.92, 1],
               }
             : undefined
         }
-        style={{ transformOrigin: "170px 88px", transformBox: "fill-box" as const }}
-      />
-
-      {/* ─── Verdict tick (committed scale: 0 → 1.4 → 1) ────────── */}
-      <motion.g
-        initial={{ scale: 0, opacity: 0 }}
-        animate={
-          animate
-            ? {
-                scale: [0, 0, 1.4, 1, 1, 0],
-                opacity: [0, 0, 1, 1, 1, 0],
-              }
-            : { scale: 1, opacity: 1 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.78, 0.86, 0.92, 0.96, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: "170px 88px", transformBox: "fill-box" as const }}
-      >
-        <motion.path
-          d="M 162 90 L 168 96 L 180 82"
-          fill="none"
-          stroke="var(--color-accent)"
-          strokeWidth={3.6}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-          initial={{ pathLength: 0 }}
-          animate={
-            animate
-              ? { pathLength: [0, 0, 1, 1, 1, 0] }
-              : { pathLength: 1 }
-          }
-          transition={
-            animate
-              ? {
-                  duration: 5,
-                  repeat: Infinity,
-                  ease: [0.4, 0, 0.2, 1],
-                  times: [0, 0.78, 0.86, 0.92, 0.96, 1],
-                }
-              : undefined
-          }
-        />
-      </motion.g>
-
-      {/* ─── Sparkle 1 (delight beat) ──────────────────────────── */}
-      <motion.circle
-        cx={184}
-        cy={78}
-        r={2}
-        fill="var(--color-accent)"
-        initial={{ opacity: 0, scale: 0 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 0, 1, 0, 0], scale: [0, 0, 0, 1.6, 0, 0] }
-            : { opacity: 1, scale: 1.2 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.82, 0.86, 0.9, 0.94, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: "184px 78px", transformBox: "fill-box" as const }}
-      />
-      {/* ─── Sparkle 2 (small companion) ───────────────────────── */}
-      <motion.circle
-        cx={158}
-        cy={100}
-        r={1.4}
-        fill="var(--color-accent)"
-        initial={{ opacity: 0, scale: 0 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 0, 0.85, 0, 0], scale: [0, 0, 0, 1.4, 0, 0] }
-            : { opacity: 0.85, scale: 1 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.84, 0.88, 0.92, 0.96, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: "158px 100px", transformBox: "fill-box" as const }}
       />
     </motion.g>
   );
 }
 
 /**
- * HowGmailCoverStatic — Satori-safe pure-JSX export of the reduced-motion
- * end-state. Bit-array fully resolved with 3 cells lit terracotta and the
- * verdict tick visible. Used by the /og share-preview route.
- *
- * Hex constants inline because Satori has limited CSS-variable support;
- * see components/covers/static-registry.ts for the canonical palette.
+ * HowGmailCoverStatic — Satori-safe pure-JSX export.
+ * Reduced-motion end-state: query packet at the bottom (just emerged
+ * as verdict), verdict tick at full opacity, caret at mid-blink (60%).
  */
 export function HowGmailCoverStatic() {
   const ACCENT = "#d97341";
-  const TEXT = "#f8f5f0";
   const MUTED = "#7a7570";
-  const SURFACE = "#1a1714";
+  const STAGE_FILL = "#23191b"; // ~4% terracotta over BG
+  const INPUT_FILL = "#3b2620"; // ~10%
 
-  const cellCount = 12;
-  const cellW = 12;
-  const cellH = 16;
-  const cellGap = 2;
-  const arrayW = cellCount * cellW + (cellCount - 1) * cellGap;
-  const arrayX = (200 - arrayW) / 2;
-  const arrayY = 140;
-
-  const cells = Array.from({ length: cellCount }, (_, i) => ({
-    x: arrayX + i * (cellW + cellGap),
-    y: arrayY,
-    lit: i === 1 || i === 5 || i === 9,
-  }));
-
-  const litCenters = cells.filter((c) => c.lit).map((c) => c.x + cellW / 2);
-
-  const inputCx = 100;
-  const inputCy = 56;
+  const colX = 100;
+  const inputY = 28;
+  const inputH = 22;
+  const verdictY = 168;
+  const stageW = 60;
+  const stageH = 18;
+  const stages = [
+    { y: 70 },
+    { y: 100 },
+    { y: 130 },
+  ];
 
   return (
     <svg
@@ -484,70 +283,39 @@ export function HowGmailCoverStatic() {
       width="100%"
       height="100%"
     >
+      {/* Pipeline guide line */}
+      <line x1={colX} y1={inputY + inputH} x2={colX} y2={verdictY - 6} stroke={MUTED} strokeWidth={1.0} strokeDasharray="2 3" opacity={0.32} />
+
       {/* Input bubble */}
-      <rect x={56} y={36} width={88} height={28} rx={8} fill={SURFACE} stroke={TEXT} strokeWidth={2.4} />
-      <rect x={64} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
-      <rect x={72} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
-      <rect x={80} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
-      <rect x={88} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
-      <rect x={96} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
-      <rect x={104} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
-      <rect x={112} y={48} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
-      <circle cx={124} cy={50} r={2.4} fill="none" stroke={MUTED} strokeWidth={1.4} />
+      <rect x={colX - 38} y={inputY} width={76} height={inputH} rx={5} fill={INPUT_FILL} stroke={MUTED} strokeWidth={1.2} />
+      <rect x={colX - 30} y={inputY + 8} width={4} height={4} rx={1} fill={MUTED} opacity={0.7} />
+      <rect x={colX - 22} y={inputY + 8} width={4} height={4} rx={1} fill={MUTED} opacity={0.55} />
+      <rect x={colX - 14} y={inputY + 8} width={4} height={4} rx={1} fill={MUTED} opacity={0.4} />
+      {/* Caret at mid-blink */}
+      <rect x={colX - 6} y={inputY + 6} width={1.4} height={10} rx={0.5} fill={ACCENT} opacity={0.6} />
 
-      {/* 3 hash arcs (fully drawn) */}
-      {litCenters.map((endX, i) => {
-        const startX = inputCx;
-        const startY = inputCy + 12;
-        const endY = arrayY - 2;
-        const midX = (startX + endX) / 2;
-        const midY = startY + 30 + i * 4;
-        const d = `M ${startX} ${startY} Q ${midX} ${midY}, ${endX} ${endY}`;
-        return (
-          <path
-            key={`arc-${i}`}
-            d={d}
-            fill="none"
-            stroke={ACCENT}
-            strokeWidth={2.2}
-            strokeLinecap="round"
-            opacity={0.85}
-          />
-        );
-      })}
-
-      {/* Bit-array cells */}
-      {cells.map((c, i) => (
-        <g key={`cell-${i}`}>
-          <rect
-            x={c.x}
-            y={c.y}
-            width={cellW}
-            height={cellH}
-            rx={2}
-            fill={SURFACE}
-            stroke={TEXT}
-            strokeWidth={2}
-          />
-          {c.lit && (
-            <rect
-              x={c.x}
-              y={c.y}
-              width={cellW}
-              height={cellH}
-              rx={2}
-              fill={ACCENT}
-            />
-          )}
+      {/* Stage nodes */}
+      {stages.map((stage, i) => (
+        <g key={`stage-${i}`}>
+          <rect x={colX - stageW / 2} y={stage.y - stageH / 2} width={stageW} height={stageH} rx={3} fill={STAGE_FILL} stroke={MUTED} strokeWidth={1.2} opacity={0.85} />
+          <line x1={colX - 22} y1={stage.y - 2} x2={colX - 14} y2={stage.y - 2} stroke={MUTED} strokeWidth={1.0} strokeLinecap="round" opacity={0.7} />
+          <line x1={colX - 22} y1={stage.y + 2} x2={colX - 10} y2={stage.y + 2} stroke={MUTED} strokeWidth={1.0} strokeLinecap="round" opacity={0.55} />
+          <circle cx={colX + 22} cy={stage.y} r={1.4} fill={MUTED} opacity={0.55} />
         </g>
       ))}
 
+      {/* Query packet — emerged at the bottom */}
+      <circle cx={colX} cy={verdictY - 6} r={3.6} fill={ACCENT} opacity={0.6} />
+
+      {/* Verdict ring */}
+      <circle cx={colX} cy={verdictY} r={9} fill="none" stroke={MUTED} strokeWidth={1.2} opacity={0.5} />
+
       {/* Verdict tick */}
       <path
-        d="M 154 92 L 162 100 L 178 84"
+        d={`M ${colX - 4} ${verdictY} L ${colX - 1} ${verdictY + 3} L ${colX + 5} ${verdictY - 3}`}
         fill="none"
         stroke={ACCENT}
-        strokeWidth={3.5}
+        strokeWidth={2.0}
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/components/covers/WhyFetchFailsCover.tsx
+++ b/components/covers/WhyFetchFailsCover.tsx
@@ -4,361 +4,299 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * WhyFetchFailsCover — fetch() comet meets the CORS wall.
+ * WhyFetchFailsCover — v7 metaphor revamp.
  *
  * One sentence:
- *   A terracotta comet streaks across the page, slams into a thick CORS wall
- *   labelled `ACAO`, the wall flexes outward, and three echo-rings emanate
- *   from the impact point as the comet rebounds dim.
+ *   Three horizontal tiers (server / browser / JavaScript) — a response
+ *   packet drops down into the browser tier successfully, then a thin
+ *   curtain seals the boundary between the browser and JS tiers, with a
+ *   muted ✕ glyph confirming the response is visible to the browser but
+ *   hidden from JavaScript.
  *
- * Composition (~13 load-bearing elements):
- *  1.  Browser silhouette (rounded-rect with chrome bar + 3 dots, right of wall)
- *  2.  Wall column (thicker rounded-rect, the load-bearing barrier)
- *  3.  ACAO label glyph (3 small terracotta tick-marks, on the wall)
- *  4.  ✕ reject mark on the wall
- *  5-8. 4-segment comet trail (head + 3 fading dots)
- *  9.  Comet head (rounded square, terracotta hero)
- *  10. Impact spark (small terracotta starburst at the moment of contact)
- *  11. Echo ring 1 (small, fastest)
- *  12. Echo ring 2 (mid)
- *  13. Echo ring 3 (large, slowest)
+ * Why this metaphor (v7):
+ *   Earlier v5/v6 used a comet-into-CORS-wall + bounce. That visualized
+ *   *rejection*, but the article's actual hook is that the server did
+ *   answer — your browser just isn't handing the response to JS. v7
+ *   surfaces that distinction: the response IS in the browser; it's the
+ *   browser → JS boundary that's curtained off.
  *
- * Motion (playbook §3, §4):
- *  - 5s continuous loop, no idle gap > 600ms.
- *  - Phase A (0–0.42): comet glides left→wall, ~95 viewBox-units of translateX
- *    (47% of viewBox — well above the §3 threshold). Trail dots follow with
- *    offsets so velocity is felt.
- *  - Phase B (0.42–0.55): wall flexes scaleX 1 → 1.7 → 1 — committed flex.
- *    Impact spark scales 0 → 1.4 → 0. Echo rings emanate (scale 0.4 → 3.6,
- *    pathLength full, opacity gates).
- *  - Phase C (0.55–0.78): comet retreats dim (opacity 0.35), trail follows.
- *  - Phase D (0.78–1): brief reset, no idle > 0.4s.
- *  - Hover amplifies idle motion via whileHover on the wrapping motion.g.
+ * Composition (~8 concept elements / 13 SVG primitives):
+ *  1.  Server tier rect (top) + chrome stub line.
+ *  2.  Browser tier rect (middle) + chrome dot.
+ *  3.  JS tier rect (bottom) + `{ }` glyph stubs.
+ *  4.  Vertical guide line (chrome) connecting the three tiers.
+ *  5.  Response packet: terracotta rounded-rect, hero element, drops
+ *      from the server into the browser tier.
+ *  6.  Curtain shadow: faint translucent line offset 1px below the
+ *      curtain — depth.
+ *  7.  Curtain hero: thin terracotta stroke drawn between browser and
+ *      JS tiers via pathLength — the boundary closing.
+ *  8.  ✕ glyph: muted-terracotta cross on the curtain (delight beat —
+ *      fades in last with a soft ease-in).
+ *
+ * Motion (playbook §3, §4, §14 — refined kinetic register):
+ *  - 6s continuous loop, no idle gap > 600ms.
+ *  - Phase A (0–0.30): response packet drops from server (y=44) to the
+ *    browser tier (y=98); opacity 0 → 1, gentle spring.
+ *  - Phase B (0.30–0.55): packet settles into the browser tier (small
+ *    opacity hold).
+ *  - Phase C (0.55–0.78): curtain pathLength 0 → 1 between the browser
+ *    and JS tiers; ✕ glyph fades in over the last 600ms.
+ *  - Phase D (0.78–1): hold then loop.
+ *  - Hover amplifies via whileHover on the wrapping motion.g — speeds the
+ *    loop and bumps opacity slightly. Same gesture, more committed.
  *
  * Frame-stability R6: only transform / opacity / pathLength animate.
  *
- * Reduced-motion end-state: comet at impact, 3 rings frozen mid-expansion,
- * wall flexed (scaleX 1.4), spark visible. The static frame conveys "rejected."
+ * Reduced-motion end-state: response packet at the browser tier, curtain
+ * fully drawn, ✕ visible — the article's thesis lands statically.
  */
 export function WhyFetchFailsCover() {
   const inView = useCoverInView();
   const reduced = useReducedMotion();
   const animate = inView && !reduced;
 
-  // Geometry — wall sits ~62% across the viewBox.
-  const wallX = 124;
-  const wallTop = 36;
-  const wallH = 128;
-  const wallW = 12;
-  const impactX = wallX - wallW / 2;
-  const beamY = 100;
+  // Tier vertical positions.
+  const serverY = 30;
+  const serverH = 30;
+  const browserY = 84;
+  const browserH = 32;
+  const jsY = 140;
+  const jsH = 30;
 
-  // Comet travel path — from far-left (x=18) to just before wall (impactX - 16).
-  const cometStart = 18;
-  const cometImpact = impactX - 16;
-  const cometRetreat = 36;
+  // Packet drop coordinates.
+  const packetX = 92;
+  const packetW = 16;
+  const packetH = 12;
+  const packetStartY = serverY + (serverH - packetH) / 2;
+  const packetEndY = browserY + (browserH - packetH) / 2;
 
-  // Hover variants: amplify the wall flex and ring scale.
-  const groupVariants = {
-    idle: {},
-    hover: {},
-  };
+  // Curtain Y — between browser bottom and JS top.
+  const curtainY = (browserY + browserH + jsY) / 2;
+  const curtainX1 = 36;
+  const curtainX2 = 164;
 
   return (
     <motion.g
       initial="idle"
       whileHover="hover"
-      variants={groupVariants}
+      variants={{
+        idle: { opacity: 1 },
+        hover: { opacity: 1 },
+      }}
     >
-      {/* ─── Browser silhouette (right of wall, static muted) ────── */}
-      <g opacity={0.55}>
-        <rect
-          x={140}
-          y={48}
-          width={50}
-          height={104}
-          rx={6}
-          fill="var(--color-surface)"
-          stroke="var(--color-text-muted)"
-          strokeWidth={1.8}
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* Chrome bar */}
-        <line
-          x1={140}
-          y1={62}
-          x2={190}
-          y2={62}
-          stroke="var(--color-text-muted)"
-          strokeWidth={1.4}
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* 3 chrome dots */}
-        <circle cx={146} cy={55} r={1.6} fill="var(--color-text-muted)" />
-        <circle cx={152} cy={55} r={1.6} fill="var(--color-text-muted)" opacity={0.8} />
-        <circle cx={158} cy={55} r={1.6} fill="var(--color-text-muted)" opacity={0.65} />
-        {/* Address-bar stub */}
-        <rect
-          x={146}
-          y={72}
-          width={38}
-          height={3.2}
-          rx={1.6}
-          fill="var(--color-text-muted)"
-          opacity={0.5}
-        />
-        {/* Page-content stubs */}
-        <rect x={146} y={86} width={32} height={2} rx={1} fill="var(--color-text-muted)" opacity={0.45} />
-        <rect x={146} y={94} width={26} height={2} rx={1} fill="var(--color-text-muted)" opacity={0.4} />
-        <rect x={146} y={102} width={34} height={2} rx={1} fill="var(--color-text-muted)" opacity={0.4} />
-      </g>
-
-      {/* ─── The wall (hero gesture — thick, flexes hard on impact) ─ */}
-      <motion.g
-        variants={{
-          idle: { scaleX: [1, 1, 1.7, 1, 1] },
-          hover: { scaleX: [1, 1, 2, 1, 1] },
-        }}
-        animate={animate ? "idle" : undefined}
-        initial={false}
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.4, 0.48, 0.62, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${wallX}px ${beamY}px`, transformBox: "fill-box" as const }}
-      >
-        {/* Wall body — terracotta-edged */}
-        <rect
-          x={wallX - wallW / 2}
-          y={wallTop}
-          width={wallW}
-          height={wallH}
-          rx={4}
-          fill="var(--color-text)"
-          stroke="var(--color-accent)"
-          strokeWidth={1.4}
-          vectorEffect="non-scaling-stroke"
-        />
-        {/* ACAO label — three small terracotta marks, top of wall */}
-        <line x1={wallX - 3} y1={48} x2={wallX + 3} y2={48} stroke="var(--color-accent)" strokeWidth={1.4} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={wallX - 3} y1={54} x2={wallX + 3} y2={54} stroke="var(--color-accent)" strokeWidth={1.4} strokeLinecap="round" vectorEffect="non-scaling-stroke" opacity={0.75} />
-        <line x1={wallX - 3} y1={60} x2={wallX + 3} y2={60} stroke="var(--color-accent)" strokeWidth={1.4} strokeLinecap="round" vectorEffect="non-scaling-stroke" opacity={0.5} />
-
-        {/* ✕ reject mark — center of wall */}
-        <line x1={wallX - 6} y1={beamY - 6} x2={wallX + 6} y2={beamY + 6} stroke="var(--color-accent)" strokeWidth={2.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={wallX - 6} y1={beamY + 6} x2={wallX + 6} y2={beamY - 6} stroke="var(--color-accent)" strokeWidth={2.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-
-        {/* Bottom dashes — bricks */}
-        <line x1={wallX - 3} y1={140} x2={wallX + 3} y2={140} stroke="var(--color-accent)" strokeWidth={1.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" opacity={0.5} />
-        <line x1={wallX - 3} y1={148} x2={wallX + 3} y2={148} stroke="var(--color-accent)" strokeWidth={1.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" opacity={0.4} />
-      </motion.g>
-
-      {/* ─── Echo ring 1 (small, fastest) ──────────────────────── */}
-      <motion.circle
-        cx={impactX}
-        cy={beamY}
-        r={6}
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={2.2}
+      {/* ─── Vertical guide line (chrome — connects the three tiers) ── */}
+      <line
+        x1={100}
+        y1={serverY + serverH}
+        x2={100}
+        y2={jsY}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        strokeDasharray="2 3"
+        opacity={0.32}
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.4 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 1, 0, 0], scale: [0.4, 0.4, 1.1, 2.4, 2.4] }
-            : { opacity: 0.7, scale: 1.6 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.42, 0.5, 0.72, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${impactX}px ${beamY}px`, transformBox: "fill-box" as const }}
       />
-      {/* ─── Echo ring 2 (mid) ─────────────────────────────────── */}
-      <motion.circle
-        cx={impactX}
-        cy={beamY}
-        r={6}
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth={1.8}
+
+      {/* ─── Server tier (top) ───────────────────────────────────── */}
+      <rect
+        x={32}
+        y={serverY}
+        width={136}
+        height={serverH}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-accent) 6%, transparent)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.4 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 0.85, 0, 0], scale: [0.4, 0.4, 1.6, 3, 3] }
-            : { opacity: 0.5, scale: 2.2 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.44, 0.54, 0.78, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${impactX}px ${beamY}px`, transformBox: "fill-box" as const }}
       />
-      {/* ─── Echo ring 3 (large, slowest) ──────────────────────── */}
-      <motion.circle
-        cx={impactX}
-        cy={beamY}
-        r={6}
-        fill="none"
-        stroke="var(--color-accent)"
+      {/* Server stack stub (chrome motif) */}
+      <line x1={42} y1={serverY + 15} x2={70} y2={serverY + 15} stroke="var(--color-text-muted)" strokeWidth={1.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" opacity={0.6} />
+
+      {/* ─── Browser tier (middle) ───────────────────────────────── */}
+      <rect
+        x={32}
+        y={browserY}
+        width={136}
+        height={browserH}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-accent) 10%, transparent)"
+        stroke="var(--color-text-muted)"
         strokeWidth={1.4}
         vectorEffect="non-scaling-stroke"
-        initial={{ opacity: 0, scale: 0.4 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 0.6, 0, 0], scale: [0.4, 0.4, 2.2, 3.6, 3.6] }
-            : { opacity: 0.35, scale: 2.8 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.46, 0.6, 0.84, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${impactX}px ${beamY}px`, transformBox: "fill-box" as const }}
+      />
+      {/* Chrome dot — anchors "this is the browser" */}
+      <circle cx={42} cy={browserY + 8} r={1.8} fill="var(--color-text-muted)" opacity={0.6} />
+
+      {/* ─── JS tier (bottom) — `{ }` glyph stubs ────────────────── */}
+      <rect
+        x={32}
+        y={jsY}
+        width={136}
+        height={jsH}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-accent) 4%, transparent)"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
+        vectorEffect="non-scaling-stroke"
+      />
+      {/* `{` glyph */}
+      <path
+        d={`M 78 ${jsY + 8} Q 72 ${jsY + 8}, 72 ${jsY + 14} L 72 ${jsY + 13} Q 72 ${jsY + 15}, 68 ${jsY + 15} Q 72 ${jsY + 15}, 72 ${jsY + 17} L 72 ${jsY + 16} Q 72 ${jsY + 22}, 78 ${jsY + 22}`}
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.75}
+      />
+      {/* `}` glyph */}
+      <path
+        d={`M 122 ${jsY + 8} Q 128 ${jsY + 8}, 128 ${jsY + 14} L 128 ${jsY + 13} Q 128 ${jsY + 15}, 132 ${jsY + 15} Q 128 ${jsY + 15}, 128 ${jsY + 17} L 128 ${jsY + 16} Q 128 ${jsY + 22}, 122 ${jsY + 22}`}
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.75}
       />
 
-      {/* ─── Impact spark (small starburst at moment of contact) ─── */}
-      <motion.g
-        initial={{ opacity: 0, scale: 0 }}
-        animate={
-          animate
-            ? { opacity: [0, 0, 1, 0, 0], scale: [0, 0, 1.4, 0, 0] }
-            : { opacity: 1, scale: 1 }
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.4, 0.46, 0.56, 1],
-              }
-            : undefined
-        }
-        style={{ transformOrigin: `${impactX}px ${beamY}px`, transformBox: "fill-box" as const }}
-      >
-        <line x1={impactX - 8} y1={beamY} x2={impactX - 4} y2={beamY} stroke="var(--color-accent)" strokeWidth={2.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={impactX} y1={beamY - 8} x2={impactX} y2={beamY - 4} stroke="var(--color-accent)" strokeWidth={2.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={impactX} y1={beamY + 4} x2={impactX} y2={beamY + 8} stroke="var(--color-accent)" strokeWidth={2.2} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={impactX - 6} y1={beamY - 6} x2={impactX - 3} y2={beamY - 3} stroke="var(--color-accent)" strokeWidth={1.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-        <line x1={impactX - 6} y1={beamY + 6} x2={impactX - 3} y2={beamY + 3} stroke="var(--color-accent)" strokeWidth={1.6} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
-      </motion.g>
-
-      {/* ─── Comet trail (3 fading dots behind the head) ────────── */}
-      {[0, 1, 2].map((i) => {
-        const offset = (i + 1) * 8;
-        return (
-          <motion.circle
-            key={`trail-${i}`}
-            cy={beamY}
-            r={3.2 - i * 0.6}
-            fill="var(--color-accent)"
-            initial={{ cx: cometStart - offset, opacity: 0 }}
-            animate={
-              animate
-                ? {
-                    cx: [
-                      cometStart - offset,
-                      cometImpact - offset,
-                      cometImpact - offset,
-                      cometRetreat - offset,
-                      cometRetreat - offset,
-                    ],
-                    opacity: [
-                      0,
-                      0.65 - i * 0.15,
-                      0.65 - i * 0.15,
-                      0.2 - i * 0.05,
-                      0,
-                    ],
-                  }
-                : { cx: cometImpact - offset, opacity: 0.65 - i * 0.15 }
-            }
-            transition={
-              animate
-                ? {
-                    duration: 5,
-                    repeat: Infinity,
-                    ease: [0.4, 0, 0.2, 1],
-                    times: [0, 0.4, 0.5, 0.7, 1],
-                  }
-                : undefined
-            }
-          />
-        );
-      })}
-
-      {/* ─── Comet head (the hero element) ─────────────────────── */}
+      {/* ─── Response packet (hero element — solid terracotta) ──── */}
       <motion.rect
-        width={18}
-        height={18}
-        rx={4.5}
-        y={beamY - 9}
+        x={packetX}
+        width={packetW}
+        height={packetH}
+        rx={2.5}
         fill="var(--color-accent)"
-        initial={{ x: cometStart, opacity: 1, scale: 1 }}
+        initial={{ y: packetStartY, opacity: 0 }}
         animate={
           animate
             ? {
-                x: [cometStart, cometImpact, cometImpact, cometRetreat, cometStart, cometStart],
-                opacity: [1, 1, 1, 0.4, 0, 1],
-                scale: [1, 1, 1.1, 0.7, 0.7, 1],
+                y: [packetStartY, packetEndY, packetEndY, packetEndY, packetStartY],
+                opacity: [0, 1, 1, 0.85, 0],
               }
-            : { x: cometImpact, opacity: 1, scale: 1.1 }
+            : { y: packetEndY, opacity: 1 }
         }
         transition={
           animate
             ? {
-                duration: 5,
+                duration: 6,
                 repeat: Infinity,
                 ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.42, 0.5, 0.7, 0.85, 1],
+                times: [0, 0.3, 0.78, 0.92, 1],
               }
             : undefined
         }
-        style={{ transformOrigin: "center", transformBox: "fill-box" as const }}
       />
+
+      {/* ─── Curtain (sealing the browser → JS boundary) ────────── */}
+      {/* Faint shadow stroke for depth */}
+      <motion.line
+        x1={curtainX1}
+        y1={curtainY + 1}
+        x2={curtainX2}
+        y2={curtainY + 1}
+        stroke="var(--color-accent)"
+        strokeWidth={1.0}
+        strokeLinecap="round"
+        opacity={0.18}
+        vectorEffect="non-scaling-stroke"
+        initial={{ pathLength: 0 }}
+        animate={animate ? { pathLength: [0, 0, 1, 1, 0] } : { pathLength: 1 }}
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.55, 0.78, 0.92, 1],
+              }
+            : undefined
+        }
+      />
+      {/* Hero curtain stroke */}
+      <motion.line
+        x1={curtainX1}
+        y1={curtainY}
+        x2={curtainX2}
+        y2={curtainY}
+        stroke="var(--color-accent)"
+        strokeWidth={1.8}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        initial={{ pathLength: 0, opacity: 0.85 }}
+        animate={
+          animate
+            ? { pathLength: [0, 0, 1, 1, 0], opacity: [0.85, 0.85, 0.95, 0.95, 0.85] }
+            : { pathLength: 1, opacity: 0.95 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.55, 0.78, 0.92, 1],
+              }
+            : undefined
+        }
+      />
+
+      {/* ─── ✕ glyph on the curtain (delight beat — soft fade-in last) ── */}
+      <motion.g
+        initial={{ opacity: 0 }}
+        animate={
+          animate
+            ? { opacity: [0, 0, 0, 0.85, 0] }
+            : { opacity: 0.85 }
+        }
+        transition={
+          animate
+            ? {
+                duration: 6,
+                repeat: Infinity,
+                ease: "easeInOut",
+                times: [0, 0.7, 0.78, 0.92, 1],
+              }
+            : undefined
+        }
+      >
+        <line x1={96} y1={curtainY - 4} x2={104} y2={curtainY + 4} stroke="var(--color-accent)" strokeWidth={1.6} strokeLinecap="round" opacity={0.7} vectorEffect="non-scaling-stroke" />
+        <line x1={96} y1={curtainY + 4} x2={104} y2={curtainY - 4} stroke="var(--color-accent)" strokeWidth={1.6} strokeLinecap="round" opacity={0.7} vectorEffect="non-scaling-stroke" />
+      </motion.g>
     </motion.g>
   );
 }
 
 /**
  * WhyFetchFailsCoverStatic — Satori-safe pure-JSX export.
- * Reduced-motion end-state: comet bounced back at far-left, wall solid,
- * ✕ visible, 2 echo-rings frozen at mid-expansion (the "impact moment").
+ * Reduced-motion end-state: response packet sits at the browser tier,
+ * curtain fully drawn between the browser and JS tiers, ✕ visible. The
+ * article's thesis lands from the still: the response is *in* the
+ * browser; the boundary to JS is sealed.
  */
 export function WhyFetchFailsCoverStatic() {
   const ACCENT = "#d97341";
-  const TEXT = "#f8f5f0";
   const MUTED = "#7a7570";
-  const SURFACE = "#1a1714";
+  const TIER_FILL_BROWSER = "#3b2620"; // ~10% terracotta over BG
+  const TIER_FILL_SERVER = "#23191b"; // ~4%
+  const TIER_FILL_JS = "#23191b";
 
-  const wallX = 122;
-  const impactX = 116;
-  const beamY = 100;
+  const serverY = 30;
+  const serverH = 30;
+  const browserY = 84;
+  const browserH = 32;
+  const jsY = 140;
+  const jsH = 30;
+  const packetX = 92;
+  const packetW = 16;
+  const packetH = 12;
+  const packetEndY = browserY + (browserH - packetH) / 2;
+  const curtainY = (browserY + browserH + jsY) / 2;
+  const curtainX1 = 36;
+  const curtainX2 = 164;
 
   return (
     <svg
@@ -367,30 +305,49 @@ export function WhyFetchFailsCoverStatic() {
       width="100%"
       height="100%"
     >
-      {/* Browser silhouette */}
-      <rect x={140} y={56} width={48} height={88} rx={5} fill={SURFACE} stroke={MUTED} strokeWidth={1.6} opacity={0.55} />
-      <line x1={140} y1={68} x2={188} y2={68} stroke={MUTED} strokeWidth={1.2} opacity={0.5} />
-      <circle cx={146} cy={62} r={1.6} fill={MUTED} opacity={0.55} />
-      <circle cx={152} cy={62} r={1.6} fill={MUTED} opacity={0.45} />
-      <circle cx={158} cy={62} r={1.6} fill={MUTED} opacity={0.4} />
+      {/* Vertical guide line */}
+      <line x1={100} y1={serverY + serverH} x2={100} y2={jsY} stroke={MUTED} strokeWidth={1.0} strokeDasharray="2 3" opacity={0.32} />
 
-      {/* Wall */}
-      <rect x={wallX - 4} y={36} width={8} height={128} rx={3} fill={TEXT} />
+      {/* Server tier */}
+      <rect x={32} y={serverY} width={136} height={serverH} rx={6} fill={TIER_FILL_SERVER} stroke={MUTED} strokeWidth={1.2} />
+      <line x1={42} y1={serverY + 15} x2={70} y2={serverY + 15} stroke={MUTED} strokeWidth={1.2} strokeLinecap="round" opacity={0.6} />
 
-      {/* ✕ on wall */}
-      <line x1={wallX - 6} y1={beamY - 6} x2={wallX + 6} y2={beamY + 6} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" />
-      <line x1={wallX - 6} y1={beamY + 6} x2={wallX + 6} y2={beamY - 6} stroke={ACCENT} strokeWidth={2.4} strokeLinecap="round" />
+      {/* Browser tier */}
+      <rect x={32} y={browserY} width={136} height={browserH} rx={6} fill={TIER_FILL_BROWSER} stroke={MUTED} strokeWidth={1.4} />
+      <circle cx={42} cy={browserY + 8} r={1.8} fill={MUTED} opacity={0.6} />
 
-      {/* Echo rings — frozen mid-expansion */}
-      <circle cx={impactX} cy={beamY} r={12} fill="none" stroke={ACCENT} strokeWidth={2} opacity={0.7} />
-      <circle cx={impactX} cy={beamY} r={20} fill="none" stroke={ACCENT} strokeWidth={1.6} opacity={0.45} />
+      {/* JS tier */}
+      <rect x={32} y={jsY} width={136} height={jsH} rx={6} fill={TIER_FILL_JS} stroke={MUTED} strokeWidth={1.2} />
+      <path
+        d={`M 78 ${jsY + 8} Q 72 ${jsY + 8}, 72 ${jsY + 14} L 72 ${jsY + 13} Q 72 ${jsY + 15}, 68 ${jsY + 15} Q 72 ${jsY + 15}, 72 ${jsY + 17} L 72 ${jsY + 16} Q 72 ${jsY + 22}, 78 ${jsY + 22}`}
+        fill="none"
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.75}
+      />
+      <path
+        d={`M 122 ${jsY + 8} Q 128 ${jsY + 8}, 128 ${jsY + 14} L 128 ${jsY + 13} Q 128 ${jsY + 15}, 132 ${jsY + 15} Q 128 ${jsY + 15}, 128 ${jsY + 17} L 128 ${jsY + 16} Q 128 ${jsY + 22}, 122 ${jsY + 22}`}
+        fill="none"
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.75}
+      />
 
-      {/* Comet bounced back to far-left */}
-      <rect x={16} y={beamY - 8} width={16} height={16} rx={4} fill={ACCENT} />
-      {/* Trail dots leading from bounce */}
-      <circle cx={40} cy={beamY} r={2.5} fill={ACCENT} opacity={0.4} />
-      <circle cx={52} cy={beamY} r={2} fill={ACCENT} opacity={0.28} />
-      <circle cx={64} cy={beamY} r={1.5} fill={ACCENT} opacity={0.18} />
+      {/* Response packet — at browser tier */}
+      <rect x={packetX} y={packetEndY} width={packetW} height={packetH} rx={2.5} fill={ACCENT} />
+
+      {/* Curtain shadow */}
+      <line x1={curtainX1} y1={curtainY + 1} x2={curtainX2} y2={curtainY + 1} stroke={ACCENT} strokeWidth={1.0} strokeLinecap="round" opacity={0.18} />
+      {/* Curtain hero */}
+      <line x1={curtainX1} y1={curtainY} x2={curtainX2} y2={curtainY} stroke={ACCENT} strokeWidth={1.8} strokeLinecap="round" opacity={0.95} />
+
+      {/* ✕ glyph */}
+      <line x1={96} y1={curtainY - 4} x2={104} y2={curtainY + 4} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" opacity={0.85} />
+      <line x1={96} y1={curtainY + 4} x2={104} y2={curtainY - 4} stroke={ACCENT} strokeWidth={1.6} strokeLinecap="round" opacity={0.85} />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
Complete metaphor revamp of `WhyFetchFails` / `BrowserStoppedAsking` / `HowGmail` / `FunctionRemembered`. v5 was over-bold; v6 calibrated toward refined; user found the metaphors themselves wrong (*"do a complete revamp of the SVG design for them"*). v7 throws out the previous concepts and starts from article-tied starting points, applied in the §14 refined register.

### v7 metaphors
- **WhyFetchFails** — three horizontal tiers (server / browser / JS); response packet flows down successfully into the browser tier, then a curtain closes between browser and JS. The response is *visible to the browser, hidden from JavaScript* — what CORS actually does.
- **BrowserStoppedAsking** — split-pane contrast. Left: sawtooth polling pattern (brief reconnects). Right: single continuous line with packets traveling. The contrast IS the metaphor.
- **HowGmail** — vertical pipeline race. Query packet drops from an input through cache / bloom / db / verdict stages and emerges before the next keystroke — the article's actual thesis (speed).
- **FunctionRemembered** — loop-and-closure visualization. Three closures emerge from a for-loop; each carries its own captured value at a different position. Targets the article's actual subject (var-vs-let loop bug), not generic "closure."

### Calibration (per playbook §14)
- Translucent fills (`color-mix` ~4–10%) on chrome; solid terracotta on the single hero per cover.
- Opacity-led motion; `pathLength` for "drawing" gestures; gentle springs/timings on chrome.
- 8–11 concept elements per cover. Thin strokes (1.0–1.4 chrome, 1.6–2.0 hero).
- 6 s loops; one hero gesture + one quiet support; no parallel stacks.
- Skills: `/critique` `/animate` `/delight` `/polish`. (`/bolder` and `/overdrive` excluded.)

Both animated and static exports refreshed; static end-states match the v7 reduced-motion frames so the OG share-preview composition picks up v7 automatically.

## Test plan
- [ ] tsc + build green (verified locally).
- [ ] Vercel preview — home list at 360 / 768 / 1024: 4 thumbnails read at 64–80 px.
- [ ] Hero tiles for each of the 4 articles render at full size.
- [ ] Reduced-motion — meaningful end-state for each cover.
- [ ] OG previews — `/og/<slug>` for each of the 4 articles renders the v7 still frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)