### PR TITLE
feat(quiz): reusable Quiz wrapper + vendor ClickSpark primitive

### DIFF
--- a/components/fancy/click-spark.tsx
+++ b/components/fancy/click-spark.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * Vendored from React Bits — https://reactbits.dev/animations/click-spark
+ * (TypeScript + CSS variant). Canvas-based radial spark burst on click,
+ * scoped to the wrapped subtree.
+ *
+ * Bytesize override: default `sparkColor` is `var(--color-accent)` (terracotta)
+ * instead of the upstream `'#fff'`, since bytesize is dark-canvas-default and
+ * the accent is the only colour with semantic load (DESIGN.md §3 / §10).
+ *
+ * Reduced-motion users get no canvas — the wrapper renders children only and
+ * the click handler is a no-op (DESIGN.md §9).
+ */
+
+import React, {
+  useRef,
+  useEffect,
+  useCallback,
+} from "react";
+import { useReducedMotion } from "motion/react";
+
+interface ClickSparkProps {
+  sparkColor?: string;
+  sparkSize?: number;
+  sparkRadius?: number;
+  sparkCount?: number;
+  duration?: number;
+  easing?: "linear" | "ease-in" | "ease-out" | "ease-in-out";
+  extraScale?: number;
+  children?: React.ReactNode;
+}
+
+interface Spark {
+  x: number;
+  y: number;
+  angle: number;
+  startTime: number;
+}
+
+export const ClickSpark: React.FC<ClickSparkProps> = ({
+  sparkColor = "var(--color-accent)",
+  sparkSize = 10,
+  sparkRadius = 15,
+  sparkCount = 8,
+  duration = 400,
+  easing = "ease-out",
+  extraScale = 1.0,
+  children,
+}) => {
+  const reduce = useReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const sparksRef = useRef<Spark[]>([]);
+  const startTimeRef = useRef<number | null>(null);
+
+  // Resolve a CSS variable string (e.g. "var(--color-accent)") to a concrete
+  // colour the canvas can stroke with. Falls back to the literal value if it
+  // isn't a var(...) expression. Re-resolved per draw so theme changes pick up.
+  const resolveColor = useCallback((value: string): string => {
+    if (typeof window === "undefined") return value;
+    const match = value.match(/^var\((--[^,)\s]+)(?:,\s*(.+))?\)$/);
+    if (!match) return value;
+    const [, name, fallback] = match;
+    const root = canvasRef.current ?? document.documentElement;
+    const resolved = getComputedStyle(root).getPropertyValue(name).trim();
+    return resolved || fallback || value;
+  }, []);
+
+  useEffect(() => {
+    if (reduce) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    let resizeTimeout: number | undefined;
+
+    const resizeCanvas = () => {
+      const { width, height } = parent.getBoundingClientRect();
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+    };
+
+    const handleResize = () => {
+      if (resizeTimeout) window.clearTimeout(resizeTimeout);
+      resizeTimeout = window.setTimeout(resizeCanvas, 100);
+    };
+
+    const ro = new ResizeObserver(handleResize);
+    ro.observe(parent);
+    resizeCanvas();
+
+    return () => {
+      ro.disconnect();
+      if (resizeTimeout) window.clearTimeout(resizeTimeout);
+    };
+  }, [reduce]);
+
+  const easeFunc = useCallback(
+    (t: number) => {
+      switch (easing) {
+        case "linear":
+          return t;
+        case "ease-in":
+          return t * t;
+        case "ease-in-out":
+          return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+        case "ease-out":
+        default:
+          return t * (2 - t);
+      }
+    },
+    [easing]
+  );
+
+  useEffect(() => {
+    if (reduce) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let animationId: number;
+
+    const draw = (timestamp: number) => {
+      if (!startTimeRef.current) {
+        startTimeRef.current = timestamp;
+      }
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      const colour = resolveColor(sparkColor);
+
+      sparksRef.current = sparksRef.current.filter((spark: Spark) => {
+        const elapsed = timestamp - spark.startTime;
+        if (elapsed >= duration) return false;
+
+        const progress = elapsed / duration;
+        const eased = easeFunc(progress);
+
+        const distance = eased * sparkRadius * extraScale;
+        const lineLength = sparkSize * (1 - eased);
+
+        const x1 = spark.x + distance * Math.cos(spark.angle);
+        const y1 = spark.y + distance * Math.sin(spark.angle);
+        const x2 = spark.x + (distance + lineLength) * Math.cos(spark.angle);
+        const y2 = spark.y + (distance + lineLength) * Math.sin(spark.angle);
+
+        ctx.strokeStyle = colour;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.stroke();
+
+        return true;
+      });
+
+      animationId = requestAnimationFrame(draw);
+    };
+
+    animationId = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+    };
+  }, [
+    reduce,
+    sparkColor,
+    sparkSize,
+    sparkRadius,
+    duration,
+    easeFunc,
+    extraScale,
+    resolveColor,
+  ]);
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (reduce) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const now = performance.now();
+    const newSparks: Spark[] = Array.from({ length: sparkCount }, (_, i) => ({
+      x,
+      y,
+      angle: (2 * Math.PI * i) / sparkCount,
+      startTime: now,
+    }));
+
+    sparksRef.current.push(...newSparks);
+  };
+
+  if (reduce) {
+    // Reduced-motion: no canvas, no click hook, no rAF loop.
+    return <>{children}</>;
+  }
+
+  // The wrapper must establish a containing block (position: relative) for the
+  // overlay canvas, but otherwise stays out of the layout. `display: inline-block`
+  // with width: 100% lets the wrapped element drive its own intrinsic size while
+  // the canvas covers the bounding box.
+  return (
+    <span
+      onClick={handleClick}
+      style={{
+        position: "relative",
+        display: "inline-block",
+        width: "100%",
+      }}
+    >
+      {children}
+      <canvas
+        ref={canvasRef}
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          pointerEvents: "none",
+        }}
+      />
+    </span>
+  );
+};
+
+export default ClickSpark;

--- a/components/fancy/index.ts
+++ b/components/fancy/index.ts
@@ -3,3 +3,4 @@ export { default as DragElements } from "./drag-elements";
 export { MediaBetweenText, type MediaBetweenTextRef } from "./media-between-text";
 export { VerticalCutReveal, type VerticalCutRevealRef } from "./vertical-cut-reveal";
 export { ScrambleIn, type ScrambleInRef } from "./scramble-in";
+export { ClickSpark, default as ClickSparkDefault } from "./click-spark";

--- a/components/widgets/Quiz.tsx
+++ b/components/widgets/Quiz.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+/**
+ * <Quiz> — reusable wrapper for "predict / pick the right answer" widgets.
+ *
+ * Renders a question, randomised options, and a verdict. On the correct pick
+ * the chosen option pulses and emits a small terracotta spark burst (via the
+ * vendored ClickSpark primitive). On a wrong pick the chosen option nods
+ * (keyframe shake) and the correct option highlights so the reader still
+ * leaves with the answer. Frame-stable: the verdict slot reserves height
+ * before any answer is given (R6 from the SVG cover playbook applies to
+ * widgets too).
+ *
+ * Single accent (DESIGN.md §3): "wrong" reads via desaturated muted border
+ * + nod + verdict copy — never red. "Right" reads via terracotta highlight +
+ * pulse + sparks — never green.
+ *
+ * Reduced motion (DESIGN.md §9): nod and pulse collapse to opacity-only;
+ * ClickSpark renders as a no-op (no canvas, no rAF). Verdict still reveals.
+ *
+ * Mobile-first: options stack as a 1-col grid on narrow containers and shift
+ * to a 2-col grid at the `quiz` container query breakpoint. Tap targets stay
+ * ≥ 44px (DESIGN.md §11).
+ *
+ * Accessibility: `role="radiogroup"`, each option `role="radio"` with
+ * `aria-checked`. The verdict region is `aria-live="polite"`. Arrow keys
+ * navigate between options; Enter / Space selects.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { ClickSpark } from "@/components/fancy/click-spark";
+import { SPRING } from "@/lib/motion";
+
+export type QuizOption = {
+  /** Stable id used to check correctness — preserved across shuffles. */
+  id: string;
+  /** What the reader sees — text or rich. */
+  label: React.ReactNode;
+};
+
+export type QuizProps = {
+  /** The question content — could be prose, code, anything. */
+  question: React.ReactNode;
+  options: QuizOption[];
+  /** Which option.id is correct. */
+  correctId: string;
+  /** Called once with `(correct, chosenId)` when the reader picks. */
+  onAnswered?: (correct: boolean, chosenId: string) => void;
+  /** Shuffle options on mount. Default true. */
+  randomize?: boolean;
+  /** Verdict copy for the right pick. */
+  rightVerdict?: React.ReactNode;
+  /** Verdict copy for a wrong pick (or reveal-answer route). */
+  wrongVerdict?: React.ReactNode;
+  /** Show a "reveal answer" escape hatch. Default true. */
+  revealable?: boolean;
+};
+
+/** Fisher–Yates — seeded by Math.random() on the call. Pure on the input array. */
+function shuffle<T>(input: readonly T[]): T[] {
+  const out = input.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+const NOD_KEYFRAMES = [0, -6, 6, -4, 4, 0];
+
+export function Quiz({
+  question,
+  options,
+  correctId,
+  onAnswered,
+  randomize = true,
+  rightVerdict,
+  wrongVerdict,
+  revealable = true,
+}: QuizProps) {
+  const reduce = useReducedMotion();
+  const groupName = useId();
+
+  // Shuffle once on mount (or use as-given) — lazy init so the order is stable
+  // across re-renders. Only re-shuffles on a fresh mount (= page reload).
+  const [shuffled] = useState<QuizOption[]>(() =>
+    randomize ? shuffle(options) : options.slice()
+  );
+
+  const [chosenId, setChosenId] = useState<string | null>(null);
+  /** "revealed" subsumes both the right-path and wrong-path answered state. */
+  const [revealed, setRevealed] = useState(false);
+  /** Distinct from `chosenId === correctId` because reveal-answer routes to
+   *  wrong-path without setting `chosenId`. */
+  const [outcome, setOutcome] = useState<"right" | "wrong" | null>(null);
+
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const onAnsweredRef = useRef(onAnswered);
+  useEffect(() => {
+    onAnsweredRef.current = onAnswered;
+  }, [onAnswered]);
+
+  const handlePick = useCallback(
+    (id: string) => {
+      if (revealed) return;
+      const correct = id === correctId;
+      setChosenId(id);
+      setRevealed(true);
+      setOutcome(correct ? "right" : "wrong");
+      onAnsweredRef.current?.(correct, id);
+    },
+    [correctId, revealed]
+  );
+
+  const handleReveal = useCallback(() => {
+    if (revealed) return;
+    setChosenId(null);
+    setRevealed(true);
+    setOutcome("wrong");
+  }, [revealed]);
+
+  // Roving keyboard nav: ArrowDown / ArrowRight → next, ArrowUp / ArrowLeft →
+  // prev. Enter / Space invokes the button (browser-native — no extra wiring).
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      if (revealed) return;
+      const last = shuffled.length - 1;
+      let next = index;
+      if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+        next = index === last ? 0 : index + 1;
+      } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+        next = index === 0 ? last : index - 1;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      buttonRefs.current[next]?.focus();
+    },
+    [revealed, shuffled.length]
+  );
+
+  const verdictNode = useMemo(() => {
+    if (!revealed || !outcome) return null;
+    return outcome === "right" ? rightVerdict : wrongVerdict;
+  }, [revealed, outcome, rightVerdict, wrongVerdict]);
+
+  return (
+    <div
+      className="bs-quiz"
+      style={{
+        // Container query target — `@container quiz` flips the option grid.
+        containerType: "inline-size",
+        containerName: "quiz",
+      }}
+    >
+      {/* Scoped grid + verdict-slot styles. Keeping them inline avoids a global
+          stylesheet for one widget; the `bs-quiz` namespace prevents leakage. */}
+      <style>{`
+        .bs-quiz-options {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-2xs);
+        }
+        @container quiz (min-width: 480px) {
+          .bs-quiz-options {
+            grid-template-columns: 1fr 1fr;
+          }
+        }
+        .bs-quiz-option {
+          width: 100%;
+          min-height: 44px;
+          padding: 10px 12px;
+          font-size: var(--text-ui);
+          line-height: 1.45;
+          text-align: left;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          color: var(--color-text);
+          cursor: pointer;
+          transition: background 200ms, color 200ms, border-color 200ms, opacity 200ms;
+        }
+        .bs-quiz-option:hover:not(:disabled) {
+          background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+        }
+        .bs-quiz-option:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-quiz-option:disabled {
+          cursor: default;
+        }
+        .bs-quiz-verdict {
+          min-height: 2.5em;
+        }
+        .bs-quiz-reveal {
+          background: transparent;
+          border: none;
+          color: var(--color-text-muted);
+          font-size: var(--text-small);
+          padding: 8px 4px;
+          cursor: pointer;
+          text-decoration: underline;
+          text-decoration-style: dotted;
+          text-underline-offset: 4px;
+          align-self: flex-start;
+        }
+        .bs-quiz-reveal:hover { color: var(--color-text); }
+        .bs-quiz-reveal:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+      `}</style>
+
+      <div className="flex flex-col gap-[var(--spacing-sm)]">
+        <div>{question}</div>
+
+        <div
+          role="radiogroup"
+          aria-label="quiz options"
+          className="bs-quiz-options"
+        >
+          {shuffled.map((opt, i) => {
+            const isChosen = chosenId === opt.id;
+            const isCorrect = opt.id === correctId;
+            const isWrongChosen = revealed && isChosen && !isCorrect;
+            const showCorrectMark = revealed && isCorrect;
+            // Other options dim once revealed (whether they were chosen-wrong
+            // or untouched — leaves the eye on the chosen + correct pair).
+            const dim = revealed && !isChosen && !isCorrect;
+
+            // Animation choices:
+            // - Right pick: one-shot scale pulse 1 → 1.04 → 1.
+            // - Wrong pick: one-shot x-keyframe nod (-6, 6, -4, 4, 0) ~ 350ms.
+            // - Both collapse to a still frame under reduced motion.
+            const animate =
+              !reduce && revealed && isChosen
+                ? isCorrect
+                  ? { scale: [1, 1.04, 1] as number[] }
+                  : { x: NOD_KEYFRAMES }
+                : { scale: 1, x: 0 };
+
+            const transition =
+              !reduce && revealed && isChosen
+                ? isCorrect
+                  ? { duration: 0.25, times: [0, 0.5, 1] }
+                  : { duration: 0.35, ease: "easeInOut" as const }
+                : SPRING.gentle;
+
+            const button = (
+              <motion.button
+                ref={(el) => {
+                  buttonRefs.current[i] = el;
+                }}
+                type="button"
+                role="radio"
+                aria-checked={isChosen}
+                name={groupName}
+                tabIndex={
+                  // Roving tabindex — first option focusable until something is
+                  // chosen, then the chosen one. Once revealed, none.
+                  revealed
+                    ? -1
+                    : chosenId === null
+                      ? i === 0
+                        ? 0
+                        : -1
+                      : isChosen
+                        ? 0
+                        : -1
+                }
+                onClick={() => handlePick(opt.id)}
+                onKeyDown={(e) => onKeyDown(e, i)}
+                disabled={revealed}
+                whileTap={revealed || reduce ? undefined : { scale: 0.97 }}
+                animate={animate}
+                transition={transition}
+                className="bs-quiz-option"
+                style={{
+                  // Border + background highlight by state. No reds, no greens —
+                  // wrong reads via desaturated-muted border + the nod itself.
+                  borderColor: showCorrectMark
+                    ? "var(--color-accent)"
+                    : isWrongChosen
+                      ? "color-mix(in oklab, var(--color-text-muted) 70%, transparent)"
+                      : isChosen
+                        ? "var(--color-accent)"
+                        : "var(--color-rule)",
+                  background: showCorrectMark
+                    ? "color-mix(in oklab, var(--color-accent) 16%, transparent)"
+                    : isWrongChosen
+                      ? "color-mix(in oklab, var(--color-accent) 6%, transparent)"
+                      : isChosen
+                        ? "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                        : undefined,
+                  opacity: dim ? 0.5 : 1,
+                  filter: isWrongChosen ? "saturate(0.4)" : undefined,
+                }}
+              >
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                  {showCorrectMark ? (
+                    <span aria-hidden style={{ color: "var(--color-accent)", fontSize: 12 }}>
+                      ✓
+                    </span>
+                  ) : null}
+                  <span>{opt.label}</span>
+                </span>
+              </motion.button>
+            );
+
+            // Wrap the correct option in <ClickSpark> so a correct click emits
+            // a terracotta spark burst around the button. ClickSpark is a
+            // no-op under reduced motion (renders children only).
+            return (
+              <div key={opt.id} style={{ display: "block" }}>
+                {isCorrect ? <ClickSpark>{button}</ClickSpark> : button}
+              </div>
+            );
+          })}
+        </div>
+
+        {revealable && !revealed ? (
+          <button type="button" onClick={handleReveal} className="bs-quiz-reveal">
+            reveal answer
+          </button>
+        ) : null}
+
+        {/* Verdict slot — fixed min-height so the container is the same size
+            before and after answering. Frame-stable per R6. */}
+        <div className="bs-quiz-verdict" aria-live="polite">
+          <AnimatePresence initial={false} mode="wait">
+            {revealed && verdictNode ? (
+              <motion.div
+                key={outcome}
+                initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+                animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.gentle}
+                style={{
+                  fontSize: "var(--text-small)",
+                  color: "var(--color-text-muted)",
+                  lineHeight: 1.6,
+                }}
+              >
+                {verdictNode}
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Quiz;

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -20,7 +20,7 @@ Every widget we've shipped collapses to one of seven shapes. Pick the shape that
 | **Scan / reveal** | "What the human saw vs what the agent saw" (unmask) | `HostilePageScan`, `ParseVsRender` | transform-based sweep OR segmented toggle |
 | **Propagation network** | "One signal becomes many" / contagion | `InfectiousJailbreak` | SVG graph + tick-based state spread |
 | **Coverage matrix** | "This defence reaches these stages, not those" | `DefenceCoverage` | CSS grid with intensity-coded cells |
-| **Premise quiz** | "Predict X — most readers fail, here's why" | `PredictTheStart` (event-loop post) | code snippet + multiple-choice + verdict |
+| **Premise quiz** | "Predict X — most readers fail, here's why" | `PredictTheStart` (event-loop post) | `<Quiz>` (see §2) wrapping the snippet + options |
 
 **Rule**: if a proposed widget doesn't fit one of these, ask whether the teaching claim is actually one claim. Most "doesn't fit" widgets are two claims in a trench coat.
 
@@ -132,6 +132,34 @@ It was first slotted into the gmail post's normalisation widget. That widget was
 - **Cadence**: `scrambleSpeed={60}` matches the §9 60 ms stagger grid. Defaults to 60. Do not go below 40 — characters blur together.
 - **Alphabet**: scoped per-article. For email/identifier reveals, use `characters="abcdefghijklmnopqrstuvwxyz0123456789.@+"` (this is the local file's default). Never a glyph-soup alphabet with symbols that can't legally appear in the target string.
 - **Budget**: one per article max — twice reads as decoration. Must teach "decode" or "normalise"; if the payload is a literal that the reader didn't type and doesn't know, don't use this primitive.
+
+### `Quiz` (✅ shipped — premise-quiz wrapper)
+
+`components/widgets/Quiz.tsx`. Reusable wrapper for any *predict / pick the right answer* widget. Renders the question (prose, code, anything), a randomised option list, and a verdict that flips on pick. Replaces the bespoke "code snippet + multiple-choice + verdict" assemblage from `PredictTheStart` with one primitive that any future quiz can lean on.
+
+- **API**: `question`, `options: { id, label }[]`, `correctId`, `onAnswered?(correct, chosenId)`, `randomize` (default `true`), `rightVerdict`, `wrongVerdict`, `revealable` (default `true`). The caller owns the question content — the wrapper does not impose a code-block layout.
+- **When to use**: the *Premise quiz* shape from §1. Open an article whose teaching is a non-obvious *order*, *outcome*, or *output*, and you want the reader's wrong intuition to create demand for the explanation.
+- **Anti-uses**: *not* a comprehension check at the end of an article (interrupts reading flow), *not* a poll (no right answer), *not* a tutorial step gate.
+- **Randomisation**: Fisher–Yates on mount via lazy `useState`. Order is stable across re-renders; only re-shuffles on a fresh page load. The `id` is preserved across the shuffle so correctness checks survive.
+- **Right path**: chosen option pulses (`scale 1 → 1.04 → 1`, ~250 ms) and emits a small terracotta spark burst via `<ClickSpark>` wrapped around the correct option. Border + background highlight to terracotta. `rightVerdict` reveals beneath.
+- **Wrong path**: chosen option does a one-shot keyframe nod (`x: [0, -6, 6, -4, 4, 0]`, ~350 ms) and gets a desaturated muted-grey border + slight `filter: saturate(0.4)`. The CORRECT option *also* highlights so the reader still leaves with the answer. `wrongVerdict` reveals beneath.
+- **Reveal-answer escape hatch**: a `reveal answer` text-button below the options routes to the wrong-path verdict (no shake) and highlights the correct option. Disable with `revealable={false}` for cases where guessing is the whole point.
+- **One-accent discipline**: terracotta is the only colour with semantic load. *Wrong* reads via desaturation + the nod + verdict copy — never a red. *Right* reads via the highlight + pulse + sparks — never a green. (DESIGN.md §3 / §10.)
+- **Frame-stability**: the verdict slot reserves `min-height: 2.5em` before any answer is given so the container does not reflow on pick. R6 from `docs/svg-cover-playbook.md` applies to widgets too.
+- **Reduced motion**: nod + pulse collapse to opacity-only feedback; `<ClickSpark>` becomes a pure pass-through (no canvas, no rAF). Verdict still reveals.
+- **Mobile-first**: options stack as a 1-col grid on narrow widths, flip to 2-col at `@container quiz (min-width: 480px)`. Tap targets ≥ 44 px.
+- **Accessibility**: `role="radiogroup"`, each option `role="radio"` with `aria-checked`. Roving `tabindex`. ArrowDown / ArrowRight → next, ArrowUp / ArrowLeft → prev. Enter / Space invokes the button. Verdict region is `aria-live="polite"`.
+- **Migration note**: `PredictTheStart` is **not** migrated to `<Quiz>` yet. The wrapper is intentionally a separate primitive first; the migration is a future pass.
+
+### `ClickSpark` (✅ shipped — internal to `<Quiz>`)
+
+`components/fancy/click-spark.tsx`. Vendored from [React Bits](https://reactbits.dev/animations/click-spark). Canvas-based radial spark burst on click — N short lines fan out from the click point, each travelling `sparkRadius` px before fading.
+
+- **Use case**: correct-answer celebration inside `<Quiz>`. Not for general decoration. Don't sprinkle this on buttons across the site.
+- **Bytesize override**: default `sparkColor` is `var(--color-accent)` (terracotta) instead of upstream `'#fff'`. Bytesize is dark-canvas-default and the accent is the only semantic colour.
+- **Reduced motion**: renders as a no-op (children only, no canvas, no rAF, no click hook). DESIGN.md §9.
+- **Layering**: the wrapper is a `position: relative; display: inline-block; width: 100%` span; the canvas overlays at `inset: 0` with `pointer-events: none` so it doesn't intercept clicks on the wrapped subtree.
+- **Don't reach for it directly**. If you need a celebration that isn't a quiz answer, write the moment from primitives (a one-shot scale + a `TextHighlighter` + a verdict line) before reaching for sparks. Sparks-as-decoration violates §9.
 
 ## 2.5. The full Fancy library — curation for bytesize
 


### PR DESCRIPTION
## Summary

- Adds `components/widgets/Quiz.tsx` — a reusable wrapper for any *predict / pick the right answer* interaction across bytesize posts. Renders question + options + verdict; randomises options on mount via Fisher-Yates; nods on wrong answers; sparkles on correct answers via a vendored ClickSpark primitive.
- Vendors `components/fancy/click-spark.tsx` from [React Bits](https://reactbits.dev/animations/click-spark) — Canvas + ResizeObserver + draw loop, structurally unchanged from upstream. Bytesize override: default `sparkColor` is `var(--color-accent)` (terracotta) instead of `'#fff'` because bytesize is dark-canvas-default.
- Documents both primitives in `docs/interactive-components.md` §2; updates the §1 *Premise quiz* row's *Core primitive* cell to point at `<Quiz>`.
- **No widget migrations.** `PredictTheStart` continues to use its bespoke implementation; the migration is a future pass.

## API

```ts
type QuizProps = {
  question: React.ReactNode;
  options: Array<{ id: string; label: React.ReactNode }>;
  correctId: string;
  onAnswered?: (correct: boolean, chosenId: string) => void;
  randomize?: boolean;        // default true
  rightVerdict?: React.ReactNode;
  wrongVerdict?: React.ReactNode;
  revealable?: boolean;       // default true
};
```

## Behaviour

**Right path** — chosen `id === correctId`:
- ClickSpark wraps the correct option, so the click emits a small terracotta spark burst around the button.
- The chosen option pulses `scale 1 → 1.04 → 1` over ~250 ms.
- Border + background highlight to terracotta (16% wash).
- `rightVerdict` reveals beneath via spring fade-in.
- Other options dim to 0.5 opacity.

**Wrong path** — chosen `id !== correctId`:
- Chosen option does a one-shot keyframe nod: `x: [0, -6, 6, -4, 4, 0]` over ~350 ms (tween, not spring — the keyframe itself is the gesture).
- Chosen option gets a desaturated muted-grey border (`color-mix(in oklab, var(--color-text-muted) 70%, transparent)`) + `filter: saturate(0.4)` + 6% terracotta wash. **No red.**
- The CORRECT option *also* highlights so the reader leaves with the answer.
- `wrongVerdict` reveals.

**Reveal-answer escape hatch** (when `revealable !== false`): a small *reveal answer* text-button below the options routes to the wrong-path verdict (no shake) and highlights the correct option.

**Reduced motion**: nod and pulse collapse to opacity-only feedback. ClickSpark renders as a no-op (children only, no canvas, no rAF, no click hook). Verdict still reveals.

## Frame stability

- Verdict slot reserves `min-height: 2.5em` before any answer is given. The container is the same height before and after picking — R6 from `docs/svg-cover-playbook.md` applies to widgets.

## Mobile-first

- Container query (`@container quiz`) flips the option grid from 1-column to 2-column at 480 px container width. No viewport breakpoints — the wrapper adapts to its parent.
- Tap targets ≥ 44 px (`min-height: 44px` on every option).
- Outer frame size is invariant to interaction state.

## Accessibility

- `role="radiogroup"` on the option container; each option is `role="radio"` with `aria-checked`.
- Roving `tabindex`: first option focusable until something is chosen, then the chosen one. Once revealed, none.
- Arrow keys navigate (Down/Right → next, Up/Left → prev). Enter / Space invokes via native button semantics.
- Verdict region is `aria-live="polite"`.
- Visible focus rings (2 px terracotta) on every interactive element.

## ClickSpark notes

- Plain Canvas + `ResizeObserver` + a draw loop — no animation libraries needed (no new deps).
- Resolves CSS-variable spark colours (`var(--color-accent)`) on each draw via `getComputedStyle`, so theme changes flow through.
- Wrapper is `position: relative; display: inline-block; width: 100%` (a `<span>`) so the canvas overlay has a containing block without disrupting the wrapped subtree's layout.

## Out of scope (deliberate)

- `PredictTheStart` is **not** migrated. The user wants the wrapper built first and will direct the migration separately.
- No changes to `MicrotaskStarvation`, `CallStackECs`, `CodeBlock`, `lib/shiki.ts`, covers, articles, or the OG route.
- No new dependencies.

## Test plan

- [ ] Local: open any post page (sanity — nothing else changed); confirm no regression.
- [ ] Type check: `pnpm exec tsc --noEmit` green.
- [ ] Build: `pnpm build` green.
- [ ] Author a throwaway test page with `<Quiz>`; verify:
  - [ ] Options shuffle on each reload but stay stable across re-renders.
  - [ ] Correct pick: pulse + sparks + verdict.
  - [ ] Wrong pick: nod + correct option highlights + verdict.
  - [ ] Reveal-answer: routes to wrong-path verdict without shake.
  - [ ] Reduced-motion (system pref): nod + pulse + sparks collapse.
  - [ ] Keyboard: Tab focuses first option; arrows navigate; Enter selects.
  - [ ] 360 px viewport: 1-column stack, verdict slot reserved before pick.
  - [ ] Container ≥ 480 px: 2-column grid.