### PR TITLE
docs: capture two-flagship patterns; add SVG cover phase; drop max-length

### DIFF
--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -7,27 +7,30 @@ argument-hint: <topic>
 
 You (Claude) are about to author a new bytesize post on the topic: **$ARGUMENTS**.
 
-This command encodes a 9-phase workflow that fires every time the author wants a new post. Read the whole file before acting. The workflow is bounded by four user checkpoints — gate hard at each of them.
+This command encodes a 10-phase workflow (A → I, with H.5 between H and I) that fires every time the author wants a new post. Read the whole file before acting. The workflow is bounded by **five user checkpoints** — gate hard at each of them. (Phase H.5 adds Checkpoint 4.5 for cover concept approval.)
 
 ## Orchestrator mode (when invoked under `/orchestrate`)
 
 If your prompt declares `ORCHESTRATOR_STATE_DIR` and `TASK_ID`, you are running as a `post-author` agent under the orchestrator. **Every user-facing checkpoint below marshals via the mailbox** at `<ORCHESTRATOR_STATE_DIR>/tasks/<TASK_ID>.json` instead of speaking to the user directly. See `.claude/agents/post-author.md` for the full marshalling protocol — read it before Phase A. Outside orchestrator mode (no `ORCHESTRATOR_STATE_DIR` in your prompt), behave exactly as the canonical pipeline below describes.
 
 Checkpoint marshalling (orchestrator mode only):
-- At each Checkpoint, write the proposal/summary into `pending_user_input.prompt`, set `request_id` (a fresh ULID), `asked_at`, leave `response: null`, flip `status` to `awaiting-user`, `phase` to the current letter.
+- At each Checkpoint (1, 2, 3, 4.5, 4), write the proposal/summary into `pending_user_input.prompt`, set `request_id` (a fresh ULID), `asked_at`, leave `response: null`, flip `status` to `awaiting-user`, `phase` to the current letter (use `H.5` for Checkpoint 4.5).
+- For Checkpoint 4.5 (cover concept), prefix the mailbox prompt with `cover-concept:` so the orchestrator surfaces it correctly.
 - Poll your task JSON every 15 seconds for non-null `pending_user_input.response`. When found: clear `pending_user_input` to `null`, flip status back to `running`, parse the response, continue.
 - Max wait 30 minutes; on timeout flip `status` to `failed` with `errors: ["awaiting-user-timeout @ Checkpoint <N>"]`.
 - Use `DEV_PORT` (not 3000) for `pnpm dev`.
 
 ## Hard rules (inviolable)
 
-1. **Never skip Checkpoints 1–4.** Surface them as explicit user-facing decisions (or mailbox transactions in orchestrator mode).
+1. **Never skip Checkpoints 1, 2, 3, 4.5, 4.** Surface them as explicit user-facing decisions (or mailbox transactions in orchestrator mode).
 2. **Never commit or push without explicit "yes, push it" at Checkpoint 4.** No implicit commits.
-3. **Never skip Phase H (correctness validation).** A failing check blocks Checkpoint 4.
+3. **Never skip Phase H (correctness validation) or Phase H.5 (cover authoring).** A failing check at H blocks H.5 + Checkpoint 4. A failing check at H.5 blocks Checkpoint 4.
 4. **Never implement a `DESIGN.md`-banned pattern** even if a design skill suggests it. The bans are authoritative. Reject with reasoning written to the review file.
 5. **Always work on `posts/<slug>` branch.** Never commit directly to `main` during the workflow.
 6. **Always write phase artifacts to `research/<slug>/`** (gitignored) so the run is resumable.
 7. **Read `DESIGN.md`, `content/posts-manifest.ts`, and `components/prose/`, `components/viz/`, `lib/motion/`, `lib/shiki.ts` before drafting code.** These define the vocabulary the post must compose from.
+8. **Read `docs/svg-cover-playbook.md` cover-to-cover before Phase H.5.** It is the authority for animated cover work — element budget, motion amplitudes, register calibration, the 12-item author checklist.
+9. **No max length per section.** Per user direction: *"there shouldn't be any max length limit per section in any of my articles, I am ready to go above and beyond limits if it's necessary to introduce a concept better."* See `docs/voice-profile.md §12.7`. Total post is a soft band of ~1500–2200 words but the gate is "did the concept land," not the count.
 
 ## Bail-out rules
 
@@ -81,8 +84,10 @@ At any checkpoint, the user may give free-form feedback ("redo the outline, swap
    - `ivov.dev/notes/<closest>` — annotated-notes density.
    - `blog.maximeheckel.com/<closest>` — widget-centric teaching.
 2. Per reference, extract: opening-hook style, abstraction ladder (concrete→abstract or reverse), widget-to-prose ratio, first-revelation placement, code-to-diagram ratio, ending style.
-3. Synthesize `research/<slug>/outline.md` — numbered sections with: title, intent, widgets used, approximate word count, pedagogy reference.
-4. **Checkpoint 3** — user reviews the outline. Last cheap edit point before code. Do not proceed until approved.
+3. Synthesize `research/<slug>/outline.md` — numbered sections with: title, intent, widgets used, a *rough advisory* word estimate (no max — see Hard rule #9), pedagogy reference.
+4. **For posts teaching a non-obvious order/output/mechanism**, the outline must include a **§0 premise-quiz opener** (a `<PredictTheStart>`-style W0 widget — see [`docs/voice-profile.md §12.1`](../../docs/voice-profile.md) and [`docs/interactive-components.md §1`](../../docs/interactive-components.md)). The opener's snippet/scenario should be referenced through the body, and the closer should loop back to it. This is the canonical anchor pattern from the two-flagship release.
+5. For posts that unify concepts usually taught separately, plan a "many-views-of-one-mechanism" structure (`docs/voice-profile.md §12.3`): name the unifying mechanism in the outline; the closer says *"X, Y, Z — three names for one mechanism."*
+6. **Checkpoint 3** — user reviews the outline. Last cheap edit point before code. Do not proceed until approved.
 
 ## Phase E — Draft Generation (autonomous)
 
@@ -95,7 +100,7 @@ At any checkpoint, the user may give free-form feedback ("redo the outline, swap
 4. Add entry to `content/posts-manifest.ts` (newest-first via POSTS_NEWEST_FIRST helper).
 5. Run `pnpm exec tsc --noEmit` + `pnpm build`. Fix any errors before proceeding.
 6. Local smoke — ask user to start `pnpm dev` if server isn't running; click through the post, interact with every widget.
-7. If this is post #2 or later: read `docs/voice-profile.md` (or memory's voice profile) and draft against it.
+7. **Read `docs/voice-profile.md` and draft against it** — particularly §12 (the patterns from the two-flagship release: premise-quiz opener, mechanism-first reframe, many-views-of-one-mechanism structure, `<Aside>` for engine internals, `<Term>` for first-jargon, widget-prose ramp, no section length cap, closer-loops-to-opener). The two flagship posts (`app/posts/the-line-that-waits-its-turn/page.tsx` and `app/posts/how-javascript-reads-its-own-future/page.tsx`) are the canonical exemplars — read them end-to-end before writing your first paragraph.
 
 ## Phase F — Design Review via skill orchestration (autonomous)
 
@@ -126,11 +131,38 @@ All 5 checks run unattended; results aggregate to `research/<slug>/validation.md
 4. **Build + Lighthouse** — `pnpm build` must pass; Lighthouse on the post page targets ≥ 95 perf/a11y/SEO.
 5. **Reading-sanity** — read end-to-end at normal pace; note voice drift, undefined terms, flow-breaking widgets. Flag these; do not silently fix voice issues.
 
-Any failing check blocks Checkpoint 4.
+Any failing check blocks Phase H.5 + Checkpoint 4.
+
+## Phase H.5 — Animated SVG cover authoring (requires user input at Checkpoint 4.5)
+
+The article body is now stable. Author the animated cover. **Authority: [`docs/svg-cover-playbook.md`](../../docs/svg-cover-playbook.md). Read it cover-to-cover before drawing any paths.** It contains the 64-px-first rule (§1), the element budget ≤ 14 (§2), motion amplitudes (§3), the bold-vs-refined register calibration (§14), and the 12-item author checklist (§10).
+
+1. **Concept lock first (Checkpoint 4.5).** Before any path, surface a one-sentence concept + element list (≤ 14) + register choice (kinetic / contemplative / pedagogical / reveal — see playbook §14). User approves or revises. The v3-failure / v4-success cycle showed that wrong metaphor + drawn paths = wasted PR. **Do not draw before the concept is approved.** In orchestrator mode this is a `cover-concept:` mailbox prompt.
+2. **Skill phasing** (per playbook §9):
+   - `/clarify` — concept-lock (above).
+   - Draft static SVG (JSX paths, no motion). Aim for the §2 element budget.
+   - `/animate` — motion design. Layer `motion.path` / `motion.g` with §3 amplitudes and §4 continuous loop discipline.
+   - `/delight` — ≤ 1 small joy beat per cover.
+   - `/polish` — final pass: tokens, alignment, off-by-one strokes.
+   - `/bolder` and `/overdrive` are **opt-in only**. Default to refined (playbook §14); apply `/bolder` only when the static draft genuinely reads as safe and the metaphor is kinetic.
+3. **Both exports required.**
+   - **Animated default** — `components/covers/<NameOf>Cover.tsx` — uses `motion/react`, hooks, CSS variables, `useId()`, `whileHover`.
+   - **Sibling `<Name>CoverStatic`** — pure JSX matching the cover's reduced-motion end-state. **Inline hex palette only.** No `motion.*`, no hooks, no `color-mix`, no CSS vars. Required by the OG share-preview composition (`app/og/[slug]/route.tsx`); CSS vars don't resolve there.
+4. **Registry update** — add the slug → component mapping in `components/covers/PostCover.tsx`.
+5. **Validation gate** (must all pass):
+   - `pnpm exec tsc --noEmit` green.
+   - `pnpm build` green.
+   - Static-export purity: `grep -E "motion\\.|use[A-Z]|color-mix|var\\(--"` returns clean inside the `<Name>CoverStatic` block.
+   - 64-px AND hero-size mental sweep — cover reads at both.
+   - Reduced-motion end-state visible (the static frame must carry the metaphor).
+   - All 12 items in `docs/svg-cover-playbook.md §10` ticked.
+6. **On failure**, refactor against `docs/svg-cover-playbook.md §11` (the diagnostic ladder) — don't tweak.
+
+A failing Phase H.5 blocks Checkpoint 4 (PR approval) until resolved.
 
 ## Phase I — PR, preview, merge (requires user input at Checkpoint 4)
 
-1. Stage: `app/posts/<slug>/`, `content/posts-manifest.ts`, any graduated widgets, updates to `docs/voice-profile.md`. **Do not** stage `research/<slug>/`. Remove `app/_scratch/<slug>/` if present.
+1. Stage: `app/posts/<slug>/`, `content/posts-manifest.ts`, any graduated widgets, **the Phase H.5 cover artefacts** (`components/covers/<NameOf>Cover.tsx` + the `components/covers/PostCover.tsx` registry entry), updates to `docs/voice-profile.md`. **Do not** stage `research/<slug>/`. Remove `app/_scratch/<slug>/` if present.
 2. Commit on branch `posts/<slug>` with a descriptive message: what shipped (widget count, section count, reading minutes) + a cliffhanger for the next post.
 3. Push the branch. `gh pr create` with title = post title, body = summary covering:
    - widgets shipped + which primitives composed from
@@ -169,8 +201,9 @@ Two `/new-post` invocations with different slugs are supported — each has its 
 | F. Design review | 15–30 min |
 | G. Iteration | 15–60 min |
 | H. Validation | 15 min |
+| H.5 Animated cover | 30–60 min (concept-lock + draft + animate + polish) |
 | I. Commit & merge | 5 min active |
-| **Total** | **~2–4 hours per post**, across 1–3 sessions |
+| **Total** | **~2.5–5 hours per post**, across 1–3 sessions |
 
 ---
 

--- a/docs/pipeline-playbook.md
+++ b/docs/pipeline-playbook.md
@@ -6,19 +6,26 @@ Cross-reference: [`voice-profile.md`](./voice-profile.md), [`interactive-compone
 
 ---
 
-## 1. Pipeline overview — nine phases, four checkpoints
+## 1. Pipeline overview — ten phases, five checkpoints
 
 ```
-A  Intake                   → Checkpoint 1 (slug + title + pitch)
-B  Research                 → Checkpoint 2 (kernel + angle)
-C  Interactive design
-D  Pedagogy analysis        → Checkpoint 3 (outline)
-E  Draft
-F  Design review (skills)
-G  Iteration on action items
-H  Correctness validation
-I  PR + preview             → Checkpoint 4 (merge or revise)
+A    Intake                       → Checkpoint 1 (slug + title + pitch)
+B    Research                     → Checkpoint 2 (kernel + angle)
+C    Interactive design
+D    Pedagogy analysis            → Checkpoint 3 (outline)
+E    Draft
+F    Design review (skills)
+G    Iteration on action items
+H    Correctness validation
+H.5  Animated SVG cover authoring → Checkpoint 4.5 (cover concept lock)
+I    PR + preview                 → Checkpoint 4 (merge or revise)
 ```
+
+Phase H.5 is new (added 2026-04-26 after the two-flagship release). It runs after the article body validates and before the PR opens — the cover metaphor inherits a stable hook + mechanism + angle from the validated body. Authority for cover work is [`svg-cover-playbook.md`](./svg-cover-playbook.md); read it cover-to-cover before authoring. See §2 → Phase H.5 for the in-pipeline brief.
+
+### Length discipline (applies across the pipeline)
+
+**No max length per section.** Right-size each section to the concept's cognitive arc — sections may run long when the concept demands it. Per user direction: *"there shouldn't be any max length limit per section in any of my articles, I am ready to go above and beyond limits if it's necessary to introduce a concept better."* Total article word count remains a soft target (around 1500–2200 words for a 12–15-min read) but is **not a hard gate**; landing the concept is the gate. The `outline.md` file at Phase D may carry rough word estimates as a planning aid, but those estimates are advisory — landing the mechanism cleanly takes priority over hitting them. See [`voice-profile.md §12.7`](./voice-profile.md).
 
 Hard rules (never skip):
 - Gate the four checkpoints. Never proceed without explicit user approval.
@@ -61,7 +68,9 @@ Other orchestrator-mode constraints:
 
 ### Phase D — Pedagogy analysis
 - Read one reference post from each inspiration site (nan.fyi, ivov.dev/notes, blog.maximeheckel.com) to calibrate pacing.
-- Write `outline.md` — numbered sections with widget placement, word count estimate, and pedagogy reference per section.
+- Write `outline.md` — numbered sections with widget placement, a rough word estimate (advisory only — see Length discipline in §1), and pedagogy reference per section.
+- **For posts teaching a non-obvious order/output/mechanism**: the outline must include a §0 premise-quiz opener (a `<PredictTheStart>`-style W0 widget). See [`voice-profile.md §12.1`](./voice-profile.md). The opener's snippet/scenario should be referenced through the body so every later section reinforces it, and the closer (final section) should loop back to it.
+- For posts teaching a mechanism that's usually presented as multiple separate concepts: name the unifying mechanism in the outline, and plan a closer that says *"X, Y, Z — three names for one mechanism."* See [`voice-profile.md §12.3`](./voice-profile.md).
 - This is the last cheap edit point before code. User gets Checkpoint 3 here.
 
 ### Phase E — Draft
@@ -100,8 +109,49 @@ Other orchestrator-mode constraints:
   6. **SEO sweep** — title ≤ 70 chars (60 ideal), description ≤ 160 chars, `keywords[]` present (8–10 terms), `alternates.canonical` set, OG + Twitter mirror title + description, `openGraph.type === "article"`, `openGraph.publishedTime` set, visible H1 matches `VISIBLE_HEADING`, `subtitle` export matches `LYRICAL_TAGLINE`. See `voice-profile.md §11`.
 - Any failing check blocks Checkpoint 4 until resolved.
 
+### Phase H.5 — Animated SVG cover authoring
+
+Runs **after** Phase H validation passes on the article body and **before** the PR is opened in Phase I. The cover metaphor is shaped by the article's mechanism — author it after the body is stable, not before. (See §6 pitfall: *"Cover authored before the article validates."*)
+
+**Authority.** [`svg-cover-playbook.md`](./svg-cover-playbook.md) is the single source of truth for cover work. **Read it cover-to-cover before authoring.** It contains:
+- The 64-px-first rule (§1) — covers are read at thumbnail size first.
+- Element budget ≤ 14 (§2) — the v3 → v4 lesson.
+- Motion amplitude rules (§3) — what reads at a 4× downscale.
+- Continuous motion, not phase-stagger (§4).
+- The bold-vs-refined calibration (§14) — the *register* the cover should land in. Default to refined for chrome; the hero element gets the punctuation.
+- The 12-item author checklist (§10) — must tick all 12 before push.
+
+**What this phase produces.**
+1. `components/covers/<NameOf>Cover.tsx` — the per-post bespoke cover component (animated default; uses `motion/react`, hooks, CSS variables, `useId`, `whileHover`).
+2. A registry update in `components/covers/PostCover.tsx` — slug → component.
+3. **A sibling `<Name>CoverStatic` export** — pure JSX matching the cover's reduced-motion end-state — for the OG share-preview composition (`app/og/[slug]/route.tsx`). The static export must use **inline hex palette only** (no `motion.*`, no hooks, no `color-mix`, no CSS vars) because it renders inside Next's OG image route, where CSS variables don't resolve.
+
+Both exports are required. Static-export purity is verified in the validation step below.
+
+**Concept-lock gate (Checkpoint 4.5).** Before drawing any paths, surface a one-sentence concept + element list to the user for approval. The v3-failure / v4-success / v7-revamp cycle (`svg-cover-playbook.md §13`) showed that wrong metaphor + drawn paths = wasted PR. Lock the concept first. In orchestrator mode this is a mailbox prompt prefixed `cover-concept:`; out of orchestrator mode it's a direct ask.
+
+**Skill phasing** (per `svg-cover-playbook.md §9` and §14):
+- `/clarify` — concept-lock. Write the cover as one sentence ("a comet hits a CORS wall and bounces"); if you can't say it in one sentence, the cover is wrong.
+- Draft static SVG — JSX paths only, no motion yet. Aim for the §2 element budget.
+- `/animate` — motion design. Layer `motion.path` / `motion.g` with §3 amplitudes and §4 loop discipline.
+- `/delight` — ≤ 1 small joy beat per cover.
+- `/polish` — final pass: token compliance, alignment, off-by-one strokes.
+
+`/bolder` and `/overdrive` are **opt-in only**. Many covers don't want them. Default to refined; apply `/bolder` only when the static draft genuinely reads as safe and the metaphor is kinetic. See `svg-cover-playbook.md §14` for per-cover register guidance (kinetic / contemplative / pedagogical / reveal).
+
+**Validation gate** (must all pass before push):
+- `pnpm exec tsc --noEmit` green.
+- `pnpm build` green.
+- Static-export purity grep on `<Name>CoverStatic`: `grep -E "motion\\.|use[A-Z]|color-mix|var\\(--"` returns clean (no matches inside the static export). The OG route can't resolve CSS vars or call hooks.
+- 64-px AND hero-size mental sweep — the cover reads at both.
+- Reduced-motion end-state visible (the static frame must carry the metaphor on its own).
+- All 12 items in `svg-cover-playbook.md §10` ticked.
+
+**On failure.** If the cover doesn't read at 64 px, refactor against `svg-cover-playbook.md §11` (the diagnostic ladder). Don't tweak — refactor. v3 → v4 was a refactor, not tweaks; that's why it succeeded.
+
 ### Phase I — PR + preview
 - Stage only post-scoped files. **Never `git add -A`** — other in-progress work on the branch may not be yours.
+- Stage Phase H.5 cover artefacts: `components/covers/<NameOf>Cover.tsx` and the `components/covers/PostCover.tsx` registry update.
 - Research dir stays gitignored. Confirm with `git status` before committing.
 - Remove `app/_scratch/<slug>/` if present.
 - Commit on the feature branch. Push with `-u`. `gh pr create` with a full body: summary, widgets shipped, P0 action resolution table, test plan, cliffhanger.
@@ -144,6 +194,9 @@ Surface: `kernel.md` (1 aha + 5 facts + differentiation notes) and `questions.md
 
 ### Checkpoint 3 — Outline approval
 Surface: `outline.md` — section-by-section, widget placement, word targets. Last cheap edit point.
+
+### Checkpoint 4.5 — Cover concept approval (Phase H.5)
+Surface: a one-sentence cover concept + an element list (≤ 14) + the chosen register (kinetic / contemplative / pedagogical / reveal — see `svg-cover-playbook.md §14`). User approves or revises **before** any paths are drawn. The v3-failure / v4-success cycle showed concept-lock saves a wasted PR. In orchestrator mode this is a `cover-concept:` mailbox prompt.
 
 ### Checkpoint 4 — PR approval
 Surface: `validation.md`, a preview URL, and explicit asks for widget/theme/kb testing. Block on explicit "yes push it" before merge.
@@ -210,6 +263,8 @@ Each of the six design-review skills targets a specific quality axis. Run all si
 - **Simulating real performance hazards in teaching widgets** — state-machine simulation, not real recursion / timer-flooding / rAF consumption. See `interactive-components.md §5`.
 - **DragElements for sequenced/structured concepts** — use static layout + springs + `<AnimatePresence>` instead. Drag is for "you decide where these go" affordances only.
 - **Clanky scripted-stepper transitions** — use `<LayoutGroup>` + `layoutId` for shared elements that move (program-counter, active-frame indicator), `<AnimatePresence>` for items that enter/exit (queue chips, stack frames), and springs (not duration tweens) for transitions.
+- **Cover authored before the article validates.** The cover metaphor is shaped by the article's mechanism, not the other way around. Author the cover **after** the article body's Phase H validation passes — the cover then has a stable hook, mechanism, and angle to inherit from. Authoring earlier risks a metaphor mismatch when the article shifts during iteration. (Phase H.5 enforces this ordering.)
+- **Capping a section to a word target.** No max length per section. Right-size each section to the concept's cognitive arc. Per user direction: *"there shouldn't be any max length limit per section in any of my articles, I am ready to go above and beyond limits if it's necessary to introduce a concept better."* The signal of bloat is meandering, not word count. See [`voice-profile.md §12.7`](./voice-profile.md).
 
 ## 6.5 Redesign-vs-iterate signal
 
@@ -225,8 +280,9 @@ PR #46's CallStackECs went through it too: round-2 used `DragElements`, round-3 
 ## 7. Reference reading order for a new Claude session
 
 1. This file (`pipeline-playbook.md`) — the pipeline + lessons.
-2. [`voice-profile.md`](./voice-profile.md) — tone, prose rules, widget rules.
+2. [`voice-profile.md`](./voice-profile.md) — tone, prose rules, widget rules. **§12 captures the patterns from the two-flagship release** (event-loop + hoisting/TDZ) — read it before drafting.
 3. [`interactive-components.md`](./interactive-components.md) — widget shapes and primitive catalogue.
-4. [`../DESIGN.md`](../DESIGN.md) — the design system (tokens, motion, bans).
-5. A recent shipped post (e.g. `app/posts/the-webpage-that-reads-the-agent/page.tsx`) — how it all composes.
-6. The `/new-post` command at `.claude/commands/new-post.md` — the canonical workflow definition.
+4. [`svg-cover-playbook.md`](./svg-cover-playbook.md) — animated cover authoring (Phase H.5 authority).
+5. [`../DESIGN.md`](../DESIGN.md) — the design system (tokens, motion, bans).
+6. A recent shipped post pair — `app/posts/the-line-that-waits-its-turn/page.tsx` and `app/posts/how-javascript-reads-its-own-future/page.tsx` — the canonical exemplars for voice + structure as of 2026-04.
+7. The `/new-post` command at `.claude/commands/new-post.md` — the canonical workflow definition.

--- a/docs/voice-profile.md
+++ b/docs/voice-profile.md
@@ -26,7 +26,7 @@ Every post answers a question the reader has already felt (*"how does X feel so 
 - **Rare terms defined in ≤ 8 words.** "Strict serialisability — a promise that, from the outside, it's as if every transaction happened one at a time." Not "for a total order σ consistent with real-time partial order, …"
 - **Citations go in `<Aside>`, `<Callout>`, or inline `<A href>` links.** Never `(Bose et al. 2008)`-style parenthetical references in body prose.
 - **No cliffhangers, no "next bytesize" teasers.** Every post stands alone. The closer lands on the reader's new capability, not on a pointer forward. Exception: one-sentence "this connects to X" if the connection is genuinely load-bearing.
-- **Cut to the bone.** Target ≤ 1500 words of `<P>` prose for a 12–15-min post. If a section is over 250 words with no interactive, it's probably too long.
+- **Cut to the bone — but don't cap a section.** Total `<P>` prose runs in a soft band of ~1500–2200 words for a 12–15-min post. **No max length per section** — right-size each one to the concept's cognitive arc. Per user direction (post #46 / #47): *"there shouldn't be any max length limit per section in any of my articles, I am ready to go above and beyond limits if it's necessary to introduce a concept better."* If a section needs 800 words to land its mechanism cleanly, take 800 — landing the concept is the gate. The signal of bloat isn't word count, it's meandering: if the prose has stopped advancing the argument, cut. See §12 for the full pattern.
 
 ## 4. Widget rules
 
@@ -196,3 +196,149 @@ When validating a post, the SEO sweep is part of the gate (`pipeline-playbook.md
 - OG + Twitter mirror title + description
 - Visible H1 matches `VISIBLE_HEADING` exactly
 - `subtitle` export matches `LYRICAL_TAGLINE`
+
+## §12. Patterns from the two-flagship release (event-loop + hoisting/TDZ)
+
+Two posts shipped back-to-back in late April 2026 — *"JavaScript Event Loop Explained: Microtasks and the Call Stack"* (`the-line-that-waits-its-turn`) and *"JavaScript Hoisting, the TDZ, and the Call Stack Explained"* (`how-javascript-reads-its-own-future`). The user's verbatim direction after the pair landed: *"I am deeply in love with the pedagogy, the tone, the writing manner, the layout, the interactive components of [these two articles]. update our content creation guidelines to follow and adhere to these for voice profiling, layout, preface and overall structure."*
+
+These patterns are additive — they don't replace §§1–11, they extend them for posts that teach a non-obvious order, output, or mechanism.
+
+### §12.1. The premise-quiz opener as the article anchor
+
+**Rule.** Open the post with a hard quiz the reader is expected to fail — a `<PredictTheStart>`-style W0 widget (see [`interactive-components.md §1`](./interactive-components.md), Premise quiz row) that surfaces a snippet, asks for the predicted output / order, and reveals a wrong answer most readers will give. The wrong answer creates demand for the explanation; everything that follows pays the demand back.
+
+**Example** (event-loop opener, `the-line-that-waits-its-turn/page.tsx`):
+
+```tsx
+{/* §0 — the quiz hook */}
+<P>
+  Before we explain anything, try the snippet below. Read it once, then
+  guess the order it prints. Most readers get this wrong on the first
+  try — and <HL>the gap between your guess and the truth is exactly
+  what this post fills</HL>.
+</P>
+
+<PredictTheStart />
+```
+
+The opener's snippet/scenario stays referenced through the body. §1 names *why* `A`, `F`, `H` print first; §3 names *why* `B` lands last; §4 names *why* `G` doesn't sit next to `F`; §6 (the closer) tells the reader to scroll back and re-run the opener. Every later section reinforces the opener's puzzle.
+
+The hoisting post does the same with a smaller snippet (`console.log(x); var x = 5;`) and walks four sections back to it.
+
+**When not to use.** Posts where the topic is a product moment / system tour rather than a non-obvious mechanism (e.g. the Gmail post). Those still want a flow widget within 150 words (§2), but the opener is a scene, not a quiz. The quiz opener is for posts whose central question is "what does this do, and why?"
+
+### §12.2. Mechanism-first reframe, not feature-first taxonomy
+
+**Rule.** Both flagship articles begin from the *mechanism* — the engine reads ahead; the loop drains microtasks first — and not from a feature taxonomy (`var` vs `let` vs `const`; microtasks vs macrotasks vs the call stack). The taxonomy is a *consequence* of the mechanism, presented after the mechanism is in the reader's hands.
+
+**Example** (hoisting post, §1):
+
+> "The trick isn't that `var` moved anywhere. *Nothing moves. The engine walks the body once before any of it runs.* On that first pass — call it the creation phase — every `var`, every `let`, every function declaration, every parameter gets a binding installed in the function's memory."
+
+§2 then runs the four declaration-kind cases. The taxonomy isn't the lesson; it's a *check* — does the mechanism explain what each kind does at line 1? Yes, and that's the proof.
+
+The TDZ article reframes hoisting + TDZ + call stack as **"one mechanism, not three quirks."** The closer (§5) lands on it: *"Hoisting, the TDZ, functions callable from above — three names for one mechanism."*
+
+**When not to use.** Posts where the topic IS a taxonomy (the agent-traps post, with its four-class framework). Those want argument-claim H2s per class (§9), not a prior mechanism. The mechanism-first reframe is for posts where two or three concepts are usually taught separately *but share a single underlying machine*.
+
+### §12.3. The "many-views-of-one-mechanism" structural device
+
+**Rule.** When teaching a system whose pieces are usually taught separately, present them as multiple views of one mechanism. The closing recap names the mechanism explicitly.
+
+The event-loop post does this with two queues + the call stack — they're not three things, they're three views of "the loop only reaches into its queues when the stack is empty, and the microtask queue drains first."
+
+The hoisting post does it with hoisting + TDZ + execution context — three names for the creation-phase pre-walk.
+
+**Closer formulation:** *"X, Y, and Z — three names for one mechanism."* (or its variant: *"the rule that lets [X feel seamless] is the same rule that lets [Y stall the tab]."*) Then a single italic line restating the mechanism. Then a single centred terracotta dot.
+
+**Example** (event-loop closer):
+
+> "The line that waits its turn is the task queue. The line that *doesn't* is the microtask queue — it gets drained completely, every checkpoint, before anything else moves. One rule explains why `await` works, why `setTimeout(0)` is never zero, and why one runaway Promise stalls your whole tab."
+
+**When not to use.** Single-concept posts (one widget, one insight) — they don't have multiple views to unify. Use this when the article frames itself as resolving an apparent contradiction or merging concepts the reader thinks of separately.
+
+### §12.4. Inline `<Aside>` for engine implementation details
+
+**Rule.** Use `<Aside>` for "if you want to go one level deeper" beats — V8 preparser citations, ECMA-262 §10.2.x references, browser-convergence history, libuv vs HTML-spec divergence, V8 fast-path optimisations. Without the Aside the article would lose technical credibility; with it the main flow stays readable.
+
+The aside is **never** load-bearing for the lesson. A reader who skips every Aside still gets the article. A reader who reads them gets the engine-internals layer that earns the post's authority.
+
+**Example** (hoisting post, §1):
+
+```tsx
+<Aside>
+  The spec name for this pre-walk is{" "}
+  <Code>FunctionDeclarationInstantiation</Code> for function bodies
+  and <Code>GlobalDeclarationInstantiation</Code> for the script. See{" "}
+  <A href="https://tc39.es/ecma262/multipage/...">ECMA-262 §10.2.11</A>.
+  Throughout this post we'll just call it the creation phase.
+</Aside>
+```
+
+**Cadence.** 1 Aside per major section is plenty; 2 in a 5-section post is the upper bound. More than that and the asides start carrying weight that should be in the prose.
+
+**When not to use.** For a callout that the reader MUST read to understand the next paragraph — that belongs in `<P>`, not `<Aside>`. The Aside is for the reader who wants the next layer down, not for the reader trying to follow the main argument.
+
+### §12.5. `<Term>` for first-introduction of jargon
+
+**Rule.** Both flagship articles `<Term>`-mark new terms on their first appearance and only their first. After that, the term is plain text or `<Code>`. The Term tag tells the reader *this is the spec name; remember it because it'll come back* — and the article rewards the memory.
+
+**Example** (hoisting post): `<Term>creation phase</Term>` on first mention in §1; thereafter just "the creation phase" in plain prose. `<Term>temporal dead zone</Term>` on first mention in §2; thereafter "the TDZ." `<Term>variable environment</Term>`, `<Term>lexical environment</Term>` on first mention in §3.
+
+**When not to use.** Don't `<Term>`-mark a word the reader already knows in the post's domain. (Don't `<Term>`-mark "function" in a hoisting article; the reader knows it.) And don't double-mark — once a term is introduced, it's introduced.
+
+### §12.6. The widget-prose ramp
+
+**Rule.** Every widget sits inside three pieces of prose:
+
+1. **Motivating ramp** (1–2 sentences) that sets up the question the widget answers.
+2. **The widget.**
+3. **Landing paragraph** (1–2 sentences, often containing an `<HL>`-marked phrase) that names what the widget showed.
+
+The widget is **never standalone**. A widget without a ramp lands in the middle of the page with no prompt; a widget without a landing paragraph leaves the reader to derive the lesson on their own. Both fail.
+
+**Example** (event-loop, around `RuntimeSimulator`):
+
+> *Ramp:* "So the engine is single-threaded, but the runtime around it is doing work in parallel… The widget below walks ten ticks of a small program and shows where every piece sits."
+>
+> `<RuntimeSimulator />`
+>
+> *Landing:* "By tick 7 the stack is empty, both queues hold one item, and the loop reaches in. It pulls from the microtask queue first… The microtask jumped the line — `<HL>the rule that let it isn't a quirk; it's the entire model</HL>`."
+
+**When not to use.** The W0 / opener widget can skip the landing paragraph if the *next section* (§1) carries that role — the opener's snippet is referenced through the body, so the landing is distributed across the article. Every other widget needs all three pieces.
+
+### §12.7. No section length cap
+
+**Rule.** **There is no max length per section.** Word counts on individual sections are not a quality signal; cognitive arc completion is. A section is "right-sized" when the concept is fully introduced — even if that takes 800 words.
+
+Per user direction: *"there shouldn't be any max length limit per section in any of my articles, I am ready to go above and beyond limits if it's necessary to introduce a concept better."*
+
+This durably replaces any prior "≤ N words per section" or "if a section is over N words it's too long" heuristic. The flagship event-loop post's §3 (the two queues + microtask checkpoint) and §4 (await desugaring) both run long, and that's correct — those are the sections where the mechanism is introduced and stress-tested across cases. Cutting them to fit a heuristic would have lost the article.
+
+The total post target stays a soft band (~1500–2200 words for a 12–15-min read) but is **not a hard gate**. If landing the mechanism takes 2400 words, take 2400.
+
+**The signal of bloat is not word count** — it's meandering. A section is too long if the prose has stopped advancing the argument. A section is right-sized if every paragraph is doing teaching work, regardless of how many of them there are.
+
+**When this binds.** This rule applies to *body* sections — the ones doing teaching. The opener (§0) and closer remain compact by their nature; the closer especially is allowed to be one paragraph + one italic line + a dot (see §9 closer pattern). Don't read "no length cap" as licence to bloat the opener.
+
+### §12.8. Closer that loops back to the opener
+
+**Rule.** The closer references the opener directly. The reader is invited to re-read the opener with their new mental model and find that the puzzle is no longer a puzzle.
+
+**Example** (event-loop closer):
+
+> "Scroll back up and run the opener again. The order isn't a riddle anymore — it's the sequence the runtime had to take."
+
+**Example** (hoisting closer):
+
+> "Hoisting, the TDZ, functions callable from above — three names for one mechanism. The opening scene wasn't a quirk. It was the mechanism showing through.
+>
+> *The engine reads your future to run your present.*"
+
+The closer is **still prose**, optionally with one italic line and a centred terracotta dot. **Not `VerticalCutReveal`** — that primitive is banned (see playbook). The pacing comes from `<HL>` and the dot, not from a reveal animation.
+
+**When not to use.** Posts that don't open with a quiz (product-moment posts) loop the closer back to the *scene* instead — the gmail post closes on "the gap between Google and Netflix" because the scene was about that gap. Same shape, different anchor. The rule is "loop back to the opening anchor," whatever the anchor was.
+
+### §12.9. Voice register confirmation (no change, just emphasis)
+
+The two flagship posts confirm — don't change — the §3 prose rules. Engineer-not-paper. Second-person hooks (*"You type two lines into a console…"*, *"Before we explain anything, try the snippet below…"*). Mechanism-first sentences (*"The engine reads your file before it runs line 1."*). Numbers felt, not derived. Aside / Term / Em / Code primitives sprinkled to build texture without bloating the prose. If a future agent finds themselves drifting from that register, re-read these two posts as the canonical exemplars.


### PR DESCRIPTION
## Summary

Update bytesize content-creation guidelines to (1) reflect the patterns the user fell in love with in the event-loop + hoisting/TDZ flagship pair, (2) add the animated SVG cover authoring step into the pipeline, and (3) drop the per-section word-length cap.

User's verbatim direction: *"I am deeply in love with the pedagogy, the tone, the writing manner, the layout, the interactive components of [the event-loop and hoisting/TDZ articles]. update our content creation guidelines to follow and adhere to these for voice profiling, layout, preface and overall structure. add the SVG animation generation step to the content creation pipeline. there shouldn't be any max length limit per section."*

### `docs/voice-profile.md`

- **New §12 — Patterns from the two-flagship release.** Eight new patterns:
  1. Premise-quiz opener as the article anchor (`<PredictTheStart>` W0 widget; opener referenced through the body; closer loops back).
  2. Mechanism-first reframe, not feature-first taxonomy.
  3. The "many-views-of-one-mechanism" structural device (closer says *"X, Y, Z — three names for one mechanism"*).
  4. Inline `<Aside>` for engine implementation details (V8 preparser, ECMA-262 §10.2.x, libuv vs HTML-spec).
  5. `<Term>` for first-introduction of jargon, only on first appearance.
  6. The widget-prose ramp (motivating ramp → widget → landing paragraph).
  7. **No section length cap.** Right-size to the concept's cognitive arc.
  8. Closer that loops back to the opener.
- §3 prose rule rewritten: no max length per section; soft total band ~1500–2200 words.

### `docs/pipeline-playbook.md`

- Phase overview now ten phases / five checkpoints (Phase H.5 added between H and I; Checkpoint 4.5 added before Checkpoint 4).
- **Phase H.5 — Animated SVG cover authoring**: concept-lock gate, `svg-cover-playbook.md` as authority, both animated + `<Name>CoverStatic` exports required, skill phasing (`/bolder` and `/overdrive` opt-in only), validation gate (tsc + build + static-export purity grep + 64-px sweep + reduced-motion end-state + 12-item checklist).
- §6 pitfalls added: cover authored before body validates; capping a section to a word target.
- §7 reading-order names the two flagship posts as the canonical exemplars.
- Length discipline rewritten at the top of §1.

### `.claude/commands/new-post.md`

- New Hard rule #9: no max length per section (with verbatim user quote).
- Phase H.5 inlined into the workflow — concept lock first; skill phasing per playbook §9; both exports required; validation gate.
- Checkpoint 4.5 (cover concept approval) added with mailbox prefix `cover-concept:` for orchestrator mode.
- Phase D outline guidance: premise-quiz opener required for non-obvious order/output/mechanism posts; many-views-of-one-mechanism structure named.
- Phase E now reads `voice-profile.md §12` as required pre-draft.
- Phase I stages the cover artefacts (`<NameOf>Cover.tsx` + registry).
- Time budget extends to ~2.5–5 hours per post.

## Sibling work in flight

- `feat/quiz-wrapper` — adds to `interactive-components.md §2`. Does not touch this PR's files.
- `feat/widget-mobile-first` — adds to `interactive-components.md §4`. Does not touch this PR's files.
- `docs/svg-cover-playbook.md` — left untouched (it is the authority cited by the new Phase H.5).

## Test plan

- [x] `pnpm exec tsc --noEmit` green (no code touched).
- [x] `pnpm build` green.
- [x] Grep for max-section-words references returns only intentional "no max length" rules.
- [ ] Reviewer: confirm voice-profile.md §12 captures the patterns observed in the two flagship articles.
- [ ] Reviewer: confirm Phase H.5 brief matches the practice from the recent cover sets.
- [ ] Reviewer: confirm `/new-post` workflow now has Checkpoint 4.5 surfaced before any cover paths are drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)