### PR TITLE
fix(footer): replace 'built by anonymous engineer' with Spolsky quote

### DIFF
--- a/components/nav/Footer.tsx
+++ b/components/nav/Footer.tsx
@@ -1,5 +1,16 @@
-import { SITE_NAME } from "@/lib/site";
-
+/**
+ * Footer — a single-line muted ornament at the bottom of every page. The
+ * footer used to credit the author ("built by An Anonymous Engineer") but
+ * the site went anonymous in PR #25; the slot has been recycled into a
+ * Spolsky quote that mirrors the site's own thesis.
+ *
+ * Joel Spolsky's "Law of Leaky Abstractions" (2002) is the canonical
+ * statement of what every lainlog post is doing: abstractions hide the
+ * mechanism only as long as the mechanism behaves well; lainlog's whole
+ * job is to walk readers into the seams. The quote pairs cleanly with
+ * SITE_ABOUT ("for people who'd rather pry the abstraction open than
+ * read about it") without being on-the-nose.
+ */
 export function Footer() {
   return (
     <footer
@@ -12,10 +23,8 @@ export function Footer() {
     >
       <div className="mx-auto flex max-w-[65ch] items-center">
         <span>
-          {SITE_NAME} · built by An Anonymous Engineer
-          <span aria-hidden className="ml-[0.25em] opacity-70">
-            {"</>"}
-          </span>
+          &ldquo;All non-trivial abstractions, to some degree, are
+          leaky.&rdquo; &mdash; Joel Spolsky
         </span>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
The footer's old credit line (\"built by An Anonymous Engineer </>\") was a residue of PR #25's anonymous-author cleanup. With the lainlog rebrand merged, that slot was an unused single-line ornament.

Replaced with **Joel Spolsky's Law of Leaky Abstractions** (2002):

> *\"All non-trivial abstractions, to some degree, are leaky.\"*

Pairs cleanly with \`SITE_ABOUT\` (\"for people who'd rather pry the abstraction open than read about it\") — same thesis lainlog posts walk readers through, sourced from the engineer who put the phrase in the canon.

Removed the now-unused \`SITE_NAME\` import; replaced raw quote characters with curly entities (\`&ldquo;\`, \`&rdquo;\`, \`&mdash;\`).

## Test plan
- [ ] Vercel preview — bottom of every page now shows the Spolsky quote in muted-mono. No layout shift.
- [ ] tsc + build green (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)