### PR TITLE
fix(prose): migrate every code listing to <CodeBlock> + correct lang props

### DIFF
--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -13,6 +13,7 @@ import {
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
 import { TextHighlighter } from "@/components/fancy";
+import { CodeBlock } from "@/components/code/CodeBlock";
 import {
   RuntimeSimulator,
   PredictTheStart,
@@ -20,6 +21,10 @@ import {
   AwaitDesugar,
   MicrotaskStarvation,
 } from "./widgets";
+import {
+  PREDICT_THE_START_SNIPPET,
+  PREDICT_THE_OUTPUT_VARIANT_CODE,
+} from "./widgets/snippets";
 import { metadata, subtitle } from "./metadata";
 
 export { metadata };
@@ -91,7 +96,15 @@ export default function TheLineThatWaitsItsTurn() {
         </P>
       </div>
 
-      <PredictTheStart />
+      <PredictTheStart
+        codeSlot={
+          <CodeBlock
+            lang="javascript"
+            filename="predict the output"
+            code={PREDICT_THE_START_SNIPPET}
+          />
+        }
+      />
 
       <div>
         <P>
@@ -217,7 +230,31 @@ export default function TheLineThatWaitsItsTurn() {
         </P>
       </div>
 
-      <PredictTheOutput />
+      <PredictTheOutput
+        codeSlots={{
+          alpha: (
+            <CodeBlock
+              lang="javascript"
+              filename="α · baseline"
+              code={PREDICT_THE_OUTPUT_VARIANT_CODE.alpha}
+            />
+          ),
+          beta: (
+            <CodeBlock
+              lang="javascript"
+              filename="β · microtasks spawn microtasks"
+              code={PREDICT_THE_OUTPUT_VARIANT_CODE.beta}
+            />
+          ),
+          gamma: (
+            <CodeBlock
+              lang="javascript"
+              filename="γ · task scheduled first"
+              code={PREDICT_THE_OUTPUT_VARIANT_CODE.gamma}
+            />
+          ),
+        }}
+      />
 
       <div>
         <P>

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState } from "react";
+import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING, PRESS } from "@/lib/motion";
@@ -153,28 +153,6 @@ const SOURCE_STROKE: Record<Source, string> = {
   micro: "transparent",
 };
 
-function CodePane({ code }: { code: string[] }) {
-  return (
-    <pre
-      className="font-mono"
-      style={{
-        background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
-        padding: "var(--spacing-sm)",
-        borderRadius: "var(--radius-sm)",
-        fontSize: 12,
-        color: "var(--color-text)",
-        lineHeight: 1.65,
-        margin: 0,
-        whiteSpace: "pre",
-        overflowX: "auto",
-        minHeight: "9em",
-      }}
-    >
-      {code.join("\n")}
-    </pre>
-  );
-}
-
 function RevealStrip({ reveal }: { reveal: Variant["reveal"] }) {
   return (
     <div
@@ -221,7 +199,9 @@ function RevealStrip({ reveal }: { reveal: Variant["reveal"] }) {
   );
 }
 
-const MemoCodePane = memo(CodePane);
+// Per-variant code text lives in `./snippets.ts` (a non-client module)
+// so the RSC `page.tsx` can pre-render each block through `<CodeBlock>`
+// and pass the highlighted elements back in via `codeSlots`.
 
 /**
  * PredictTheOutput (W2) — three selectable variants. Reader picks an
@@ -234,8 +214,17 @@ const MemoCodePane = memo(CodePane);
  * Frame stability (R6): variant chooser, code pane, predict options, and
  * reveal strip share a single fixed-rectangle canvas. The reveal strip has
  * `min-height` so the card doesn't grow when it appears.
+ *
+ * Code rendering: Shiki-highlighted code panes (one per variant) are
+ * pre-rendered by the article's RSC `page.tsx` and passed in as
+ * `codeSlots`, keyed by variant id. Keeps Shiki out of the client bundle.
  */
-export function PredictTheOutput() {
+type Props = {
+  /** One pre-rendered Shiki block per variant. */
+  codeSlots: Record<Variant["id"], React.ReactNode>;
+};
+
+export function PredictTheOutput({ codeSlots }: Props) {
   const [variantId, setVariantId] = useState<Variant["id"]>("alpha");
   const [picked, setPicked] = useState<number | null>(null);
   const [revealed, setRevealed] = useState(false);
@@ -342,7 +331,7 @@ export function PredictTheOutput() {
           })}
         </div>
 
-        <MemoCodePane code={variant.code} />
+        {codeSlots[variantId]}
 
         {/* Predict / reveal area — fixed-rectangle, shares min-height. */}
         <div style={{ minHeight: "9em" }}>

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState } from "react";
+import { useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING, PRESS } from "@/lib/motion";
@@ -43,23 +43,10 @@ function CaptionCue({ children }: { children: React.ReactNode }) {
  *   →  A · F · H · C · E · G · D · B
  * --------------------------------------------------------------------------*/
 
-const SNIPPET = [
-  `console.log("A");`,
-  `setTimeout(() => console.log("B"), 0);`,
-  `Promise.resolve()`,
-  `  .then(() => {`,
-  `    console.log("C");`,
-  `    return Promise.resolve("D");`,
-  `  })`,
-  `  .then((d) => console.log(d));`,
-  `queueMicrotask(() => console.log("E"));`,
-  `(async () => {`,
-  `  console.log("F");`,
-  `  await null;`,
-  `  console.log("G");`,
-  `})();`,
-  `console.log("H");`,
-];
+// The opener snippet text lives in `./snippets.ts` (a non-client module)
+// so the RSC `page.tsx` can pre-render it through `<CodeBlock>` and pass
+// the highlighted element back in via the `codeSlot` prop. The widget
+// itself never needs to read the raw text.
 
 type Option = {
   /** Tokens, joined with a tabular separator for display. */
@@ -97,32 +84,6 @@ const SEP = "·";
 function tokensToLine(tokens: string[]) {
   return tokens.join(` ${SEP} `);
 }
-
-function CodePane() {
-  return (
-    <pre
-      className="font-mono"
-      style={{
-        background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
-        padding: "var(--spacing-sm)",
-        borderRadius: "var(--radius-sm)",
-        fontSize: 12,
-        lineHeight: 1.55,
-        color: "var(--color-text)",
-        margin: 0,
-        whiteSpace: "pre",
-        overflowX: "auto",
-        // Reserve enough rows that the pane doesn't shift when scrolling.
-        // 15 lines × ~19px line-height + 24px padding ≈ 309px.
-        minHeight: 280,
-      }}
-    >
-      {SNIPPET.join("\n")}
-    </pre>
-  );
-}
-
-const MemoCodePane = memo(CodePane);
 
 function OptionButton({
   option,
@@ -219,8 +180,19 @@ function OptionButton({
  *
  * Mobile-first: 360px target. Options stack vertically on <lg, 2×2 on lg+.
  * Snippet wraps to its own scroll container only as a last resort.
+ *
+ * Code rendering: the article's RSC `page.tsx` pre-renders the opener
+ * snippet through `<CodeBlock>` (Shiki, dual-theme) and passes the
+ * resulting element in via `codeSlot`. Keeps Shiki out of the client
+ * bundle and lets this widget stay a `"use client"` component for the
+ * pick/reveal state.
  */
-export function PredictTheStart() {
+type Props = {
+  /** Pre-rendered Shiki block for the opener snippet (see page.tsx). */
+  codeSlot: React.ReactNode;
+};
+
+export function PredictTheStart({ codeSlot }: Props) {
   const [picked, setPicked] = useState<number | null>(null);
   const [revealed, setRevealed] = useState(false);
 
@@ -337,7 +309,7 @@ export function PredictTheStart() {
       }
     >
       <div className="flex flex-col gap-[var(--spacing-sm)]">
-        <MemoCodePane />
+        {codeSlot}
 
         {/* Options — stacked on mobile, 2x2 on lg+. Frame-stable: container
             never resizes after pick or reveal. */}

--- a/app/posts/the-line-that-waits-its-turn/widgets/snippets.ts
+++ b/app/posts/the-line-that-waits-its-turn/widgets/snippets.ts
@@ -1,0 +1,53 @@
+/**
+ * Code snippets for the event-loop article's quiz widgets, kept in a
+ * non-client module so the article's RSC `page.tsx` can import them and
+ * pre-render them through `<CodeBlock>` (Shiki). The widgets themselves
+ * (`"use client"`) only need the highlighted JSX element back in via a
+ * `codeSlot` / `codeSlots` prop — they don't read these strings directly.
+ *
+ * Keeping the strings here, not in the widget files, avoids the "you can
+ * only import components from a use-client module" RSC boundary trap.
+ */
+
+/** PredictTheStart (W0) — the article's opener snippet. */
+export const PREDICT_THE_START_SNIPPET = [
+  `console.log("A");`,
+  `setTimeout(() => console.log("B"), 0);`,
+  `Promise.resolve()`,
+  `  .then(() => {`,
+  `    console.log("C");`,
+  `    return Promise.resolve("D");`,
+  `  })`,
+  `  .then((d) => console.log(d));`,
+  `queueMicrotask(() => console.log("E"));`,
+  `(async () => {`,
+  `  console.log("F");`,
+  `  await null;`,
+  `  console.log("G");`,
+  `})();`,
+  `console.log("H");`,
+].join("\n");
+
+/** PredictTheOutput (W2) — three variants. */
+export const PREDICT_THE_OUTPUT_VARIANT_CODE = {
+  alpha: [
+    `console.log("A");`,
+    `setTimeout(() => console.log("B"), 0);`,
+    `Promise.resolve().then(() => console.log("C"));`,
+    `console.log("D");`,
+  ].join("\n"),
+  beta: [
+    `setTimeout(() => console.log("T"), 0);`,
+    `Promise.resolve().then(() => {`,
+    `  console.log("P1");`,
+    `  Promise.resolve().then(() => console.log("P2"));`,
+    `});`,
+  ].join("\n"),
+  gamma: [
+    `setTimeout(() => console.log("first?"), 0);`,
+    `Promise.resolve().then(() => console.log("second?"));`,
+  ].join("\n"),
+} as const;
+
+export type PredictTheOutputVariantId =
+  keyof typeof PREDICT_THE_OUTPUT_VARIANT_CODE;


### PR DESCRIPTION
## Summary
User-reported bug: `PredictTheStart` (event-loop article opener) rendered its snippet via raw `<pre>` instead of the Shiki-highlighted `<CodeBlock>` primitive. Audit + sweep across all articles + widgets.

### Migrations (raw `<pre>` → `<CodeBlock>`)
- `app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx` — opener snippet now receives a `codeSlot: ReactNode` prop pre-rendered by the RSC `page.tsx` (standard RSC + Shiki pattern; widget stays a client component for pick/reveal state). `lang="javascript"`.
- `app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx` — three variants (alpha/beta/gamma) now receive `codeSlots: Record<VariantId, ReactNode>` from `page.tsx`. `lang="javascript"`.
- New `app/posts/the-line-that-waits-its-turn/widgets/snippets.ts` (non-client module) hoists the snippet strings out of the `"use client"` widgets so the RSC page can import them without crossing the use-client boundary (which would have forced them through Flight serialization and broken at build).

### Lang-prop audit
All 14 existing `<CodeBlock>` usages reviewed; every `lang` is already correct (`javascript`, `tsx`, `http`, `html`, `bash`, `text`). The two `lang="text"` calls in the WebSocket article (RFC 6455 GUID, accept-formula) use Shiki's built-in plain-text alias and work without registration.

### Out of scope (intentional)
- `MicrotaskStarvation` and `CallStackECs` — owned by the parallel `feat/widget-mobile-first` PR.
- `AwaitDesugar`, `RuntimeSimulator`, `_handshake-shared.tsx`'s `TranscriptPane` — these are interactive code-viz widgets with per-line dynamic highlight overlays driven by step-/predicate-based logic, not static teaching listings. Migrating them to `<CodeBlock>` would lose the line-tracking that's the whole point of the widget.

## Test plan
- [ ] Vercel preview — every article's snippets render syntax-highlighted with correct keyword classes for the language.
- [ ] PredictTheStart specifically — opener snippet now shows JS keyword colors.
- [ ] PredictTheOutput — switching variant tabs swaps to a Shiki-highlighted block per variant.
- [x] tsc + build green (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)