### PR TITLE
feat(widgets): mobile-first redesign of queue-race + call-stack-ECs + doc

### DIFF
--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -21,6 +21,8 @@ import {
   WhyTwoPasses,
   ClosingDot,
 } from "./widgets";
+import { CALL_STACK_SNIPPET } from "./widgets/CallStackSnippet";
+import { CodeBlock } from "@/components/code";
 import { metadata, subtitle } from "./metadata";
 
 export { metadata };
@@ -227,9 +229,9 @@ export default function HowJavaScriptReadsItsOwnFuture() {
         <P>
           Step through the widget below to watch a tiny program run:{" "}
           <Code>compute(7)</Code> calls <Code>multiply(7, 2)</Code>, which
-          returns <Code>14</Code>. The arrow shows where the thread is —
-          pointing from the line being run to the context running it. Each
-          call pushes a new EC onto the stack; each return pops one.{" "}
+          returns <Code>14</Code>. The highlighted line and the highlighted
+          frame are paired — the line being run, and the context running it.
+          Each call pushes a new EC onto the stack; each return pops one.{" "}
           <HL>
             Whichever frame is on top is the engine&apos;s thread of
             execution.
@@ -237,7 +239,16 @@ export default function HowJavaScriptReadsItsOwnFuture() {
         </P>
       </div>
 
-      <CallStackECs />
+      <CallStackECs
+        codeSlot={
+          <CodeBlock
+            code={CALL_STACK_SNIPPET}
+            lang="javascript"
+            filename="program.js"
+            showLineNumbers
+          />
+        }
+      />
 
       <div className="pt-[var(--spacing-lg)]">
         <P>

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -6,80 +6,60 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { WidgetShell } from "@/components/viz/WidgetShell";
 import { PRESS, SPRING } from "@/lib/motion";
+import { CALL_STACK_SNIPPET } from "./CallStackSnippet";
 
 /**
- * CallStackECs — W3, the SPINE of "how JavaScript reads its own future".
+ * CallStackECs v2 — mobile-first, frame-stable.
  *
- * A static, annotated call-stack visualization. The reader presses Step
- * (or Run) to walk through a tiny program. On each step:
- *   - the active source line lights up in the code pane,
- *   - execution-context cards push/pop on the stack pane via spring,
- *   - on desktop, an SVG arrow connects the active line to the active EC
- *     ("the thread of execution is here"),
- *   - on mobile (≤ 640px container) the arrow collapses to a small
- *     down-glyph between the two stacked panes,
- *   - the console pane mirrors `console.log` output as it fires.
+ * Layout:
+ *   - Mobile (< 720 px container): vertical stack — controls / code pane /
+ *     stack pane / console pane. Each region reserves a fixed `min-h` so the
+ *     outer shell never resizes during stepping. Tap targets ≥ 44 px.
+ *   - lg (≥ 720 px container, via @container query): two columns — code +
+ *     console on the left, stack on the right. The SVG arrow overlay
+ *     activates only at this breakpoint to connect active line → top frame.
  *
- * Replaces the round-2 DragElements implementation. The cards are not
- * draggable; the thread of execution is *annotated*, not manipulated.
+ * Code rendering: the snippet is pre-rendered by `<CodeBlock>` (server
+ * component, async) in `page.tsx` and passed in as a `codeSlot: ReactNode`
+ * prop. The widget overlays a terracotta wash on the active line by
+ * measuring the rendered Shiki `<span class="line">` rows with
+ * `useLayoutEffect` + `ResizeObserver`. The Shiki HTML is unchanged.
  *
- * Frame stability (R6): every pane reserves a fixed min-height that fits
- * the deepest stack the snippet produces (3 frames) and the longest
- * console output, so step changes never reflow the outer shell.
+ * Frame stability (R6):
+ *   - code pane min-height fits the SNIPPET line count.
+ *   - stack pane min-height fits the deepest stack (3 frames).
+ *   - console pane min-height fits the longest emit list (2 lines).
+ *   - mobile down-glyph row reserves its own height (rendered always; toggled
+ *     visible/hidden so :nth-child indexes stay stable for the @container
+ *     fallback).
  */
 
 type ECName = "global" | "compute" | "multiply";
 
-type Binding = {
-  name: string;
-  value: string;
-};
+type Binding = { name: string; value: string };
 
 type EC = {
-  /** Stable identifier — keeps cards mounted across steps where possible. */
   id: ECName;
-  /** Header label inside the card. */
   label: string;
-  /** The card's variable environment at this step. */
   ve: Binding[];
 };
 
-type ConsoleLine = {
-  /** Monotonically incremented per emit. */
-  id: number;
-  text: string;
-};
+type ConsoleLine = { id: number; text: string };
 
 type Step = {
-  /** Stack from bottom to top. The top frame is the running EC. */
   stack: EC[];
-  /** Active line in the source panel (1-indexed). */
+  /** 1-indexed line number into SNIPPET. */
   activeLine: number | null;
-  /** New console.log output appended at this step (if any). */
   emit: string | null;
-  /** Caption beat. */
   beat: string;
 };
 
-const SNIPPET = [
-  "function multiply(a, b) {",
-  "  const result = a * b;",
-  "  return result;",
-  "}",
-  "",
-  "function compute(x) {",
-  "  const doubled = multiply(x, 2);",
-  "  console.log(doubled);",
-  "  return doubled;",
-  "}",
-  "",
-  "const answer = compute(7);",
-  "console.log(answer);",
-];
+const SNIPPET_LINES = CALL_STACK_SNIPPET.replace(/\n+$/, "").split("\n").length;
 
 const GLOBAL_VE_INITIAL: Binding[] = [
   { name: "multiply", value: "ƒ" },
@@ -195,9 +175,17 @@ const STEPS: Step[] = [
 const TOTAL = STEPS.length;
 const RUN_INTERVAL_MS = 900;
 
-type Props = { initialStep?: number };
+type Props = {
+  initialStep?: number;
+  /**
+   * Pre-rendered `<CodeBlock>` from `page.tsx`. Server-side Shiki output
+   * with line numbers + chrome. The widget overlays the active-line wash
+   * on top of this slot via absolute positioning.
+   */
+  codeSlot?: ReactNode;
+};
 
-export function CallStackECs({ initialStep = 0 }: Props) {
+export function CallStackECs({ initialStep = 0, codeSlot }: Props) {
   const [step, setStep] = useState(initialStep);
   const [consoleLog, setConsoleLog] = useState<ConsoleLine[]>([]);
   const [running, setRunning] = useState(false);
@@ -208,7 +196,6 @@ export function CallStackECs({ initialStep = 0 }: Props) {
   const current = STEPS[clamped];
   const topFrame = current.stack[current.stack.length - 1];
 
-  // Console-log emissions: append once per fresh step.
   useEffect(() => {
     if (lastEmittedStep.current === clamped) return;
     lastEmittedStep.current = clamped;
@@ -220,7 +207,6 @@ export function CallStackECs({ initialStep = 0 }: Props) {
     }
   }, [clamped, current.emit]);
 
-  // Auto-run loop.
   useEffect(() => {
     if (!running) return;
     if (clamped >= TOTAL - 1) {
@@ -252,7 +238,6 @@ export function CallStackECs({ initialStep = 0 }: Props) {
       return;
     }
     if (clamped >= TOTAL - 1) {
-      // restart from beginning
       setStep(0);
       setConsoleLog([]);
       lastEmittedStep.current = -1;
@@ -280,117 +265,132 @@ export function CallStackECs({ initialStep = 0 }: Props) {
   return (
     <WidgetShell
       title="call stack · execution contexts"
+      measurements={`step ${clamped + 1}/${TOTAL}`}
       caption={caption}
       captionTone="prominent"
-      controls={
+    >
+      <div className="bs-csec">
+        {/* Controls strip — single row at 360 px. Tap targets ≥ 44 px. */}
         <div
+          className="bs-csec-controls"
           role="group"
-          aria-label="Step controls"
-          className="flex flex-wrap items-center justify-center gap-[var(--spacing-2xs)] font-sans"
-          style={{ fontSize: "var(--text-ui)" }}
+          aria-label="Call-stack step controls"
         >
-          <motion.button
-            type="button"
+          <CtrlBtn
             onClick={onBack}
             disabled={clamped === 0}
-            aria-label="Step back"
-            style={btnStyle(false, clamped === 0)}
-            {...PRESS}
+            kind="muted"
+            ariaLabel="Step back"
           >
-            ← Back
-          </motion.button>
-          <motion.button
-            type="button"
+            <span aria-hidden>←</span>
+            <span className="bs-csec-btn-label">Back</span>
+          </CtrlBtn>
+          <CtrlBtn
             onClick={onRunToggle}
-            aria-label={running ? "Pause auto-run" : "Run auto-step"}
-            style={btnStyle(true, false)}
-            {...PRESS}
+            kind="accent"
+            ariaLabel={running ? "Pause auto-run" : "Run auto-step"}
           >
-            {runLabel}
-          </motion.button>
-          <motion.button
-            type="button"
+            <span aria-hidden>{running ? "⏸" : "▶"}</span>
+            <span className="bs-csec-btn-label">{runLabel}</span>
+          </CtrlBtn>
+          <CtrlBtn
             onClick={onStep}
             disabled={clamped === TOTAL - 1 || running}
-            aria-label="Step forward"
-            style={btnStyle(false, clamped === TOTAL - 1 || running)}
-            {...PRESS}
+            kind="primary"
+            ariaLabel="Step forward"
           >
-            Step →
-          </motion.button>
-          <motion.button
-            type="button"
+            <span className="bs-csec-btn-label">Step</span>
+            <span aria-hidden>→</span>
+          </CtrlBtn>
+          <CtrlBtn
             onClick={onReset}
-            aria-label="Reset"
-            style={btnStyle(false, false)}
-            {...PRESS}
+            kind="ghost"
+            ariaLabel="Reset to first step"
           >
-            Reset
-          </motion.button>
-          <span
-            className="font-mono tabular-nums"
-            style={{
-              fontSize: 11,
-              color: "var(--color-text-muted)",
-              marginLeft: 6,
-            }}
-          >
-            {clamped + 1}/{TOTAL}
-          </span>
+            <span aria-hidden>↺</span>
+            <span className="bs-csec-btn-label">Reset</span>
+          </CtrlBtn>
         </div>
-      }
-    >
-      <CallStackBoard
-        snippet={SNIPPET}
-        activeLine={current.activeLine}
-        stack={current.stack}
-        topId={topFrame.id}
-        consoleLog={consoleLog}
-        reducedMotion={Boolean(reducedMotion)}
-      />
+
+        <CallStackBoard
+          activeLine={current.activeLine}
+          stack={current.stack}
+          topId={topFrame.id}
+          consoleLog={consoleLog}
+          reducedMotion={Boolean(reducedMotion)}
+          codeSlot={codeSlot}
+        />
+      </div>
+
+      <style>{`
+        .bs-csec {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+          min-width: 0;
+        }
+        .bs-csec-controls {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          align-items: center;
+          justify-content: flex-start;
+          min-height: 48px;
+        }
+        .bs-csec-btn-label {
+          font-family: var(--font-sans);
+          font-size: var(--text-ui);
+        }
+      `}</style>
     </WidgetShell>
   );
 }
 
 /* ------------------------------------------------------------------ */
-/*  Board: code pane + stack pane + arrow overlay + console pane.     */
+/*  Board: code pane (Shiki + active-line wash) + stack pane +        */
+/*  console pane + arrow (desktop) / down-glyph (mobile).             */
 /* ------------------------------------------------------------------ */
 
 function CallStackBoard({
-  snippet,
   activeLine,
   stack,
   topId,
   consoleLog,
   reducedMotion,
+  codeSlot,
 }: {
-  snippet: string[];
   activeLine: number | null;
   stack: EC[];
   topId: ECName;
   consoleLog: ConsoleLine[];
   reducedMotion: boolean;
+  codeSlot?: ReactNode;
 }) {
-  // Geometry refs for the SVG arrow (desktop only).
   const boardRef = useRef<HTMLDivElement | null>(null);
   const codePaneRef = useRef<HTMLDivElement | null>(null);
+  const codeSlotRef = useRef<HTMLDivElement | null>(null);
   const stackPaneRef = useRef<HTMLDivElement | null>(null);
-  const lineRefs = useRef<Map<number, HTMLLIElement>>(new Map());
   const cardRefs = useRef<Map<ECName, HTMLDivElement>>(new Map());
 
+  /** Active-line wash geometry (relative to the codeSlot wrapper). */
+  const [washRect, setWashRect] = useState<{ top: number; height: number } | null>(
+    null,
+  );
+
+  /** Container-width branch — drives single-column vs two-column + arrow. */
+  const [isWide, setIsWide] = useState(false);
+
+  /** SVG arrow geometry (board-relative, only used when isWide). */
   const [arrow, setArrow] = useState<{
     from: { x: number; y: number };
     to: { x: number; y: number };
-    visible: boolean;
   } | null>(null);
 
-  const [isWide, setIsWide] = useState(false);
-
-  // Track container width via ResizeObserver — drives the desktop/mobile split.
+  // Width branch via ResizeObserver.
   useLayoutEffect(() => {
     const el = boardRef.current;
     if (!el) return;
-    const update = () => setIsWide(el.clientWidth >= 640);
+    const update = () => setIsWide(el.clientWidth >= 720);
     update();
     if (typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(update);
@@ -398,183 +398,140 @@ function CallStackBoard({
     return () => ro.disconnect();
   }, []);
 
-  // Recompute arrow geometry whenever the active line / top card / width changes.
+  // Measure the active line inside the rendered Shiki HTML and position the
+  // terracotta wash over it. Re-measures when activeLine changes, fonts load,
+  // or the code pane resizes.
+  useLayoutEffect(() => {
+    const slot = codeSlotRef.current;
+    if (!slot) return;
+    const measure = () => {
+      if (activeLine == null) {
+        setWashRect(null);
+        return;
+      }
+      // Shiki output: each source line is `<span class="line">…</span>` inside
+      // the highlighted body. We index by 0-based position.
+      const lineEls = slot.querySelectorAll<HTMLElement>("span.line");
+      const target = lineEls[activeLine - 1];
+      if (!target) {
+        setWashRect(null);
+        return;
+      }
+      const slotRect = slot.getBoundingClientRect();
+      const lineRect = target.getBoundingClientRect();
+      setWashRect({
+        top: lineRect.top - slotRect.top,
+        height: lineRect.height,
+      });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(slot);
+    return () => ro.disconnect();
+  }, [activeLine, codeSlot]);
+
+  // Arrow from active line (right edge) to top stack card (left edge).
   useLayoutEffect(() => {
     if (!isWide) {
       setArrow(null);
       return;
     }
     const board = boardRef.current;
-    const lineEl = activeLine != null ? lineRefs.current.get(activeLine) : null;
+    const slot = codeSlotRef.current;
     const cardEl = cardRefs.current.get(topId);
-    if (!board || !lineEl || !cardEl) {
+    if (!board || !slot || !cardEl || activeLine == null) {
+      setArrow(null);
+      return;
+    }
+    const lineEls = slot.querySelectorAll<HTMLElement>("span.line");
+    const target = lineEls[activeLine - 1];
+    if (!target) {
       setArrow(null);
       return;
     }
     const boardRect = board.getBoundingClientRect();
-    const lineRect = lineEl.getBoundingClientRect();
+    const lineRect = target.getBoundingClientRect();
     const cardRect = cardEl.getBoundingClientRect();
-    const from = {
-      x: lineRect.right - boardRect.left + 4,
-      y: lineRect.top - boardRect.top + lineRect.height / 2,
-    };
-    const to = {
-      x: cardRect.left - boardRect.left - 8,
-      y: cardRect.top - boardRect.top + Math.min(20, cardRect.height / 2),
-    };
-    setArrow({ from, to, visible: true });
-  }, [activeLine, topId, isWide, stack.length]);
+    setArrow({
+      from: {
+        x: lineRect.right - boardRect.left + 4,
+        y: lineRect.top - boardRect.top + lineRect.height / 2,
+      },
+      to: {
+        x: cardRect.left - boardRect.left - 8,
+        y: cardRect.top - boardRect.top + Math.min(20, cardRect.height / 2),
+      },
+    });
+  }, [activeLine, topId, isWide, stack.length, codeSlot]);
 
-  // Re-measure on window resize too (covers font swaps, etc.).
+  // Re-measure on window resize too.
   useEffect(() => {
-    const onResize = () => {
-      // Trigger a re-render via state nudge.
-      setIsWide((w) => w);
-    };
+    const onResize = () => setIsWide((w) => w);
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
   return (
-    <div
-      ref={boardRef}
-      className="bs-csec-board"
-      style={{
-        position: "relative",
-        display: "grid",
-        gap: "var(--spacing-sm)",
-        gridTemplateColumns: "minmax(0, 1fr)",
-      }}
-    >
-      {/* Code pane */}
-      <div
-        ref={codePaneRef}
-        style={{
-          background:
-            "color-mix(in oklab, var(--color-surface) 35%, transparent)",
-          border: "1px solid var(--color-rule)",
-          borderRadius: 3,
-          padding: "10px 12px",
-          minWidth: 0,
-          minHeight: 220,
-        }}
-      >
-        <div
-          className="font-sans"
-          style={{
-            fontSize: 9,
-            letterSpacing: "0.08em",
-            color: "var(--color-text-muted)",
-            marginBottom: 8,
-          }}
-        >
-          CODE
-        </div>
-        <ol
-          className="font-mono"
-          style={{
-            listStyle: "none",
-            margin: 0,
-            padding: 0,
-            display: "flex",
-            flexDirection: "column",
-            gap: 1,
-            fontSize: 11.5,
-            lineHeight: 1.5,
-          }}
-        >
-          {snippet.map((line, i) => {
-            const lineNum = i + 1;
-            const isActive = activeLine === lineNum;
-            return (
-              <motion.li
-                key={lineNum}
-                ref={(el) => {
-                  if (el) lineRefs.current.set(lineNum, el);
-                  else lineRefs.current.delete(lineNum);
-                }}
-                initial={false}
-                animate={{ opacity: isActive ? 1 : 0.6 }}
-                transition={
-                  reducedMotion ? { duration: 0 } : { duration: 0.2 }
+    <div ref={boardRef} className="bs-csec-board">
+      {/* Code pane — reserved height fits SNIPPET. The codeSlot is the
+          server-rendered <CodeBlock>; the wash <div> overlays it. */}
+      <div ref={codePaneRef} className="bs-csec-region bs-csec-code">
+        <div className="bs-csec-region-head">CODE</div>
+        <div ref={codeSlotRef} className="bs-csec-codeslot">
+          {/* Active-line wash — sits behind the Shiki HTML via stacking
+              order. Animates `transform: translateY` on the y axis only;
+              its own height is unchanged once measured (R6 inside the
+              region). */}
+          <AnimatePresence>
+            {washRect ? (
+              <motion.div
+                key={`wash-${activeLine}`}
+                aria-hidden
+                initial={
+                  reducedMotion
+                    ? { opacity: 0 }
+                    : { opacity: 0 }
                 }
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={
+                  reducedMotion ? { duration: 0 } : { duration: 0.18 }
+                }
+                className="bs-csec-wash"
                 style={{
-                  display: "grid",
-                  gridTemplateColumns: "1.2em 2em minmax(0, 1fr)",
-                  alignItems: "center",
-                  columnGap: 6,
-                  padding: "1px 6px",
-                  borderRadius: 2,
-                  background: isActive
-                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-                    : "transparent",
-                  color: isActive
-                    ? "var(--color-accent)"
-                    : "var(--color-text)",
-                  fontWeight: isActive ? 600 : 400,
+                  top: 0,
+                  height: washRect.height,
+                  transform: `translateY(${washRect.top}px)`,
                 }}
-              >
-                <span
-                  aria-hidden
-                  style={{
-                    color: "var(--color-accent)",
-                    fontSize: 10,
-                    visibility: isActive ? "visible" : "hidden",
-                  }}
-                >
-                  ▶
-                </span>
-                <span
-                  style={{
-                    color: "var(--color-text-muted)",
-                    fontSize: 10,
-                    textAlign: "right",
-                  }}
-                >
-                  {lineNum}
-                </span>
-                <span
-                  style={{
-                    minWidth: 0,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {line || " "}
-                </span>
-              </motion.li>
-            );
-          })}
-        </ol>
+              />
+            ) : null}
+          </AnimatePresence>
+          {codeSlot ?? <FallbackCode lines={SNIPPET_LINES} />}
+        </div>
       </div>
 
-      {/* Mobile-only down-glyph hint between code and stack.
-          Always rendered so :nth-child indexes stay stable; CSS hides on
-          desktop. */}
+      {/* Mobile-only down-glyph between code and stack panes. Always
+          rendered so the @container fallback's :nth-child indices remain
+          stable; CSS hides it on desktop. */}
       <div
         aria-hidden
         className="bs-csec-glyph"
         style={{
           display: isWide ? "none" : "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          margin: "-4px 0 -4px 0",
         }}
       >
         <motion.span
           key={`${activeLine}-${topId}`}
           initial={
-            reducedMotion
-              ? { opacity: 1, y: 0 }
-              : { opacity: 0, y: -4 }
+            reducedMotion ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.6 }
           }
-          animate={{ opacity: 1, y: 0 }}
+          animate={{ opacity: 1, scale: 1 }}
           transition={reducedMotion ? { duration: 0 } : SPRING.smooth}
           style={{
             color: "var(--color-accent)",
             fontFamily: "var(--font-mono)",
-            fontSize: 14,
+            fontSize: 16,
             lineHeight: 1,
           }}
         >
@@ -582,40 +539,10 @@ function CallStackBoard({
         </motion.span>
       </div>
 
-      {/* Stack pane */}
-      <div
-        ref={stackPaneRef}
-        style={{
-          position: "relative",
-          background:
-            "color-mix(in oklab, var(--color-surface) 25%, transparent)",
-          border: "1px solid var(--color-rule)",
-          borderRadius: 3,
-          padding: "10px 12px",
-          minHeight: 240,
-          minWidth: 0,
-        }}
-      >
-        <div
-          className="font-sans"
-          style={{
-            fontSize: 9,
-            letterSpacing: "0.08em",
-            color: "var(--color-text-muted)",
-            marginBottom: 8,
-          }}
-        >
-          CALL STACK
-        </div>
-        {/* Cards laid out top-of-stack at the top, bottom-of-stack below. */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column-reverse",
-            gap: "var(--spacing-2xs)",
-            justifyContent: "flex-start",
-          }}
-        >
+      {/* Stack pane — reserved height fits 3 frames. */}
+      <div ref={stackPaneRef} className="bs-csec-region bs-csec-stack">
+        <div className="bs-csec-region-head">CALL STACK</div>
+        <div className="bs-csec-cards">
           <AnimatePresence initial={false}>
             {stack.map((frame) => (
               <ECCard
@@ -632,113 +559,177 @@ function CallStackBoard({
         </div>
       </div>
 
-      {/* Console pane */}
-      <div
-        aria-label="console output"
-        style={{
-          background: "var(--color-surface)",
-          border: "1px solid var(--color-rule)",
-          borderRadius: 3,
-          padding: "10px 12px",
-          minHeight: 92,
-          minWidth: 0,
-          fontFamily: "var(--font-mono)",
-          fontSize: 11.5,
-          color: "var(--color-text)",
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
-        }}
-      >
-        <div
-          className="font-sans"
-          style={{
-            fontSize: 9,
-            letterSpacing: "0.08em",
-            color: "var(--color-text-muted)",
-            marginBottom: 6,
-          }}
-        >
-          CONSOLE
-        </div>
-        <AnimatePresence initial={false}>
-          {consoleLog.map((l) => (
-            <motion.div
-              key={l.id}
-              initial={
-                reducedMotion ? { opacity: 1 } : { opacity: 0, y: 4 }
-              }
-              animate={{ opacity: 1, y: 0 }}
-              transition={
-                reducedMotion ? { duration: 0 } : { duration: 0.2 }
-              }
-              style={{
-                display: "grid",
-                gridTemplateColumns: "1.2em minmax(0, 1fr)",
-                columnGap: 6,
-                minWidth: 0,
-              }}
-            >
-              <span style={{ color: "var(--color-text-muted)" }}>›</span>
-              <span
-                style={{
-                  minWidth: 0,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
+      {/* Console pane — reserved height fits ≤ 2 emit lines (the snippet's
+          maximum). */}
+      <div className="bs-csec-region bs-csec-console" aria-label="console output">
+        <div className="bs-csec-region-head">CONSOLE</div>
+        <div className="bs-csec-console-body" aria-live="polite">
+          <AnimatePresence initial={false}>
+            {consoleLog.map((l) => (
+              <motion.div
+                key={l.id}
+                layout
+                initial={
+                  reducedMotion ? { opacity: 1 } : { opacity: 0, y: 4 }
+                }
+                animate={{ opacity: 1, y: 0 }}
+                transition={reducedMotion ? { duration: 0 } : { duration: 0.2 }}
+                className="bs-csec-console-line font-mono"
               >
+                <span style={{ color: "var(--color-text-muted)" }}>›</span>{" "}
                 {l.text}
-              </span>
-            </motion.div>
-          ))}
-        </AnimatePresence>
-        {consoleLog.length === 0 ? (
-          <div
-            style={{
-              color: "var(--color-text-muted)",
-              fontSize: 11,
-              fontStyle: "italic",
-            }}
-          >
-            (no output yet — press Run)
-          </div>
-        ) : null}
+              </motion.div>
+            ))}
+          </AnimatePresence>
+          {consoleLog.length === 0 ? (
+            <div className="bs-csec-console-empty font-sans">
+              (no output yet — press Run)
+            </div>
+          ) : null}
+        </div>
       </div>
 
-      {/* Desktop SVG arrow overlay. */}
+      {/* Desktop SVG arrow overlay — only when isWide and we have geometry. */}
       {isWide && arrow ? (
         <ArrowOverlay arrow={arrow} reducedMotion={reducedMotion} />
       ) : null}
 
-      <style jsx>{`
-        @container widget (min-width: 640px) {
+      <style>{`
+        .bs-csec-board {
+          position: relative;
+          display: grid;
+          grid-template-columns: minmax(0, 1fr);
+          gap: var(--spacing-sm);
+          min-width: 0;
+        }
+        .bs-csec-region {
+          background: color-mix(in oklab, var(--color-surface) 35%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          padding: 10px 12px;
+          min-width: 0;
+        }
+        .bs-csec-region-head {
+          font-family: var(--font-sans);
+          font-size: 9px;
+          letter-spacing: 0.08em;
+          color: var(--color-text-muted);
+          margin-bottom: 6px;
+          text-transform: uppercase;
+        }
+        /* Reserved heights — R6 frame stability. */
+        .bs-csec-code { min-height: 240px; }
+        .bs-csec-stack { min-height: 264px; }
+        .bs-csec-console { min-height: 88px; }
+
+        .bs-csec-codeslot {
+          position: relative;
+          min-width: 0;
+          /* The CodeBlock has its own margin (.my-[var(--spacing-lg)]); we
+             neutralise it inside the widget so the pane's reserved height
+             stays accurate. */
+        }
+        .bs-csec-codeslot > .bs-code {
+          margin: 0 !important;
+        }
+        .bs-csec-wash {
+          position: absolute;
+          left: 0;
+          right: 0;
+          background: color-mix(in oklab, var(--color-accent) 16%, transparent);
+          border-left: 2px solid var(--color-accent);
+          pointer-events: none;
+          z-index: 1;
+        }
+        /* Stack cards: top-of-stack visually on top. */
+        .bs-csec-cards {
+          display: flex;
+          flex-direction: column-reverse;
+          gap: var(--spacing-2xs);
+          justify-content: flex-start;
+        }
+        .bs-csec-glyph {
+          justify-content: center;
+          align-items: center;
+          min-height: 24px;
+        }
+        .bs-csec-console-body {
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          font-family: var(--font-mono);
+          font-size: 11.5px;
+          color: var(--color-text);
+          min-height: 44px;
+        }
+        .bs-csec-console-line {
+          line-height: 1.45;
+        }
+        .bs-csec-console-empty {
+          color: var(--color-text-muted);
+          font-size: 11px;
+          font-style: italic;
+        }
+
+        @container widget (min-width: 720px) {
           .bs-csec-board {
-            grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+            grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
             grid-template-rows: auto auto;
           }
-          /* code pane: top-left */
-          .bs-csec-board > :global(:nth-child(1)) {
+          /* code pane — top-left */
+          .bs-csec-board > .bs-csec-code {
             grid-column: 1 / 2;
             grid-row: 1 / 2;
           }
-          /* mobile glyph: hidden on desktop */
-          .bs-csec-board > :global(.bs-csec-glyph) {
+          /* mobile glyph hides */
+          .bs-csec-board > .bs-csec-glyph {
             display: none !important;
           }
-          /* stack pane: top-right */
-          .bs-csec-board > :global(:nth-child(3)) {
+          /* stack pane — right column, full height */
+          .bs-csec-board > .bs-csec-stack {
             grid-column: 2 / 3;
-            grid-row: 1 / 2;
+            grid-row: 1 / 3;
           }
-          /* console pane: spans both columns, row 2 */
-          .bs-csec-board > :global(:nth-child(4)) {
-            grid-column: 1 / 3;
+          /* console pane — left column, row 2 */
+          .bs-csec-board > .bs-csec-console {
+            grid-column: 1 / 2;
             grid-row: 2 / 3;
           }
         }
       `}</style>
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Fallback code — used if the codeSlot prop wasn't supplied.        */
+/*  The active-line wash measurement targets `span.line`, so the      */
+/*  fallback emits the same DOM shape Shiki produces.                 */
+/* ------------------------------------------------------------------ */
+
+function FallbackCode({ lines }: { lines: number }) {
+  const arr = CALL_STACK_SNIPPET.replace(/\n+$/, "").split("\n").slice(0, lines);
+  return (
+    <pre
+      className="font-mono"
+      style={{
+        margin: 0,
+        padding: 0,
+        fontSize: 11.5,
+        lineHeight: 1.5,
+        color: "var(--color-text)",
+        whiteSpace: "pre",
+        overflowX: "auto",
+      }}
+    >
+      <code>
+        {arr.map((line, i) => (
+          <span className="line" key={i} style={{ display: "block" }}>
+            {line || " "}
+          </span>
+        ))}
+      </code>
+    </pre>
   );
 }
 
@@ -754,12 +745,10 @@ function ArrowOverlay({
   reducedMotion: boolean;
 }) {
   const { from, to } = arrow;
-  // Cubic curve with horizontal handles for a gentle s-shape.
   const dx = Math.max(40, (to.x - from.x) * 0.5);
   const c1 = { x: from.x + dx, y: from.y };
   const c2 = { x: to.x - dx, y: to.y };
   const path = `M ${from.x} ${from.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${to.x} ${to.y}`;
-  // Arrowhead at the end of the curve.
   const angle = Math.atan2(to.y - c2.y, to.x - c2.x);
   const headLen = 8;
   const headW = 5;
@@ -784,6 +773,7 @@ function ArrowOverlay({
         height: "100%",
         pointerEvents: "none",
         overflow: "visible",
+        zIndex: 2,
       }}
     >
       <AnimatePresence mode="wait">
@@ -792,9 +782,7 @@ function ArrowOverlay({
           initial={reducedMotion ? { opacity: 1 } : { opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={
-            reducedMotion ? { duration: 0 } : { duration: 0.15 }
-          }
+          transition={reducedMotion ? { duration: 0 } : { duration: 0.15 }}
         >
           <motion.path
             d={path}
@@ -802,14 +790,10 @@ function ArrowOverlay({
             stroke="var(--color-accent)"
             strokeWidth={2}
             strokeLinecap="round"
-            initial={
-              reducedMotion ? { pathLength: 1 } : { pathLength: 0 }
-            }
+            initial={reducedMotion ? { pathLength: 1 } : { pathLength: 0 }}
             animate={{ pathLength: 1 }}
             transition={
-              reducedMotion
-                ? { duration: 0 }
-                : { type: "spring", stiffness: 240, damping: 28 }
+              reducedMotion ? { duration: 0 } : SPRING.smooth
             }
           />
           <motion.polygon
@@ -853,13 +837,9 @@ function ECCard({
         else cardRefs.current.delete(frameId);
       }}
       layout={!reducedMotion}
-      initial={
-        reducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: -16 }
-      }
+      initial={reducedMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: -16 }}
       animate={{ opacity: 1, y: 0 }}
-      exit={
-        reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -16 }
-      }
+      exit={reducedMotion ? { opacity: 0, y: 0 } : { opacity: 0, y: -16 }}
       transition={reducedMotion ? { duration: 0 } : SPRING.smooth}
       style={{
         padding: "8px 10px",
@@ -899,9 +879,7 @@ function ECCard({
           style={{
             fontSize: 12,
             fontWeight: 600,
-            color: isTop
-              ? "var(--color-accent)"
-              : "var(--color-text-muted)",
+            color: isTop ? "var(--color-accent)" : "var(--color-text-muted)",
             minWidth: 0,
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -939,9 +917,7 @@ function ECCard({
                 minWidth: 0,
               }}
             >
-              <span style={{ color: "var(--color-text-muted)" }}>
-                {b.name}
-              </span>
+              <span style={{ color: "var(--color-text-muted)" }}>{b.name}</span>
               <span
                 style={{
                   textAlign: "right",
@@ -967,19 +943,66 @@ function ECCard({
   );
 }
 
-function btnStyle(primary: boolean, disabled: boolean): React.CSSProperties {
-  return {
+/* ------------------------------------------------------------------ */
+/*  CtrlBtn — tap target ≥ 44 × 44 px.                                */
+/* ------------------------------------------------------------------ */
+
+function CtrlBtn({
+  children,
+  onClick,
+  disabled,
+  kind,
+  ariaLabel,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  kind: "primary" | "accent" | "muted" | "ghost";
+  ariaLabel?: string;
+}) {
+  const base: React.CSSProperties = {
     minHeight: 44,
     padding: "0 12px",
     borderRadius: "var(--radius-sm)",
-    border: `1px solid ${primary ? "var(--color-accent)" : "var(--color-rule)"}`,
-    background: primary
-      ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
-      : "transparent",
-    color: primary ? "var(--color-accent)" : "var(--color-text)",
+    border: "1px solid var(--color-rule)",
+    background: "transparent",
+    color: "var(--color-text)",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
     fontFamily: "var(--font-mono)",
     fontSize: 12,
     cursor: disabled ? "not-allowed" : "pointer",
     opacity: disabled ? 0.5 : 1,
+    whiteSpace: "nowrap",
   };
+  const variant: Record<typeof kind, React.CSSProperties> = {
+    primary: {
+      background: "var(--color-accent)",
+      color: "var(--color-bg)",
+      border: "1px solid var(--color-accent)",
+      fontWeight: 600,
+    },
+    accent: {
+      background: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+      color: "var(--color-accent)",
+      border: "1px solid var(--color-accent)",
+    },
+    muted: {},
+    ghost: {
+      color: "var(--color-text-muted)",
+    },
+  };
+  return (
+    <motion.button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      style={{ ...base, ...variant[kind] }}
+      {...(disabled ? {} : PRESS)}
+    >
+      {children}
+    </motion.button>
+  );
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackSnippet.ts
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackSnippet.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared call-stack code snippet — imported by both the RSC page (which
+ * pre-renders it via `<CodeBlock>`) and the client widget (which measures
+ * the rendered Shiki output to position the active-line wash).
+ *
+ * Kept in its own module without `"use client"` so the page can import the
+ * raw string. If this lived inside `CallStackECs.tsx` (a client module),
+ * the bundler would wrap every export as a client reference, and the
+ * `<CodeBlock>` call from the page would receive a function instead of a
+ * string for `code`.
+ */
+export const CALL_STACK_SNIPPET = `function multiply(a, b) {
+  const result = a * b;
+  return result;
+}
+
+function compute(x) {
+  const doubled = multiply(x, 2);
+  console.log(doubled);
+  return doubled;
+}
+
+const answer = compute(7);
+console.log(answer);
+`;

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -345,12 +345,9 @@ export default function TheLineThatWaitsItsTurn() {
         </P>
         <P>
           The widget below makes the priority rule playable. Build a queue:
-          tap <em>+ microtask</em> a few times, then <em>+ macrotask</em>, then{" "}
+          tap <em>+ micro</em> a few times, then <em>+ macro</em>, then{" "}
           <em>Run</em> — the console writes the firing order so you can see
-          microtasks drain first. Then add a{" "}
-          <em>+ self-scheduling micro</em>: a microtask that schedules another
-          microtask. The macrotask never gets its turn — that&apos;s
-          starvation, made visible without freezing your tab.
+          microtasks drain first.
         </P>
       </div>
 
@@ -358,13 +355,17 @@ export default function TheLineThatWaitsItsTurn() {
 
       <div>
         <P>
-          Each loop tick, the engine drains every pending microtask before
-          touching macrotasks. With a self-scheduling microtask in flight, the
-          microtask queue keeps re-filling itself — the macrotask waits and
-          waits, even though the engine isn&apos;t doing real work, just
-          servicing the queue. Same rule, different consequence: the priority
-          that lets <Code>await</Code> feel seamless is the same priority that
-          lets one runaway Promise hold a tab hostage.
+          Each loop tick, the engine drains every pending microtask{" "}
+          <em>before</em> it touches macrotasks. Add a few of each and click{" "}
+          <em>Run</em> to feel the priority.{" "}
+          <HL>Now click <em>+ self-sched</em></HL> — a microtask whose body
+          schedules another microtask. Every time the engine drains it, the
+          queue grows by one. The microtask queue <em>never empties</em>, so
+          the loop never moves to the macrotask queue. Macrotasks (timers,
+          fetch responses, the next render frame) are stranded.{" "}
+          <HL>That&apos;s microtask starvation:</HL> a runaway Promise chain
+          stalls everything else, even though the runtime isn&apos;t actually
+          busy — just servicing its own queue.
         </P>
         <Aside>
           Node has a different inventory but the same hazard. Its loop runs in

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING, PRESS } from "@/lib/motion";
@@ -23,26 +23,30 @@ function CaptionCue({ children }: { children: React.ReactNode }) {
 }
 
 /* ---------------------------------------------------------------------------
- * MicrotaskStarvation — "Queue Race".
+ * MicrotaskStarvation — "Queue Race" v2 (mobile-first, frame-stable).
  *
- * State-machine simulation of the event-loop priority rule:
- *   On each tick:  drain ALL microtasks  →  run ONE macrotask  →  repeat.
+ * Layout:
+ *   - Mobile (< 720 px container): vertical stack, fixed reserved heights for
+ *     every region. No horizontal scroll on the shell. Buttons stay one row;
+ *     queue chips overflow horizontally inside their own bounded strip.
+ *   - lg (≥ 720 px container, via @container query): two columns — queues +
+ *     console side-by-side under the controls strip.
  *
- * The reader builds the queues by tapping `+ microtask` and `+ macrotask`,
- * then taps `Run` to drain one tick. The console pane records the firing
- * order. A fourth button — `+ self-scheduling micro` — adds a microtask
- * that, when fired, enqueues another microtask (capped at SELF_HOPS to
- * keep the demo finite). With self-scheduling micros pending, the
- * macrotask never gets a turn — that is microtask starvation, made
- * visible without simulating a real freeze.
+ * Frame stability (R6): the outer shell never resizes during interaction.
+ * Each region reserves a fixed `min-h-*`; growth happens inside reserved
+ * space. Console scrolls internally past 6 lines; queues scroll horizontally
+ * past viewport width. Starved badge fades in place — never reflows headers.
  *
- * No real Promise / setTimeout recursion. No rAF. Pure state machine.
+ * State machine only — no real Promise / setTimeout recursion. The
+ * `+ self-scheduling micro` chip caps at SELF_HOPS hops, then settles, so
+ * the demo stays finite even though it teaches an unbounded concept.
  * --------------------------------------------------------------------------*/
 
 const SELF_HOPS = 6;
 const STARVED_BADGE_AT = 4;
-const FIRE_DELAY_MS = 280; // visible per-step pacing for the Run animation
+const FIRE_DELAY_MS = 280;
 const MAX_CONSOLE_LINES = 12;
+const TOOLTIP_FADE_MS = 6000;
 
 type Chip = {
   id: string;
@@ -72,15 +76,32 @@ export function MicrotaskStarvation() {
   const [running, setRunning] = useState(false);
   const [starved, setStarved] = useState(false);
 
-  // Counters for label generation. Persist across resets via state, not refs,
-  // so the chip labels stay readable.
   const [microSeq, setMicroSeq] = useState(0);
   const [macroSeq, setMacroSeq] = useState(0);
 
-  // Active-chip indicator: which chip is currently "firing" (highlighted).
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  /** First-click mini-tooltip explaining the self-scheduling button. */
+  const [selfHintShown, setSelfHintShown] = useState(false);
+  const [selfHintVisible, setSelfHintVisible] = useState(false);
+  const hintTimerRef = useRef<number | null>(null);
+
   const cancelRef = useRef(false);
+
+  // Auto-fade the self-scheduling tooltip after TOOLTIP_FADE_MS or once a
+  // run starts (whichever comes first).
+  useEffect(() => {
+    if (!selfHintVisible) return;
+    hintTimerRef.current = window.setTimeout(() => {
+      setSelfHintVisible(false);
+    }, TOOLTIP_FADE_MS);
+    return () => {
+      if (hintTimerRef.current != null) {
+        window.clearTimeout(hintTimerRef.current);
+        hintTimerRef.current = null;
+      }
+    };
+  }, [selfHintVisible]);
 
   const addMicro = useCallback(() => {
     if (running) return;
@@ -106,7 +127,11 @@ export function MicrotaskStarvation() {
       ]);
       return next;
     });
-  }, [running]);
+    if (!selfHintShown) {
+      setSelfHintShown(true);
+      setSelfHintVisible(true);
+    }
+  }, [running, selfHintShown]);
 
   const addMacro = useCallback(() => {
     if (running) return;
@@ -128,14 +153,12 @@ export function MicrotaskStarvation() {
     setStarved(false);
     setRunning(false);
     setActiveId(null);
+    setSelfHintVisible(false);
   }, []);
 
-  // Read latest queue state via functional setters; UI updates each step.
   const wait = (ms: number) =>
     new Promise<void>((res) => {
       const t = window.setTimeout(res, ms);
-      // best-effort cancel: we still resolve, but the run loop checks
-      // cancelRef.current to bail.
       void t;
     });
 
@@ -144,7 +167,6 @@ export function MicrotaskStarvation() {
       kind: "micro" | "macro",
       step: number,
     ): Promise<{ fired: boolean; spawnedSelf: boolean }> => {
-      // Snapshot top-of-queue.
       let snapshot: Chip | undefined;
       if (kind === "micro") {
         setMicro((q) => {
@@ -157,15 +179,12 @@ export function MicrotaskStarvation() {
           return q;
         });
       }
-      // Allow setMicro/setMacro flush.
       await wait(0);
       if (!snapshot) return { fired: false, spawnedSelf: false };
 
-      // Highlight the head briefly.
       setActiveId(snapshot.id);
       await wait(reduce ? 0 : Math.round(FIRE_DELAY_MS * 0.45));
 
-      // Pop it + write to console + maybe spawn next self-scheduling micro.
       const fired = snapshot;
       let spawnedSelf = false;
       if (kind === "micro") {
@@ -199,12 +218,9 @@ export function MicrotaskStarvation() {
         );
       }
 
-      // Trigger starved badge once we've drained STARVED_BADGE_AT consecutive
-      // micros within the same Run with macros pending.
       if (kind === "micro" && step >= STARVED_BADGE_AT) {
         setStarved((prev) => {
           if (prev) return prev;
-          // Only mark starved if there ARE macros waiting.
           let hasMacro = false;
           setMacro((q) => {
             hasMacro = q.length > 0;
@@ -221,8 +237,6 @@ export function MicrotaskStarvation() {
     [reduce],
   );
 
-  // Probe current queue lengths via setState callback — guarantees freshest
-  // values without subscribing to render cycles.
   const peekMicroLen = () =>
     new Promise<number>((res) => {
       setMicro((q) => {
@@ -242,9 +256,8 @@ export function MicrotaskStarvation() {
     if (running) return;
     cancelRef.current = false;
     setRunning(true);
+    setSelfHintVisible(false);
 
-    // Hard cap on micro-drain steps in a single Run (handles self-scheduling
-    // chains). Visually matches "the macrotask never got its turn".
     const MAX_MICRO_STEPS_PER_TICK = 32;
 
     let microSteps = 0;
@@ -256,7 +269,6 @@ export function MicrotaskStarvation() {
       microLen = await peekMicroLen();
     }
 
-    // ONE macrotask, only if we drained micros (else: starved).
     if (!cancelRef.current && microSteps < MAX_MICRO_STEPS_PER_TICK) {
       const macLen = await peekMacroLen();
       if (macLen > 0) {
@@ -268,8 +280,8 @@ export function MicrotaskStarvation() {
     setRunning(false);
   }, [running, fireOneFromQueue]);
 
-  // Derived
-  const outputStr = output.map((o) => o.label).join(" · ") || "—";
+  const totalQueued = micro.length + macro.length;
+  const canRun = !running && totalQueued > 0;
 
   return (
     <WidgetShell
@@ -301,221 +313,261 @@ export function MicrotaskStarvation() {
         )
       }
       captionTone="prominent"
-      controls={
-        <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] w-full">
-          <motion.button
-            type="button"
-            onClick={addMicro}
-            disabled={running}
-            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-            style={{
-              padding: "8px 14px",
-              fontSize: "var(--text-ui)",
-              background: "color-mix(in oklab, var(--color-accent) 14%, transparent)",
-              color: "var(--color-accent)",
-              border: "1px solid var(--color-accent)",
-              opacity: running ? 0.5 : 1,
-              cursor: running ? "not-allowed" : "pointer",
-            }}
-            {...(running ? {} : PRESS)}
-          >
-            + microtask
-          </motion.button>
-          <motion.button
-            type="button"
-            onClick={addMacro}
-            disabled={running}
-            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-            style={{
-              padding: "8px 14px",
-              fontSize: "var(--text-ui)",
-              background: "transparent",
-              color: "var(--color-text)",
-              border: "1px solid var(--color-rule)",
-              opacity: running ? 0.5 : 1,
-              cursor: running ? "not-allowed" : "pointer",
-            }}
-            {...(running ? {} : PRESS)}
-          >
-            + macrotask
-          </motion.button>
-          <motion.button
-            type="button"
-            onClick={addSelf}
-            disabled={running}
-            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-            style={{
-              padding: "8px 14px",
-              fontSize: "var(--text-ui)",
-              background: "color-mix(in oklab, var(--color-accent) 8%, transparent)",
-              color: "var(--color-accent)",
-              border: "1px dashed var(--color-accent)",
-              opacity: running ? 0.5 : 1,
-              cursor: running ? "not-allowed" : "pointer",
-            }}
-            {...(running ? {} : PRESS)}
-            aria-label="add a self-scheduling microtask (warning: starves the macrotask queue)"
-          >
-            + self-scheduling micro
-          </motion.button>
-          <motion.button
-            type="button"
+    >
+      <div className="bs-qrace">
+        {/* Tick counter strip — fixed height, aria-live announces ticks. */}
+        <div
+          className="bs-qrace-tick font-mono tabular-nums"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <span style={{ color: "var(--color-text-muted)" }}>tick</span>{" "}
+          <span style={{ color: "var(--color-accent)" }}>{tick}</span>
+          <span style={{ color: "var(--color-text-muted)", margin: "0 8px" }}>
+            ·
+          </span>
+          <span style={{ color: "var(--color-text-muted)" }}>output</span>{" "}
+          <span style={{ color: "var(--color-text)" }}>{output.length}</span>
+          {running ? (
+            <span
+              className="bs-qrace-run"
+              aria-hidden
+              style={{ marginLeft: 10, color: "var(--color-accent)" }}
+            >
+              ▸ running
+            </span>
+          ) : null}
+        </div>
+
+        {/* Body grid — single column on mobile, 2 cols at lg. */}
+        <div className="bs-qrace-body">
+          <div className="bs-qrace-queues">
+            <QueueRegion
+              label="microtask queue"
+              chips={micro}
+              activeId={activeId}
+              accent
+              reservedCount={5}
+            />
+            <QueueRegion
+              label="macrotask queue"
+              chips={macro}
+              activeId={activeId}
+              accent={false}
+              reservedCount={2}
+              badge={starved ? "starved" : null}
+            />
+          </div>
+          <ConsolePane lines={output} />
+        </div>
+
+        {/* Controls strip. Tap targets ≥ 44px; flex-wrap only as last resort
+            — at 360 px the row stays single via short labels. */}
+        <div
+          className="bs-qrace-controls"
+          role="group"
+          aria-label="Queue controls"
+        >
+          <CtrlBtn onClick={addMicro} disabled={running} kind="accent">
+            <span aria-hidden>+</span>
+            <span>micro</span>
+          </CtrlBtn>
+          <CtrlBtn onClick={addMacro} disabled={running} kind="muted">
+            <span aria-hidden>+</span>
+            <span>macro</span>
+          </CtrlBtn>
+          <div className="bs-qrace-self-wrap">
+            <CtrlBtn
+              onClick={addSelf}
+              disabled={running}
+              kind="dashed"
+              ariaLabel="add a self-scheduling microtask"
+            >
+              <span aria-hidden>↻</span>
+              <span>self-sched</span>
+            </CtrlBtn>
+            <AnimatePresence>
+              {selfHintVisible ? (
+                <motion.div
+                  key="hint"
+                  className="bs-qrace-hint"
+                  initial={
+                    reduce ? { opacity: 0 } : { opacity: 0, y: -4 }
+                  }
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={reduce ? { duration: 0 } : SPRING.smooth}
+                  role="note"
+                >
+                  This microtask schedules another microtask. Hit Run — the
+                  queue never empties.
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </div>
+          <CtrlBtn
             onClick={run}
-            disabled={running || (micro.length === 0 && macro.length === 0)}
-            className="font-sans rounded-[var(--radius-md)] min-h-[44px]"
-            style={{
-              padding: "8px 22px",
-              fontSize: "var(--text-ui)",
-              background: "var(--color-accent)",
-              color: "var(--color-bg)",
-              border: "none",
-              opacity:
-                running || (micro.length === 0 && macro.length === 0) ? 0.5 : 1,
-              cursor:
-                running || (micro.length === 0 && macro.length === 0)
-                  ? "not-allowed"
-                  : "pointer",
-              fontWeight: 600,
-            }}
-            {...(running || (micro.length === 0 && macro.length === 0)
-              ? {}
-              : PRESS)}
+            disabled={!canRun}
+            kind="primary"
+            ariaLabel={running ? "running" : "run one tick"}
           >
             {running ? "running…" : "Run ▸"}
-          </motion.button>
-          <motion.button
-            type="button"
-            onClick={reset}
-            className="font-sans rounded-[var(--radius-sm)] min-h-[44px]"
-            style={{
-              padding: "8px 14px",
-              fontSize: "var(--text-ui)",
-              color: "var(--color-text-muted)",
-              background: "transparent",
-              border: "1px solid var(--color-rule)",
-            }}
-            {...PRESS}
-          >
+          </CtrlBtn>
+          <CtrlBtn onClick={reset} kind="ghost" ariaLabel="reset queues">
             reset
-          </motion.button>
+          </CtrlBtn>
         </div>
-      }
-    >
-      <div className="flex flex-col gap-[var(--spacing-md)]">
-        <div className="bs-qrace-grid">
-          <QueueColumn
-            label="microtask queue"
-            chips={micro}
-            activeId={activeId}
-            accent
-          />
-          <QueueColumn
-            label="macrotask queue"
-            chips={macro}
-            activeId={activeId}
-            accent={false}
-            badge={starved ? "starved" : null}
-          />
-        </div>
-        <ConsolePane lines={output} />
-        <p
-          className="font-sans"
-          style={{
-            fontSize: 12,
-            color: "var(--color-text-muted)",
-            margin: 0,
-            textAlign: "center",
-            lineHeight: 1.5,
-          }}
-        >
+
+        <p className="bs-qrace-rule">
           Run = drain <em>all</em> microtasks, then <em>one</em> macrotask, then
           repeat.
         </p>
-        <style>{`
-          .bs-qrace-grid {
-            display: grid;
-            grid-template-columns: 1fr;
-            gap: var(--spacing-md);
-          }
-          @media (min-width: 640px) {
-            .bs-qrace-grid {
-              grid-template-columns: 1fr 1fr;
-            }
-          }
-        `}</style>
       </div>
+
+      <style>{`
+        .bs-qrace {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+        }
+        .bs-qrace-tick {
+          min-height: 24px;
+          line-height: 24px;
+          font-size: 12px;
+          letter-spacing: 0.02em;
+          padding: 0 2px;
+        }
+        .bs-qrace-body {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-sm);
+        }
+        .bs-qrace-queues {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+        }
+        .bs-qrace-controls {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 6px;
+          padding-top: 4px;
+        }
+        .bs-qrace-self-wrap {
+          position: relative;
+          display: inline-flex;
+        }
+        .bs-qrace-hint {
+          position: absolute;
+          left: 0;
+          top: calc(100% + 6px);
+          z-index: 2;
+          width: max-content;
+          max-width: 240px;
+          padding: 6px 10px;
+          font-family: var(--font-sans);
+          font-size: 11px;
+          line-height: 1.4;
+          color: var(--color-text);
+          background: var(--color-surface);
+          border: 1px solid var(--color-accent);
+          border-radius: var(--radius-sm);
+        }
+        .bs-qrace-hint::before {
+          content: "";
+          position: absolute;
+          top: -5px;
+          left: 18px;
+          width: 8px;
+          height: 8px;
+          background: var(--color-surface);
+          border-top: 1px solid var(--color-accent);
+          border-left: 1px solid var(--color-accent);
+          transform: rotate(45deg);
+        }
+        .bs-qrace-rule {
+          font-family: var(--font-sans);
+          font-size: 11px;
+          color: var(--color-text-muted);
+          text-align: center;
+          margin: 2px 0 0 0;
+          line-height: 1.5;
+        }
+        @container widget (min-width: 720px) {
+          .bs-qrace-body {
+            grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+          }
+        }
+      `}</style>
     </WidgetShell>
   );
 }
 
-function QueueColumn({
+/* ----------------------------------------------------------------------- */
+/*  Queue region — fixed reserved height; chips overflow horizontally     */
+/*  inside the bounded strip when the queue grows past the viewport.      */
+/* ----------------------------------------------------------------------- */
+
+function QueueRegion({
   label,
   chips,
   activeId,
   accent,
   badge,
+  reservedCount,
 }: {
   label: string;
   chips: Chip[];
   activeId: string | null;
   accent: boolean;
   badge?: string | null;
+  /** Used to size the reserved strip on mobile. Microtask gets more height. */
+  reservedCount: number;
 }) {
-  // Reserve at least 4 chip rows of vertical space (R6 frame stability).
-  const RESERVED = 4;
-  const ROW_H = 30;
+  // Reserved heights match the spec: 192 px for micros (5 rows × ~32 + chrome),
+  // 96 px for macros (2 rows). Both are min-heights so chips stack inside,
+  // never push the surrounding regions.
+  const STRIP_H = reservedCount >= 4 ? 168 : 72;
   return (
-    <div className="flex flex-col gap-[var(--spacing-2xs)]">
-      <div
-        className="flex items-center justify-between font-sans"
-        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
-      >
-        <span style={{ letterSpacing: "0.02em" }}>{label}</span>
-        <AnimatePresence initial={false}>
-          {badge ? (
-            <motion.span
-              key="badge"
-              initial={{ opacity: 0, scale: 0.7 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.7 }}
-              transition={SPRING.smooth}
-              className="font-mono"
-              style={{
-                fontSize: 10,
-                padding: "2px 8px",
-                borderRadius: 999,
-                color: "var(--color-bg)",
-                background: "var(--color-accent)",
-                letterSpacing: "0.04em",
-                textTransform: "uppercase",
-              }}
-            >
-              {badge}
-            </motion.span>
-          ) : (
-            <span
-              className="font-mono tabular-nums"
-              style={{ fontSize: 11, opacity: 0.7 }}
-            >
-              {chips.length}
-            </span>
-          )}
-        </AnimatePresence>
+    <div className="bs-qrace-region">
+      <div className="bs-qrace-head">
+        <span style={{ color: "var(--color-text-muted)" }}>{label}</span>
+        <span className="bs-qrace-head-right">
+          <AnimatePresence initial={false}>
+            {badge ? (
+              <motion.span
+                key="badge"
+                initial={{ opacity: 0, scale: 0.7 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.7 }}
+                transition={SPRING.smooth}
+                className="bs-qrace-badge font-mono"
+                aria-live="polite"
+              >
+                {badge}
+              </motion.span>
+            ) : null}
+          </AnimatePresence>
+          <span
+            className="font-mono tabular-nums"
+            style={{ color: "var(--color-text-muted)", opacity: 0.8 }}
+          >
+            {chips.length}
+          </span>
+        </span>
       </div>
       <div
+        className="bs-qrace-strip"
         style={{
-          border: `1px ${accent ? "solid" : "dashed"} var(--color-rule)`,
-          borderRadius: "var(--radius-sm)",
-          padding: 8,
-          minHeight: RESERVED * (ROW_H + 6) + 16,
-          display: "flex",
-          flexDirection: "column",
-          gap: 6,
+          minHeight: STRIP_H,
+          borderStyle: accent ? "solid" : "dashed",
           background: accent
-            ? "color-mix(in oklab, var(--color-accent) 4%, transparent)"
+            ? "color-mix(in oklab, var(--color-accent) 5%, transparent)"
             : "color-mix(in oklab, var(--color-surface) 30%, transparent)",
-          position: "relative",
         }}
+        aria-live="polite"
+        aria-label={`${label} (${chips.length} pending)`}
       >
         <AnimatePresence initial={false}>
           {chips.length === 0 ? (
@@ -524,154 +576,224 @@ function QueueColumn({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="font-sans"
-              style={{
-                fontSize: 11,
-                color: "var(--color-text-muted)",
-                opacity: 0.5,
-                fontStyle: "italic",
-                position: "absolute",
-                top: "50%",
-                left: 0,
-                right: 0,
-                textAlign: "center",
-                transform: "translateY(-50%)",
-                pointerEvents: "none",
-              }}
+              className="bs-qrace-empty font-sans"
             >
               empty
             </motion.span>
           ) : (
-            chips.map((c) => {
-              const isActive = activeId === c.id;
-              return (
-                <motion.div
-                  key={c.id}
-                  layout
-                  layoutId={`chip-${c.id}`}
-                  initial={{ opacity: 0, scale: 0.8, y: 6 }}
-                  animate={{
-                    opacity: 1,
-                    scale: isActive ? 1.04 : 1,
-                    y: 0,
-                  }}
-                  exit={{ opacity: 0, scale: 0.7, x: 18 }}
-                  transition={SPRING.smooth}
-                  className="font-mono"
-                  style={{
-                    height: ROW_H,
-                    lineHeight: `${ROW_H}px`,
-                    paddingInline: 12,
-                    fontSize: 12,
-                    borderRadius: 4,
-                    background: accent
-                      ? isActive
+            <div className="bs-qrace-chiprow">
+              {chips.map((c) => {
+                const isActive = activeId === c.id;
+                return (
+                  <motion.div
+                    key={c.id}
+                    layout
+                    layoutId={`chip-${c.id}`}
+                    initial={{ opacity: 0, scale: 0.8, y: 6 }}
+                    animate={{
+                      opacity: 1,
+                      scale: isActive ? 1.06 : 1,
+                      y: 0,
+                    }}
+                    exit={{ opacity: 0, scale: 0.7 }}
+                    transition={SPRING.smooth}
+                    className="bs-qrace-chip font-mono"
+                    style={{
+                      background: accent
+                        ? isActive
+                          ? "var(--color-accent)"
+                          : "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                        : isActive
+                          ? "color-mix(in oklab, var(--color-text) 14%, transparent)"
+                          : "color-mix(in oklab, var(--color-surface) 80%, transparent)",
+                      color: accent
+                        ? isActive
+                          ? "var(--color-bg)"
+                          : "var(--color-accent)"
+                        : "var(--color-text)",
+                      borderStyle: c.kind === "self" ? "dashed" : "solid",
+                      borderColor: accent
                         ? "var(--color-accent)"
-                        : "color-mix(in oklab, var(--color-accent) 12%, transparent)"
-                      : isActive
-                        ? "color-mix(in oklab, var(--color-text) 14%, transparent)"
-                        : "color-mix(in oklab, var(--color-surface) 80%, transparent)",
-                    color: accent
-                      ? isActive
-                        ? "var(--color-bg)"
-                        : "var(--color-accent)"
-                      : "var(--color-text)",
-                    border: `1px ${
-                      c.kind === "self" ? "dashed" : "solid"
-                    } ${
-                      accent ? "var(--color-accent)" : "var(--color-rule)"
-                    }`,
-                    textAlign: "left",
-                  }}
-                >
-                  {c.label}
-                  {c.kind === "self" ? (
-                    <span
-                      aria-hidden
-                      style={{
-                        marginLeft: 8,
-                        fontSize: 10,
-                        opacity: 0.7,
-                      }}
-                    >
-                      ↻
-                    </span>
-                  ) : null}
-                </motion.div>
-              );
-            })
+                        : "var(--color-rule)",
+                    }}
+                  >
+                    {c.label}
+                    {c.kind === "self" ? (
+                      <span
+                        aria-hidden
+                        style={{ marginLeft: 6, fontSize: 10, opacity: 0.7 }}
+                      >
+                        ↻
+                      </span>
+                    ) : null}
+                  </motion.div>
+                );
+              })}
+            </div>
           )}
         </AnimatePresence>
       </div>
+
+      <style>{`
+        .bs-qrace-region {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          min-width: 0;
+        }
+        .bs-qrace-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          font-family: var(--font-sans);
+          font-size: 11px;
+          letter-spacing: 0.02em;
+          min-height: 16px;
+        }
+        .bs-qrace-head-right {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .bs-qrace-badge {
+          font-size: 10px;
+          padding: 2px 8px;
+          border-radius: 999px;
+          color: var(--color-bg);
+          background: var(--color-accent);
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+        .bs-qrace-strip {
+          position: relative;
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          padding: 8px;
+          overflow-x: auto;
+          overflow-y: hidden;
+          touch-action: pan-x;
+          -webkit-overflow-scrolling: touch;
+        }
+        .bs-qrace-empty {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 11px;
+          color: var(--color-text-muted);
+          opacity: 0.5;
+          font-style: italic;
+          pointer-events: none;
+        }
+        .bs-qrace-chiprow {
+          display: flex;
+          flex-wrap: nowrap;
+          gap: 6px;
+          align-items: center;
+          min-height: 40px;
+        }
+        .bs-qrace-chip {
+          flex: 0 0 auto;
+          min-width: 56px;
+          height: 40px;
+          line-height: 40px;
+          padding: 0 12px;
+          font-size: 12px;
+          border-radius: 4px;
+          border-width: 1px;
+          text-align: center;
+          white-space: nowrap;
+        }
+      `}</style>
     </div>
   );
 }
 
+/* ----------------------------------------------------------------------- */
+/*  Console pane — fixed reserved height; lines past 6 scroll internally  */
+/*  so the pane never grows. Caret blinks slowly while idle.              */
+/* ----------------------------------------------------------------------- */
+
 function ConsolePane({ lines }: { lines: ConsoleLine[] }) {
-  const RESERVED_LINES = 4;
+  const reduce = useReducedMotion();
+  const RESERVED_LINES = 6;
   const LINE_H = 22;
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  // Pin scroll to the bottom as new lines arrive (so the latest is always
+  // visible without changing pane height).
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [lines.length]);
+
   return (
-    <div className="flex flex-col gap-[var(--spacing-2xs)]">
-      <div
-        className="flex items-baseline justify-between font-sans"
-        style={{ fontSize: 11, color: "var(--color-text-muted)" }}
-      >
-        <span style={{ letterSpacing: "0.02em" }}>console · firing order</span>
+    <div className="bs-qrace-console-region">
+      <div className="bs-qrace-console-head">
+        <span style={{ color: "var(--color-text-muted)" }}>
+          console · firing order
+        </span>
         <span
           className="font-mono tabular-nums"
-          style={{ fontSize: 11, opacity: 0.7 }}
+          style={{ color: "var(--color-text-muted)", opacity: 0.8 }}
         >
           {lines.length}
         </span>
       </div>
       <div
-        style={{
-          background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
-          border: "1px solid var(--color-rule)",
-          borderRadius: "var(--radius-sm)",
-          padding: "8px 12px",
-          minHeight: RESERVED_LINES * LINE_H + 16,
-          fontSize: 12,
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
-        }}
+        ref={scrollerRef}
+        className="bs-qrace-console"
+        style={{ minHeight: RESERVED_LINES * LINE_H + 16 }}
+        aria-live="polite"
       >
-        <AnimatePresence initial={false}>
-          {lines.length === 0 ? (
+        {lines.length === 0 ? (
+          <span className="bs-qrace-console-empty font-sans">
+            waiting for Run
             <motion.span
-              key="empty"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="font-sans"
+              aria-hidden
+              animate={
+                reduce
+                  ? { opacity: 1 }
+                  : { opacity: [0.2, 1, 1, 0.2] }
+              }
+              transition={
+                reduce
+                  ? { duration: 0 }
+                  : { duration: 1.6, repeat: Infinity, times: [0, 0.4, 0.6, 1] }
+              }
               style={{
-                fontSize: 11,
-                color: "var(--color-text-muted)",
-                opacity: 0.5,
-                fontStyle: "italic",
-                lineHeight: `${LINE_H}px`,
+                marginLeft: 4,
+                color: "var(--color-accent)",
+                fontFamily: "var(--font-mono)",
               }}
             >
-              waiting for Run…
+              ▍
             </motion.span>
-          ) : (
-            lines.map((l, i) => (
+          </span>
+        ) : (
+          <AnimatePresence initial={false}>
+            {lines.map((l, i) => (
               <motion.div
                 key={l.id}
                 layout
-                initial={{ opacity: 0, x: -10 }}
-                animate={{ opacity: 1, x: 0 }}
+                initial={
+                  reduce
+                    ? { opacity: 0 }
+                    : { opacity: 0, y: 4 }
+                }
+                animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0 }}
-                transition={SPRING.smooth}
-                className="font-mono"
+                transition={
+                  reduce ? { duration: 0 } : { duration: 0.2 }
+                }
+                className="bs-qrace-console-line font-mono"
                 style={{
-                  lineHeight: `${LINE_H}px`,
                   color:
                     l.kind === "micro"
                       ? "var(--color-accent)"
                       : "var(--color-text)",
-                  whiteSpace: "pre",
                 }}
               >
                 <span
@@ -687,10 +809,122 @@ function ConsolePane({ lines }: { lines: ConsoleLine[] }) {
                   {l.kind === "micro" ? "micro" : "macro"} → {l.label}
                 </span>
               </motion.div>
-            ))
-          )}
-        </AnimatePresence>
+            ))}
+          </AnimatePresence>
+        )}
       </div>
+
+      <style>{`
+        .bs-qrace-console-region {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          min-width: 0;
+        }
+        .bs-qrace-console-head {
+          display: flex;
+          align-items: baseline;
+          justify-content: space-between;
+          font-family: var(--font-sans);
+          font-size: 11px;
+          letter-spacing: 0.02em;
+          min-height: 16px;
+        }
+        .bs-qrace-console {
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          padding: 8px 12px;
+          font-size: 12px;
+          line-height: 22px;
+          overflow-y: auto;
+          max-height: 192px;
+          -webkit-overflow-scrolling: touch;
+        }
+        .bs-qrace-console-line {
+          white-space: pre;
+          line-height: 22px;
+        }
+        .bs-qrace-console-empty {
+          font-size: 11px;
+          color: var(--color-text-muted);
+          font-style: italic;
+          line-height: 22px;
+          opacity: 0.7;
+        }
+      `}</style>
     </div>
+  );
+}
+
+/* ----------------------------------------------------------------------- */
+/*  CtrlBtn — control row button. Tap target ≥ 44 × 44 px.                */
+/* ----------------------------------------------------------------------- */
+
+function CtrlBtn({
+  children,
+  onClick,
+  disabled,
+  kind,
+  ariaLabel,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  kind: "primary" | "accent" | "muted" | "dashed" | "ghost";
+  ariaLabel?: string;
+}) {
+  const base: React.CSSProperties = {
+    minHeight: 44,
+    padding: "0 12px",
+    borderRadius: "var(--radius-sm)",
+    fontFamily: "var(--font-sans)",
+    fontSize: "var(--text-ui)",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+    border: "1px solid var(--color-rule)",
+    background: "transparent",
+    color: "var(--color-text)",
+    whiteSpace: "nowrap",
+  };
+  const variant: Record<typeof kind, React.CSSProperties> = {
+    primary: {
+      background: "var(--color-accent)",
+      color: "var(--color-bg)",
+      border: "1px solid var(--color-accent)",
+      fontWeight: 600,
+      padding: "0 18px",
+    },
+    accent: {
+      background:
+        "color-mix(in oklab, var(--color-accent) 14%, transparent)",
+      color: "var(--color-accent)",
+      border: "1px solid var(--color-accent)",
+    },
+    muted: {},
+    dashed: {
+      background:
+        "color-mix(in oklab, var(--color-accent) 8%, transparent)",
+      color: "var(--color-accent)",
+      border: "1px dashed var(--color-accent)",
+    },
+    ghost: {
+      color: "var(--color-text-muted)",
+    },
+  };
+  return (
+    <motion.button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      style={{ ...base, ...variant[kind] }}
+      {...(disabled ? {} : PRESS)}
+    >
+      {children}
+    </motion.button>
   );
 }

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -321,6 +321,101 @@ Every widget wraps in `<WidgetShell>`. Consistent header/canvas/controls/caption
 - **Props you'll actually pass**: `value`, `total`, `onChange`, optionally `playable={false}` (for non-autoplay widgets), `playInterval` (custom cadence), `counterNoun` (when "step" reads wrong), `ariaLabel`.
 - **Stepper deprecation**: `<Stepper>` is preserved as a shim that forwards to `WidgetNav` for one release, so external imports survive. Migrate your callsite to `<WidgetNav>` directly when you touch the widget.
 
+### 4.7 Mobile-first widget building (v2 — added after the queue-race + call-stack-ECs redesigns)
+
+The two widgets in [`MicrotaskStarvation`](../app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx) and [`CallStackECs`](../app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx) shipped first as desktop-shaped layouts that broke on mobile and changed the shell's outer size during interaction. The user's note was clear: *"for mobile devices we are able to render it nicely on the entire screen and the layout or the size of the overall component doesn't change on interactions."* These guidelines codify the rebuild so future widgets start mobile-first by default.
+
+**1. The 360 px first rule.** Every widget is designed for a 360 px viewport before any larger breakpoint. Ergonomic minimums:
+- Tap target ≥ 44 × 44 CSS px on every interactive element (`min-h-[44px]` plus padding sized for the glyph).
+- Body / chip / line font size ≥ 11 px; UI-control font size ≥ 12 px.
+- No element is clipped at 360 px. Buttons may use icon + short label (e.g. `↻ self-sched`) instead of full sentences so the controls row stays single-line.
+- Horizontal scroll is permitted **inside** a bounded region (e.g. `overflow-x-auto` on a queue strip when chips exceed viewport width) but **never** on the widget shell itself.
+
+**2. R6 frame-stability rule for widgets.** The shell's `width × height` MUST NOT change during interaction. Every region whose contents grow or shrink (queues filling, console writing, EC stack pushing, verdict revealing) reserves a fixed `min-height` so growth happens *inside* the reserved space, not by pushing siblings around. Variable content beyond the reservation scrolls **internally** (e.g. console pane scrolls past 6 lines without growing). Concrete pattern from `MicrotaskStarvation`:
+
+```css
+.bs-qrace-strip { min-height: 168px; overflow-x: auto; }   /* micro queue */
+.bs-qrace-console { min-height: 148px; max-height: 192px; overflow-y: auto; }
+```
+
+Forbidden: animating `width`, `height`, `top`, `left`, `viewBox`, or any geometric SVG attribute on the shell or any region container. Use `transform`, `opacity`, and `motion.div` `layout` only.
+
+**3. Container queries over viewport breakpoints.** Widgets sit inside articles whose container width is narrower than the viewport. Drive layout flips off the *render context*, not the device:
+
+```css
+@container widget (min-width: 720px) { … }   /* not @media (min-width: 1024px) */
+```
+
+`WidgetShell` already declares `container-type: inline-size`. The 720 px breakpoint is the canonical "ok, we have room for two columns" threshold — same as `CallStackECs` and `MicrotaskStarvation`.
+
+**4. Vertical-stack-on-mobile, side-by-side-on-desktop pattern.** Author the mobile shape first; promote to two columns at the container breakpoint. The mobile-only down-glyph (`↓` between code and stack panes in `CallStackECs`) is *always rendered* and toggled visible / hidden via CSS so `:nth-child` indices stay stable across both layouts.
+
+```
+mobile (< 720 px)            desktop (≥ 720 px)
+┌───────────────┐            ┌──────────┬──────────┐
+│ controls      │            │ controls (full row)  │
+├───────────────┤            ├──────────┼──────────┤
+│ region A      │            │ region A │ region B │
+├───────────────┤            ├──────────┤ (spans)  │
+│   ↓ glyph     │            │ region C │          │
+├───────────────┤            └──────────┴──────────┘
+│ region B      │
+├───────────────┤
+│ region C      │
+└───────────────┘
+```
+
+**5. Code rendering inside widgets — the RSC + `codeSlot` pattern.** Use [`<CodeBlock>`](../components/code/CodeBlock.tsx) for any syntax-highlighted snippet. CodeBlock is a server component (async); widgets are typically `"use client"`. The pattern: `page.tsx` (RSC) renders the `<CodeBlock>` and passes it to the widget as a `codeSlot: ReactNode` prop. The widget overlays interactive layers (e.g. an active-line wash) on top with absolute positioning + `useLayoutEffect` + `ResizeObserver` to measure the rendered Shiki `span.line` rows. Never re-implement Shiki client-side; never animate the Shiki HTML itself.
+
+```tsx
+// page.tsx (RSC)
+<CallStackECs codeSlot={<CodeBlock code={SNIPPET} lang="javascript" />} />
+
+// widget.tsx ("use client")
+type Props = { codeSlot?: ReactNode };
+// in JSX:
+<div ref={codeSlotRef} className="codeslot">
+  <ActiveLineWash rect={washRect} />
+  {codeSlot}
+</div>
+```
+
+Languages registered in [`lib/shiki.ts`](../lib/shiki.ts): `typescript`, `tsx`, `javascript`, `jsx`, `bash`, `python`, `json`, `http`, `html`. Anything else: add it there in a separate PR before using.
+
+**Caveat — snippet exports must NOT live in the client widget file.** Next wraps every export from a `"use client"` module as a client reference, including string constants. Importing `CALL_STACK_SNIPPET` from the client widget into the RSC page hands `<CodeBlock code={...}>` a *function* instead of a string, which prerender catches as `TypeError: a.replace is not a function`. Put the snippet in its own `*.ts` file alongside the widget (e.g. `CallStackSnippet.ts`, no `"use client"`) and import it from both sides. See `app/posts/how-javascript-reads-its-own-future/widgets/CallStackSnippet.ts` for the working example.
+
+**6. Reduced-motion contract for widgets.** Every widget MUST branch on `useReducedMotion()`. The reduced path collapses to: opacity-only crossfades; `pathLength` reveals teleport to 1; `layoutId` indicators appear in their final position rather than gliding. Pattern:
+
+```tsx
+const reduce = useReducedMotion();
+<motion.div
+  initial={reduce ? { opacity: 0 } : { opacity: 0, y: -16 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={reduce ? { duration: 0 } : SPRING.smooth}
+/>
+```
+
+`setTimeout` / `setInterval` cadences should also gate on `reduce` — auto-step cadences double, fire-delay falls to 0, console-caret blink stops.
+
+**7. Accessibility minimums.**
+- `aria-live="polite"` on regions that announce state changes — tick counter, current EC, console pane, queue length.
+- `role="group"` + `aria-label` on every controls strip.
+- `role="radiogroup"` / `role="radio"` for option groups (premise quiz, scenario tabs).
+- Focus rings preserved (no `outline: none` without a replacement). Tap targets ≥ 44 × 44 px (rule 1).
+- Keyboard nav: arrow keys + Enter for ordered controls; Tab to focus and Enter / Space to fire for buttons.
+- State-dependent `aria-label`s name the *current* state, never a future outcome.
+
+**8. Frame-stability checklist (run before push).**
+- [ ] Every variable-content region has a fixed `min-height`.
+- [ ] No element animates `width` / `height` / `viewBox` / `top` / `left` / geometric SVG attributes. Only `transform`, `opacity`, `pathLength`, motion-derived `cx` / `x1`.
+- [ ] Outer shell renders identically at 360 px and at the lg breakpoint between idle / mid-step / post-step. (Open dev-tools, set viewport to 360 × 800, screenshot at idle, click through, screenshot again — outer rect identical.)
+- [ ] No horizontal overflow on the widget shell at 360 px.
+- [ ] Reduced-motion path verified: animation collapses without breaking layout.
+- [ ] Tap targets all ≥ 44 px high — including the small icon-only buttons.
+- [ ] Container queries (not viewport `@media`) drive every layout flip.
+
+This sub-section is the doc anchor future widget tasks will cite. Cross-reference: [`mobile-first-verification.md`](./mobile-first-verification.md) for the project-wide mobile audit script.
+
 ## 5. Anti-patterns (from actual review feedback)
 
 ### Auto-playing on mount


### PR DESCRIPTION
## Summary

Two widgets — `MicrotaskStarvation` (queue race) and `CallStackECs` (call stack · execution contexts) — were redesigned mobile-first with R6 frame-stability. The third deliverable is a new `docs/interactive-components.md §4.7` sub-section codifying the mobile-first widget guidelines so future widgets follow them by default.

User feedback that motivated the rebuild:
> for mobile devices we are able to render it nicely on the entire screen and the layout or the size of the overall component doesn't change on interactions. re-draw it in a better layout optimized for mobile-first website.

> point #3 should be applied to the interactive component 'call stack · execution contexts' too. Make sure we document it all so that whenever the next time we are building a component, it is already understood what guidelines need to be followed while creating one.

## Changes

### MicrotaskStarvation (queue race)
- Vertical-stack layout at 360 px: tick counter, micro queue, macro queue, console, controls. Two-column at lg via `@container widget (min-width: 720px)`.
- All regions reserve fixed `min-height` (R6); the shell never resizes during interaction. Console scrolls internally past 6 lines; queues overflow horizontally inside their bounded strip.
- Buttons: short labels (`+ micro` / `+ macro` / `+ self-sched` / `Run` / `reset`) so the controls row stays one line at 360 px. Tap targets ≥ 44 px.
- New: first-click mini-tooltip on `+ self-sched` ("This microtask schedules another microtask. Hit Run — the queue never empties.") that fades after 6 s or when Run is pressed. Helps the reader connect button → mechanism.
- Self-scheduling explainer paragraph rewritten in the page prose to spell out *why* the queue never empties.
- State-machine only; cap at 6 hops. No real Promise / setTimeout recursion.

### CallStackECs (call stack · execution contexts)
- Vertical-stack at 360 px: controls, code pane, mobile down-glyph, stack pane, console. Two-column at lg.
- Code pane uses `<CodeBlock>` via the **RSC + codeSlot pattern**: page.tsx (RSC) renders `<CodeBlock>` and passes it as a `codeSlot: ReactNode` prop. The widget overlays an active-line wash on top using absolute positioning + `useLayoutEffect` + `ResizeObserver` to measure rendered Shiki `span.line` rows.
- The shared snippet (`CallStackSnippet.ts`) is in its own non-client module — exporting it from the `"use client"` widget would wrap it as a client reference and break `<CodeBlock>` (string → function).
- SVG arrow overlay desktop-only; mobile shows a pulsing terracotta down-glyph between the code and stack panes. The matched line+card highlight pair carries the thread-of-execution metaphor.

### Docs
- New `docs/interactive-components.md §4.7 Mobile-first widget building` sub-section. Covers: 360 px first rule, R6 frame-stability for widgets, container queries over viewport breakpoints, vertical-stack-on-mobile pattern, RSC + codeSlot for Shiki + the client-reference caveat, reduced-motion contract, accessibility minimums, pre-push checklist. Cross-references the two widgets as canonical examples.
- Inserted right after §4.5 to avoid conflict with the parallel `feat/quiz-wrapper` agent's §2 work.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm build` clean — all 7 posts prerender.
- [x] No `VerticalCutReveal` / `DragElements` references in either widget.
- [ ] Mental sweep at 360 px: shells render without horizontal scroll; tap targets ≥ 44 px; outer height invariant before / mid / after interaction.
- [ ] Reduced-motion path: opacity-only crossfades; no broken layout.
- [ ] Container queries flip the layout at 720 px (not viewport `@media`).
- [ ] Self-scheduling tooltip appears on first click only; fades after 6 s or Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)