### PR TITLE
post: MCPs Explained — what they are and how they work

### DIFF
--- a/app/posts/mcps-explained/metadata.ts
+++ b/app/posts/mcps-explained/metadata.ts
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { SITE_URL as SITE } from "@/lib/site";
+
+const SLUG = "mcps-explained";
+const VISIBLE_HEADING = "MCPs Explained: What They Are and How They Work";
+const HOOK =
+  "Model Context Protocol, end-to-end. The handshake that opens every session, the six primitives that ride it, the two transports that carry it, and why every published MCP attack is a host-side failure — not a protocol flaw.";
+
+export const metadata: Metadata = {
+  title: `${VISIBLE_HEADING} — lainlog`,
+  description: HOOK,
+  keywords: [
+    "MCP",
+    "model context protocol",
+    "MCP server",
+    "MCP client",
+    "MCP host",
+    "JSON-RPC",
+    "tool calling",
+    "sampling",
+    "elicitation",
+    "roots",
+    "Streamable HTTP",
+    "Anthropic",
+    "AI agents",
+    "lethal trifecta",
+    "tool poisoning",
+  ],
+  alternates: {
+    canonical: `${SITE}/posts/${SLUG}`,
+  },
+  openGraph: {
+    title: `${VISIBLE_HEADING} — lainlog`,
+    description: HOOK,
+    url: `${SITE}/posts/${SLUG}`,
+    type: "article",
+    publishedTime: "2026-04-28T00:00:00.000Z",
+    images: [{ url: `${SITE}/og/${SLUG}`, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${VISIBLE_HEADING} — lainlog`,
+    description: HOOK,
+    images: [`${SITE}/og/${SLUG}`],
+  },
+};

--- a/app/posts/mcps-explained/page.tsx
+++ b/app/posts/mcps-explained/page.tsx
@@ -148,12 +148,12 @@ export default function MCPsExplained() {
         <P>
           The story has a person at the centre. David Soria Parra joined
           Anthropic in mid-2024 after a stretch building developer tools at
-          Meta and Atlassian. He was, predictably, copy-pasting between Claude
-          Desktop and his IDE. He had also worked on LSP at his previous job,
-          and the structural symmetry hit him immediately. With Justin
-          Spahr-Summers, he prototyped a JSON-RPC-shaped protocol that put a
-          shared layer between any AI host and any tool. Roughly six weeks
-          later — November 25, 2024 — Anthropic announced{" "}
+          Meta and Atlassian. He was copy-pasting between Claude Desktop and
+          his IDE. He had also worked on LSP at his previous job, and the
+          parallel was obvious. With Justin Spahr-Summers, he prototyped a
+          JSON-RPC-shaped protocol that put a shared layer between any AI
+          host and any tool. Roughly six weeks later — November 25, 2024 —
+          Anthropic announced{" "}
           <A href="https://www.anthropic.com/news/model-context-protocol">
             the Model Context Protocol
           </A>{" "}
@@ -300,9 +300,8 @@ export default function MCPsExplained() {
           </HL>{" "}
           <Code>tools/list</Code>, <Code>tools/call</Code>,{" "}
           <Code>resources/read</Code>, <Code>sampling/createMessage</Code>,{" "}
-          <Code>elicitation/create</Code> — every later method is just a
-          JSON-RPC envelope shaped to the contract. The next two sections walk
-          those primitives one by one.
+          <Code>elicitation/create</Code> — every later method is the same
+          envelope, shaped to the contract.
         </P>
         <Aside>
           Version mismatch isn&apos;t fatal. If the client requests a version
@@ -452,13 +451,14 @@ export default function MCPsExplained() {
         <P>
           <strong>HITL #1 — before send.</strong> When the server&apos;s{" "}
           <Code>sampling/createMessage</Code> arrives, the client doesn&apos;t
-          forward it to the model immediately. It surfaces the request to the
-          user — the messages, the system prompt, the requested model
-          preferences — and lets the user approve, edit, or reject. The
-          edit case is non-trivial: the user can rewrite a server&apos;s
-          prompt before it hits their model. In practice most hosts make this
-          a one-click approve, but the option to edit is the protocol&apos;s
-          escape hatch against a malicious or buggy server.
+          forward it to the model immediately — it hands it up to the host.
+          The host surfaces the request to the user — the messages, the
+          system prompt, the requested model preferences — and lets the user
+          approve, edit, or reject. The edit case is non-trivial: the user
+          can rewrite a server&apos;s prompt before it hits their model. In
+          practice most hosts make this a one-click approve, but the option
+          to edit is the protocol&apos;s escape hatch against a malicious or
+          buggy server.
         </P>
         <P>
           <strong>HITL #2 — before return.</strong> The model produces a
@@ -490,8 +490,8 @@ export default function MCPsExplained() {
           because you asked nicely.
         </P>
         <P>
-          And there is one subtle thing about <Code>includeContext</Code>:
-          it&apos;s a request, not a guarantee. <Code>none</Code> means the
+          <Code>includeContext</Code> has its own subtlety: it&apos;s a
+          request, not a guarantee. <Code>none</Code> means the
           server&apos;s messages are the entire prompt — no user
           conversation history bleeds in. <Code>thisServer</Code> says the
           host may choose to attach context the user has already shared with
@@ -522,6 +522,7 @@ export default function MCPsExplained() {
           from the inference layer in a way nothing else has. Whether the
           ecosystem leans into it or not is a question for 2026 and beyond.
         </Aside>
+        <Dots />
         <H2 id="roots">Roots</H2>
         <P>
           <Term>Roots</Term> are the filesystem boundary the client tells the
@@ -542,6 +543,7 @@ export default function MCPsExplained() {
           server feature. We&apos;ll see what happens when a host fails to
           enforce roots in §7.
         </P>
+        <Dots />
         <H2 id="elicitation">Elicitation</H2>
         <P>
           <Term>Elicitation</Term> is the newest of the six primitives, added

--- a/app/posts/mcps-explained/page.tsx
+++ b/app/posts/mcps-explained/page.tsx
@@ -1,0 +1,815 @@
+import {
+  Prose,
+  H1,
+  H2,
+  P,
+  Code,
+  A,
+  Aside,
+  Callout,
+  Dots,
+  Term,
+} from "@/components/prose";
+import { PostBackLink } from "@/components/nav/PostBackLink";
+import { PostNavCards } from "@/components/nav/PostNavCards";
+import { TextHighlighter } from "@/components/fancy";
+import { CodeBlock } from "@/components/code/CodeBlock";
+import {
+  PredictTheHandshake,
+  RoleTopology,
+  HandshakeWalkthrough,
+  SixPrimitives,
+  TransportToggle,
+} from "./widgets";
+import {
+  INITIALIZE_REQUEST_SNIPPET,
+  TRANSPORT_STDIO_SNIPPET,
+  TRANSPORT_HTTP_SNIPPET,
+} from "./widgets/snippets";
+import { metadata } from "./metadata";
+
+export { metadata };
+
+const HL_TRANSITION = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/** Highlight a load-bearing phrase. ltr swipe, spring, in-view-once. */
+function HL({
+  children,
+  direction = "ltr",
+}: {
+  children: React.ReactNode;
+  direction?: "ltr" | "rtl" | "ttb" | "btt";
+}) {
+  return (
+    <TextHighlighter
+      transition={HL_TRANSITION}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      direction={direction}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+export default function MCPsExplained() {
+  return (
+    <Prose>
+      <div className="pt-[var(--spacing-xl)]">
+        <PostBackLink />
+        <H1>MCPs Explained: What They Are and How They Work</H1>
+        <p
+          className="mt-[var(--spacing-sm)] font-mono tabular-nums"
+          style={{
+            fontSize: "var(--text-small)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <time dateTime="2026-04-28">apr 28, 2026</time>
+          <span className="mx-2">·</span>
+          <span>17 min read</span>
+        </p>
+
+        {/* §0 — the premise quiz */}
+        <P>
+          Before we explain anything, look at the JSON below. A client just
+          opened an MCP session by sending it. Read it once, then guess what
+          the server sends back.{" "}
+          <HL>
+            The gap between option 1 and option 2 is the whole shape of MCP.
+          </HL>
+        </P>
+      </div>
+
+      <PredictTheHandshake
+        codeSlot={
+          <CodeBlock
+            lang="json"
+            filename="initialize · request"
+            code={INITIALIZE_REQUEST_SNIPPET}
+          />
+        }
+      />
+
+      <div>
+        <P>
+          Most readers reach for option 1 — &ldquo;a list of tools&rdquo; — because
+          they think of MCP as a manifest you load. It isn&apos;t. The server
+          sends back a contract first: <em>here&apos;s the protocol version I
+          speak, here are the capabilities I support.</em> The client confirms
+          with a one-way <Code>notifications/initialized</Code>, and only{" "}
+          <em>then</em> can either side ask the other for tools, resources,
+          prompts, or anything else. The handshake doesn&apos;t list
+          capabilities — it negotiates them.
+        </P>
+        <P>
+          That negotiation is the entire spine of the protocol. Once you can
+          read it, every other part of MCP becomes a corollary: how servers
+          expose tools, how clients let servers ask the model for things, how
+          the same dance survives over a subprocess pipe or a session-tracked
+          HTTPS endpoint, why every published security incident reads as a
+          host-side mistake. This post walks the spine, then the corollaries.
+        </P>
+      </div>
+
+      {/* §1 — why MCP exists: N×M */}
+      <div>
+        <Dots />
+        <H2>Why MCP exists: the N×M problem</H2>
+        <P>
+          Picture the world a year ago. You&apos;re using Claude Desktop to
+          summarise a Notion page; the model can&apos;t see Notion, so you
+          paste. You ask Cursor to scaffold a feature against your team&apos;s
+          GitHub; the model can&apos;t see GitHub, so you paste. You wire a
+          Linear plugin to ChatGPT, then a different Linear adapter to
+          Cursor, then a third for Cline. Every host writes a one-off
+          integration for every tool. The integration count grows as{" "}
+          <em>N hosts × M tools</em>, and at some point the world gives up.
+        </P>
+        <P>
+          Engineers have seen this shape before. Editors and language servers
+          had the same nightmare: every IDE reimplemented Go-to-definition for
+          every language, until Microsoft published the{" "}
+          <A href="https://microsoft.github.io/language-server-protocol/">
+            Language Server Protocol
+          </A>{" "}
+          in 2016. Each editor implemented LSP once. Each language wrote one
+          server. The N×M cell-grid collapsed into a clean <em>N+M</em>: every
+          host and every tool implements the protocol once, and they meet in
+          the middle.{" "}
+          <HL>
+            Every host and every tool implements the protocol once → N+M.
+          </HL>{" "}
+          That is the entire structural reason MCP exists.
+        </P>
+        <P>
+          The story has a person at the centre. David Soria Parra joined
+          Anthropic in mid-2024 after a stretch building developer tools at
+          Meta and Atlassian. He was, predictably, copy-pasting between Claude
+          Desktop and his IDE. He had also worked on LSP at his previous job,
+          and the structural symmetry hit him immediately. With Justin
+          Spahr-Summers, he prototyped a JSON-RPC-shaped protocol that put a
+          shared layer between any AI host and any tool. Roughly six weeks
+          later — November 25, 2024 — Anthropic announced{" "}
+          <A href="https://www.anthropic.com/news/model-context-protocol">
+            the Model Context Protocol
+          </A>{" "}
+          as an open specification with reference servers, an SDK, and a
+          permissive licence.
+        </P>
+        <P>
+          By the time you are reading this — early 2026 — both OpenAI and
+          Google Gemini ship native MCP support. The public ecosystem holds
+          more than ten thousand servers; the JavaScript and Python SDKs pull
+          something on the order of ninety-seven million downloads a month.
+          The spec page calls MCP a <em>USB-C port for AI applications</em>.
+          That metaphor isn&apos;t marketing — it&apos;s the right shape. One
+          plug. One contract. Any host on one side, any capability on the
+          other.
+        </P>
+        <Aside>
+          The LSP comparison isn&apos;t just rhetorical. MCP&apos;s wire format
+          is{" "}
+          <A href="https://www.jsonrpc.org/specification">JSON-RPC 2.0</A>,
+          which LSP also uses. If you&apos;ve ever shipped a language-server
+          extension, you already speak two thirds of the protocol — only the
+          methods change.
+        </Aside>
+      </div>
+
+      {/* §2 — three roles, one boundary */}
+      <div>
+        <Dots />
+        <H2>Three roles, one boundary</H2>
+        <P>
+          Before any wire format makes sense, you have to install the
+          topology. MCP names exactly three roles, and the trust boundary
+          lives between two of them.
+        </P>
+        <P>
+          A <Term>host</Term> is the application the user trusts — Claude
+          Desktop, Cursor, ChatGPT&apos;s desktop client, Cline. The host
+          owns the model, the conversation, and the user&apos;s consent. A{" "}
+          <Term>client</Term> is a small adapter that lives <em>inside</em> the
+          host and speaks MCP on its behalf; one client per server, owned by
+          the host. A <Term>server</Term> is a focused capability provider — a
+          filesystem, a GitHub adapter, a Notion adapter — that does one thing
+          and exposes it through a JSON-RPC endpoint.
+        </P>
+        <P>
+          The split looks like over-engineering until you ask <em>where the
+          user&apos;s trust lives.</em> It lives in the host. The host is the
+          piece of software the user installed, granted permissions to,
+          pointed at a model. Servers are configured later, often
+          one-click-installs from a third-party registry. If the host let
+          servers reach into the conversation directly, every tool install
+          would be a credential install. So MCP separates them: the client
+          is the sealed adapter, owned by the host, that lets the server
+          speak <em>only</em> through the protocol surface. The host enforces
+          the boundary at the protocol layer.
+        </P>
+      </div>
+
+      <RoleTopology />
+
+      <div>
+        <P>
+          Three things a server <em>cannot do</em>, and these are the
+          load-bearing facts: it cannot see the user&apos;s ongoing
+          conversation, it cannot see the other servers running alongside it,
+          and it cannot call the model directly. Anything from those three
+          buckets must come through the host — and the host gets to say no.
+          That last clause is the entire security model, hiding in plain
+          sight; we&apos;ll cash it in at §7.
+        </P>
+        <P>
+          The host is the only thing on this canvas that knows the user. The
+          servers are isolated by design — and because they&apos;re isolated,
+          you can install a dozen of them without thinking about cross-tool
+          contamination. That property is why <em>marketplace</em> energy
+          actually works for MCP: each server is a self-contained capability
+          behind a uniform pipe.
+        </P>
+      </div>
+
+      {/* §3 — the handshake IS the protocol */}
+      <div>
+        <Dots />
+        <H2>The handshake is the protocol</H2>
+        <P>
+          Now to the spine. Every MCP session starts with the same three
+          messages, and after them, every later message — every tool call,
+          every resource read, every sampling round-trip — is just JSON-RPC
+          riding the same connection.
+        </P>
+        <P>
+          Message one is the <Code>initialize</Code> request. The client
+          declares which protocol version it speaks (the current stable
+          baseline is <Code>2025-06-18</Code>), what capabilities it
+          <em> can</em> offer to the server (roots, sampling, elicitation),
+          and a small <Code>clientInfo</Code> tag for logs and crash reports.
+          Note what&apos;s <em>not</em> in the request: any mention of tools,
+          resources, or prompts. The client doesn&apos;t expose those — the
+          server does. The handshake is asymmetric on purpose.
+        </P>
+        <P>
+          Message two is the <Code>initialize</Code> response. The server
+          echoes the version it&apos;ll commit to (it picks the latest
+          version <em>both</em> sides understand, so an older client can
+          still talk to a newer server), then declares <em>its</em>{" "}
+          capabilities — the actual <Code>tools</Code>,{" "}
+          <Code>resources</Code>, <Code>prompts</Code> primitives it offers,
+          plus optional sub-flags like <Code>listChanged</Code> for change
+          notifications. After this exchange, both sides are pinned to the
+          intersection. The session has a contract.
+        </P>
+        <P>
+          Message three is <Code>notifications/initialized</Code>: the client
+          says &ldquo;I&apos;ve read your response, I&apos;m ready.&rdquo;
+          It&apos;s a JSON-RPC <Term>notification</Term> — no <Code>id</Code>,
+          no response expected. Until the server sees it, the spec forbids the
+          server from sending anything but ping or logging. Until the client
+          sees the response, the spec forbids the client from sending anything
+          but ping. The handshake is a hard gate; nothing else moves until
+          it&apos;s done.
+        </P>
+      </div>
+
+      <HandshakeWalkthrough />
+
+      <div>
+        <P>
+          What the handshake gives both sides is a kind of contract pinning.
+          Neither side can be surprised later by a feature the other never
+          declared. If the client doesn&apos;t advertise{" "}
+          <Code>sampling</Code>, the server simply must not call it; the
+          server&apos;s SDK won&apos;t even expose the method. If the server
+          doesn&apos;t advertise <Code>tools</Code>, the client won&apos;t
+          call <Code>tools/list</Code>. The intersection is the working set,
+          and it&apos;s known up front. Capability mismatches are a startup
+          error, not a runtime mystery.
+        </P>
+        <P>
+          That is the whole protocol, structurally.{" "}
+          <HL>
+            The handshake is the protocol; everything after is JSON-RPC riding
+            the negotiated session.
+          </HL>{" "}
+          <Code>tools/list</Code>, <Code>tools/call</Code>,{" "}
+          <Code>resources/read</Code>, <Code>sampling/createMessage</Code>,{" "}
+          <Code>elicitation/create</Code> — every later method is just a
+          JSON-RPC envelope shaped to the contract. The next two sections walk
+          those primitives one by one.
+        </P>
+        <Aside>
+          Version mismatch isn&apos;t fatal. If the client requests a version
+          the server can&apos;t serve, the server replies with JSON-RPC error{" "}
+          <Code>-32602</Code> and a <Code>data.supported</Code> array listing
+          versions it does serve. The client picks one and re-handshakes.
+          That&apos;s the same pattern LSP uses, and the same one HTTP{" "}
+          <Code>Upgrade</Code> uses for WebSocket, and the same one TLS uses
+          for cipher selection. Long-lived protocols all eventually need to
+          re-negotiate.
+        </Aside>
+      </div>
+
+      {/* §4 — server primitives */}
+      <div>
+        <Dots />
+        <H2>What servers expose: tools, resources, prompts</H2>
+        <P>
+          A server offers three kinds of things. They&apos;re all just JSON-RPC
+          methods underneath, and they all ride the same negotiated session,
+          but the protocol gives them three different names because{" "}
+          <em>who pulls the trigger</em> is different in each case. That&apos;s
+          the unifier. One axis, three points on it.
+        </P>
+        <P>
+          <Term>Tools</Term> are <strong>model-controlled</strong>. The model,
+          mid-turn, decides to call <Code>read_file</Code> or{" "}
+          <Code>create_pull_request</Code>; the host routes the call through
+          the client to the server, gets the result, and feeds it back into
+          the model&apos;s next turn. The schema for inputs is plain JSON
+          Schema — same shape OpenAI&apos;s function-calling API uses, same
+          shape Anthropic&apos;s tool-use API uses. As of{" "}
+          <Code>2025-06-18</Code>, tools can also declare an{" "}
+          <Code>outputSchema</Code> and return <Code>structuredContent</Code>{" "}
+          alongside the free-form <Code>content</Code> array, which lets the
+          model parse results without prompt-engineering its way out of
+          ambiguity.
+        </P>
+        <P>
+          Tool descriptions are arbitrary text. The model reads them. The
+          spec is explicit on this point: <strong>annotations like{" "}
+          <Code>readOnlyHint</Code>, <Code>destructiveHint</Code>, or{" "}
+          <Code>idempotentHint</Code> are advisory hints that hosts MUST treat
+          as untrusted unless the server itself is trusted</strong>. A tool
+          that says &ldquo;I&apos;m read-only&rdquo; in its annotations is a
+          self-report; it isn&apos;t the protocol&apos;s job to verify it.
+          That sentence will matter a lot in §7.
+        </P>
+        <P>
+          <Term>Resources</Term> are <strong>app-controlled</strong>. Where a
+          tool is something the model decides to invoke, a resource is
+          something the host decides to inject — a file, a snippet, a piece
+          of structured context, identified by a URI. The host might surface
+          a resource in a UI affordance (&ldquo;attach this file to the
+          chat&rdquo;), or pull resources in automatically based on the
+          user&apos;s open workspace. URIs follow{" "}
+          <A href="https://datatracker.ietf.org/doc/html/rfc6570">
+            RFC 6570
+          </A>{" "}
+          templates: <Code>file:///{`{path}`}</Code>,{" "}
+          <Code>git://{`{repo}`}/{`{ref}`}/{`{path}`}</Code>, whatever the
+          server defines. <Code>resources/subscribe</Code> opts into a push
+          notification when the resource changes — useful for IDE-shaped
+          servers where the file you read three minutes ago is now stale.
+        </P>
+        <P>
+          <Term>Prompts</Term> are <strong>user-controlled</strong>. They&apos;re
+          templated chat-completion seeds the user invokes deliberately,
+          usually surfaced as slash-commands in the host UI. A{" "}
+          <Code>code_review</Code> prompt with a <Code>language</Code>{" "}
+          argument; an <Code>incident_postmortem</Code> prompt with a{" "}
+          <Code>severity</Code> argument. <Code>prompts/get</Code> returns a{" "}
+          <Code>messages[]</Code> array that becomes the opening of a fresh
+          turn. These are the safest of the three by construction: nothing
+          fires unless the user typed the slash.
+        </P>
+        <P>
+          Three primitives, one axis. <em>Tools, the model triggers.
+          Resources, the host triggers. Prompts, the user triggers.</em>{" "}
+          Every server-side capability you&apos;ll ever read about in the MCP
+          ecosystem is one of these three, distinguished by who pulls the
+          trigger. The widget below puts them on a single canvas with three
+          more we haven&apos;t met yet — the ones the <em>client</em> exposes,
+          and the reason this protocol is interesting.
+        </P>
+      </div>
+
+      {/* §5 — client primitives, sampling deep */}
+      <div>
+        <Dots />
+        <H2>What clients expose to servers: sampling, roots, elicitation</H2>
+        <P>
+          Here is the part that surprises people. Three of MCP&apos;s six
+          primitives don&apos;t go from client to server at all. They go the
+          other way. The client exposes them; the server invokes them. And
+          one of the three is genuinely radical:{" "}
+          <HL>
+            servers can be agentic without ever owning a model.
+          </HL>
+        </P>
+      </div>
+
+      <SixPrimitives />
+
+      <div>
+        <P>
+          Tap the <em>sampling</em> chip; that&apos;s where the protocol
+          earns its &ldquo;ahead of its time&rdquo; reputation. The other two
+          — roots and elicitation — are sharper-than-they-look but not
+          surprising once you see them.
+        </P>
+        <H2 id="sampling">Sampling, in depth</H2>
+        <P>
+          <Term>Sampling</Term> lets the server ask the host&apos;s model for
+          a completion. Method:{" "}
+          <Code>sampling/createMessage</Code>. Direction: server → client.
+          The server sends a <Code>messages[]</Code> array, an optional{" "}
+          <Code>systemPrompt</Code>, optional <Code>modelPreferences</Code>{" "}
+          (hints — name, intelligence priority, speed priority, cost
+          priority), an optional{" "}
+          <Code>includeContext</Code> flag (<Code>none</Code>,{" "}
+          <Code>thisServer</Code>, or <Code>allServers</Code>), and a{" "}
+          <Code>maxTokens</Code> ceiling. The client routes the request to
+          whichever model the user picked, gets a response back, and returns
+          it to the server.
+        </P>
+        <P>
+          The radical move is who pays. The server doesn&apos;t need an
+          OpenAI key, an Anthropic key, a Google key. It doesn&apos;t need
+          a billing relationship with a model provider at all. The user&apos;s
+          host already has one — the user is signed in to Claude Desktop,
+          they pay Anthropic for tokens, the host charges <em>them</em>. The
+          server gets an inference for free, on the user&apos;s dime, against
+          the user&apos;s chosen model. That&apos;s a different shape than
+          most agent frameworks, and it lets a server&apos;s author build
+          something genuinely intelligent — multi-step orchestration,
+          summarisation, classification, planning — without standing up any
+          inference infrastructure of their own.
+        </P>
+        <P>
+          Now the careful part: a model invocation that can be triggered by
+          a server is, in the worst case, an attack vector. The server&apos;s
+          messages could contain anything. Anything could come back. So
+          sampling is wrapped in two human-in-the-loop gates the spec
+          recommends and every reasonable host implements:
+        </P>
+        <P>
+          <strong>HITL #1 — before send.</strong> When the server&apos;s{" "}
+          <Code>sampling/createMessage</Code> arrives, the client doesn&apos;t
+          forward it to the model immediately. It surfaces the request to the
+          user — the messages, the system prompt, the requested model
+          preferences — and lets the user approve, edit, or reject. The
+          edit case is non-trivial: the user can rewrite a server&apos;s
+          prompt before it hits their model. In practice most hosts make this
+          a one-click approve, but the option to edit is the protocol&apos;s
+          escape hatch against a malicious or buggy server.
+        </P>
+        <P>
+          <strong>HITL #2 — before return.</strong> The model produces a
+          response. Before that response leaves the client, the host shows
+          it to the user. Approve, edit, or reject — same three options.
+          That&apos;s the second gate: a server can&apos;t exfiltrate the
+          model&apos;s output by simply asking the model nicely, because the
+          user sees what comes back before the server does.
+        </P>
+        <P>
+          Two gates, both labelled SHOULD in the spec rather than MUST, but
+          all three of the major hosts that have shipped sampling treat them
+          as MUST in practice. The protocol document is careful here: it
+          describes the boundary the host should enforce, but acknowledges
+          the host is the one doing the enforcing. Typical MCP rhythm.
+        </P>
+        <P>
+          One subtle thing about <Code>modelPreferences</Code>: they are{" "}
+          <em>hints</em>, not contracts. A server can express &ldquo;I&apos;d
+          like a fast, cheap model — Haiku-class is fine&rdquo; via{" "}
+          <Code>speedPriority: 0.8, costPriority: 0.7</Code>. The host might
+          honour that, or it might route to Sonnet, or to a local
+          llama.cpp build, or to whatever the user has configured as the
+          default. The server gets back a <Code>model</Code> field telling it
+          what was actually used, and a <Code>stopReason</Code>, and the
+          <Code>content</Code> the model produced. Programming against
+          sampling means programming for graceful degradation — your
+          summariser shouldn&apos;t assume frontier-model quality just
+          because you asked nicely.
+        </P>
+        <P>
+          And there is one subtle thing about <Code>includeContext</Code>:
+          it&apos;s a request, not a guarantee. <Code>none</Code> means the
+          server&apos;s messages are the entire prompt — no user
+          conversation history bleeds in. <Code>thisServer</Code> says the
+          host may choose to attach context the user has already shared with
+          this particular server. <Code>allServers</Code> reaches across the
+          installed MCP graph. Hosts will, almost without exception, keep
+          this gated: the default is <Code>none</Code>, escalation requires
+          explicit user consent, and the user sees what context attached
+          alongside the HITL #1 review.
+        </P>
+        <P>
+          The honest hardship: sampling is underadopted. Claude Desktop ships
+          it. A few open-source clients ship it. Most of the big general-
+          purpose hosts that talk to MCP — including, as of late 2025, the
+          ones from the largest model providers — gate sampling behind opt-in
+          flags, ship partial implementations, or skip it altogether. The
+          protocol exists; the ecosystem has not caught up. If you&apos;re
+          building a server today and you want it to work for the broadest
+          audience, you treat sampling as a nice-to-have augmentation, not a
+          load-bearing feature. That&apos;s an honest place for the protocol
+          to be — radical idea, gradual ecosystem.
+        </P>
+        <Aside>
+          The economics of sampling are doing something quietly novel. Today
+          most agent stacks bundle inference and orchestration into the same
+          service, paid for by the same vendor. With sampling, an MCP server
+          can ship as &ldquo;just orchestration logic plus data access,&rdquo;
+          and the host pays for the model. That uncouples the agent layer
+          from the inference layer in a way nothing else has. Whether the
+          ecosystem leans into it or not is a question for 2026 and beyond.
+        </Aside>
+        <H2 id="roots">Roots</H2>
+        <P>
+          <Term>Roots</Term> are the filesystem boundary the client tells the
+          server it&apos;s allowed to operate inside. <Code>roots/list</Code>{" "}
+          goes server → client; the response is an array of <Code>file://</Code>{" "}
+          URIs naming the workspace directories the user has authorised. When
+          the user opens a new workspace or closes one, the client fires{" "}
+          <Code>notifications/roots/list_changed</Code> as a sub-flag-gated
+          notification, and the server is expected to refresh its sense of
+          scope.
+        </P>
+        <P>
+          The shape is IDE-shaped. An editor with three open workspaces
+          declares three roots. A filesystem MCP server reads files inside
+          those roots and refuses anything outside. Any server that ignores
+          roots — that walks up <Code>../..</Code> looking for{" "}
+          <Code>~/.ssh/id_rsa</Code> — is a host-side bug pretending to be a
+          server feature. We&apos;ll see what happens when a host fails to
+          enforce roots in §7.
+        </P>
+        <H2 id="elicitation">Elicitation</H2>
+        <P>
+          <Term>Elicitation</Term> is the newest of the six primitives, added
+          in <Code>2025-06-18</Code>. It lets the server, mid-tool-call, ask
+          the user a follow-up question. <Code>elicitation/create</Code>{" "}
+          carries a <Code>message</Code> string and a{" "}
+          <Code>requestedSchema</Code> — a JSON Schema (restricted to
+          primitive types: string, number, boolean, plus enums) describing
+          the shape of the expected reply. The client renders the schema as
+          a form, the user fills it, the client returns the reply.
+        </P>
+        <P>
+          What this lets servers do: stop hard-coding every choice into the
+          tool input schema. A calendar tool can have a generic{" "}
+          <Code>create_event</Code> tool and ask &ldquo;which calendar?&rdquo;
+          when it&apos;s actually needed, instead of forcing the model to
+          guess from a static enum. A deploy tool can ask &ldquo;production
+          or staging?&rdquo; only when the model didn&apos;t specify. It&apos;s
+          the protocol getting more conversational — and the schema
+          restriction (primitive types only) is on purpose: the client must
+          be able to render the form without an HTML engine.
+        </P>
+      </div>
+
+      {/* §6 — transports */}
+      <div>
+        <Dots />
+        <H2>Two transports: stdio and Streamable HTTP</H2>
+        <P>
+          The same JSON-RPC dance ships over two wire formats. They&apos;re
+          the same protocol — same handshake, same primitives, same error
+          codes. What changes is who lives where.
+        </P>
+        <P>
+          Over <strong>stdio</strong>, the host launches the server as a
+          subprocess and wires their stdio together. Stdin is{" "}
+          client → server; stdout is server → client; stderr is the
+          server&apos;s free-form log channel. Each JSON-RPC message is one
+          line. The big stdio rule —{" "}
+          <strong>messages MUST NOT contain embedded newlines, and the
+          server MUST NOT write non-MCP bytes to stdout</strong> — exists
+          because the framing <em>is</em> &ldquo;split on{" "}
+          <Code>\n</Code>.&rdquo; A stray <Code>console.log</Code> printing
+          to stdout will corrupt the next message. Server logs go to stderr
+          for exactly this reason. Shutdown is by closing the subprocess&apos;s
+          stdin and waiting; <Code>SIGTERM</Code> after a timeout, then{" "}
+          <Code>SIGKILL</Code> if needed.
+        </P>
+        <P>
+          Over <strong>Streamable HTTP</strong>, the server is a standalone
+          web service the host connects to. Single endpoint —{" "}
+          <Code>POST /mcp</Code> for client → server,{" "}
+          <Code>GET /mcp</Code> with{" "}
+          <Code>Accept: text/event-stream</Code> for server → client push.
+          POSTs can return either a single JSON response (for cheap calls) or
+          an SSE stream (for streaming responses or to deliver multiple
+          notifications at once). The server assigns an{" "}
+          <Term>Mcp-Session-Id</Term> on the initialize response; the client
+          echoes it on every subsequent request. Lose the session id and the
+          server returns 404. Reconnects use SSE event ids plus{" "}
+          <Code>Last-Event-ID</Code> to replay any messages the client
+          missed during disconnect — <em>resumability</em>, in spec
+          parlance, and the reason the protocol survives flaky networks.
+        </P>
+      </div>
+
+      <TransportToggle
+        panes={{
+          stdio: {
+            node: (
+              <CodeBlock
+                lang="bash"
+                filename="stdio · subprocess pipe"
+                code={TRANSPORT_STDIO_SNIPPET}
+              />
+            ),
+          },
+          http: {
+            node: (
+              <CodeBlock
+                lang="http"
+                filename="Streamable HTTP · session-tracked"
+                code={TRANSPORT_HTTP_SNIPPET}
+              />
+            ),
+          },
+        }}
+      />
+
+      <div>
+        <P>
+          Streamable HTTP also requires an{" "}
+          <Code>MCP-Protocol-Version</Code> header on every post-init
+          request (added in <Code>2025-06-18</Code>) so a load-balanced server
+          can route to the correct version handler without re-running the
+          handshake. And there are two security-critical client-side rules
+          when you bind a local Streamable-HTTP server: validate the{" "}
+          <Code>Origin</Code> header against an allowlist (DNS-rebinding
+          mitigation — without this, a malicious web page could ask{" "}
+          <Code>localhost:3000</Code> for a tool call), and bind to{" "}
+          <Code>127.0.0.1</Code> rather than <Code>0.0.0.0</Code> so the
+          server isn&apos;t discoverable from the rest of the network.
+        </P>
+        <P>
+          The honest comparison is short. Stdio is zero infrastructure, dies
+          with the host process, runs one client per server, and is wonderful
+          for local capabilities — your filesystem, your git, your SQLite
+          file. Streamable HTTP is shareable across clients, survives
+          reconnects, can be load-balanced, and is the future for hosted
+          servers. It needs auth, it needs origin checks, it needs session
+          management. Most reference servers ship both transports; you pick
+          based on whether the server needs to live in your editor or in the
+          cloud.
+        </P>
+        <Aside>
+          The 2024-11-05 revision of the spec carried a different transport
+          called HTTP+SSE — two endpoints, one for POST and one for the SSE
+          stream, with explicit endpoint discovery. It worked, but it was
+          fragile. Streamable HTTP collapsed both endpoints into one and
+          added the session id and event-id replay machinery, and the older
+          transport was deprecated in <Code>2025-03-26</Code>. If you read
+          older MCP guides, the &ldquo;HTTP+SSE&rdquo; phrase you&apos;ll see
+          is this older shape; modern servers don&apos;t implement it.
+        </Aside>
+      </div>
+
+      {/* §7 — security */}
+      <div>
+        <Dots />
+        <H2>The boundary is the security model</H2>
+        <P>
+          Now we cash in §2&apos;s promise. A year of MCP shipping in
+          production has produced a steady drip of security incidents — tool
+          poisoning, rug-pulls, credential exfiltration, public data leaks.
+          Every time, the same thing is true:{" "}
+          <HL>
+            every published attack on MCP is a host-side trust-boundary
+            failure, not a protocol flaw.
+          </HL>
+        </P>
+        <P>
+          The protocol exposes the boundary; it does not enforce it. The
+          host&apos;s job is to enforce it. Every published incident is a
+          host that didn&apos;t. Three families:
+        </P>
+        <P>
+          <strong>
+            Tool poisoning (Invariant Labs, April 2025).
+          </strong>{" "}
+          A malicious server hides instructions in the tool{" "}
+          <Code>description</Code> or in the advisory annotations the spec
+          warns are untrusted. The model reads the description in full when
+          deciding whether to call the tool; the user, in most host UIs, sees
+          only the tool name and a short summary. The hidden instruction is
+          legible to the model, invisible to the user. The model follows it.
+          That is a host-side disclosure failure: the host showed the user a
+          truncated view of something the model was being asked to trust.
+        </P>
+        <P>
+          <strong>Rug-pulls.</strong> A server changes its tool description
+          after the user installed it. The user originally approved&nbsp;
+          <em>tool X with description X</em>; the model now sees{" "}
+          <em>tool X with description Y</em>. Some hosts surface the diff;
+          most don&apos;t. The protocol&apos;s <Code>listChanged</Code>{" "}
+          notification gives the host the trigger it needs to surface a
+          change — the host has to actually use it.
+        </P>
+        <P>
+          <strong>
+            Cursor <Code>mcp.json</Code> exfiltration (Check Point, 2025).
+          </strong>{" "}
+          A poisoned filesystem MCP server tricks the host into reading{" "}
+          <Code>~/.cursor/mcp.json</Code> — which contains every other
+          server&apos;s credentials — plus <Code>~/.ssh/</Code>. The user&apos;s
+          declared roots didn&apos;t include either path. The server asked
+          anyway. The host, configured permissively, complied. That is a
+          roots-violation, full stop: the host let one server reach for
+          files outside its declared scope.
+        </P>
+        <Callout tone="warn">
+          The pattern across all three is what Simon Willison called the{" "}
+          <Term>lethal trifecta</Term> in his July 2025 essay on the
+          Supabase / Cursor incident: <em>privileged data, untrusted input,
+          external communication.</em> A privileged service-role token
+          processed an untrusted issue body that contained SQL injection
+          instructions; the agent used the token to read sensitive rows and
+          then wrote them to a public thread. None of those three legs is a
+          protocol flaw. Each is an architectural choice the host made.{" "}
+          <strong>The host&apos;s job is to break at least one leg of that
+          triangle.</strong> Read his original essay at{" "}
+          <A href="https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/">
+            simonwillison.net
+          </A>{" "}
+          if you haven&apos;t — it&apos;s the rubric the entire ecosystem
+          should be using.
+        </Callout>
+        <P>
+          What does &ldquo;break at least one leg&rdquo; look like in
+          practice? On <em>privileged data</em>: scope tokens to the minimum
+          needed; never give an agent a service-role token when a row-level
+          read-only token will do. On <em>untrusted input</em>: treat
+          everything from a server — descriptions, annotations, resource
+          contents, sampling responses — as data, never as instructions; if
+          the agent reads a comment from an untrusted source, it must not
+          act on instructions inside it without explicit user consent. On{" "}
+          <em>external communication</em>: gate the side-effect actions —
+          posting, emailing, opening pull requests — behind a confirmation
+          step the user has to physically click. Any one of those three,
+          enforced rigorously, breaks the chain.
+        </P>
+        <P>
+          MCP didn&apos;t invent any of these problems. They&apos;re the
+          same pattern every privileged-agent system has had to learn the
+          hard way, since long before LLMs. What MCP did was make the
+          boundary <em>visible</em> — three roles, one negotiated session,
+          one enforcement seam. That visibility is also why every MCP
+          incident reads as predictable in retrospect: you can see exactly
+          which leg of the trifecta the host failed to break.
+        </P>
+      </div>
+
+      {/* §8 — closer */}
+      <div>
+        <Dots />
+        <H2>One handshake, six primitives, one boundary</H2>
+        <P>
+          Scroll back up to the opener. The four options aren&apos;t a
+          riddle anymore — option 2 was the entire shape of the protocol,
+          compressed into one message. The server replies with capabilities;
+          the client confirms; everything else rides what they agreed.
+        </P>
+        <P>
+          <em>Tools, resources, prompts, sampling, roots, elicitation —
+          six names for messages riding one negotiated session.</em> Two
+          transports for the wire, one boundary the host enforces, one
+          handshake to start every conversation. That is the whole protocol
+          — and once you can see it, the ecosystem stops looking like magic
+          and starts looking like, well, a protocol.
+        </P>
+        <p
+          className="mt-[var(--spacing-md)] font-serif"
+          style={{
+            fontStyle: "italic",
+            fontSize: "var(--text-medium)",
+            textAlign: "center",
+            color: "var(--color-text)",
+            maxWidth: "44ch",
+            marginInline: "auto",
+            lineHeight: 1.45,
+          }}
+        >
+          The model didn&apos;t get smarter. The conversation did.
+        </p>
+        <p
+          aria-hidden
+          className="font-mono text-center select-none"
+          style={{
+            marginBlock: "var(--spacing-xl)",
+            color: "var(--color-accent)",
+            opacity: 0.8,
+            fontSize: "var(--text-body)",
+            letterSpacing: "0.2em",
+          }}
+        >
+          ·
+        </p>
+      </div>
+      <PostNavCards slug="mcps-explained" />
+    </Prose>
+  );
+}

--- a/app/posts/mcps-explained/widgets/HandshakeWalkthrough.tsx
+++ b/app/posts/mcps-explained/widgets/HandshakeWalkthrough.tsx
@@ -86,7 +86,7 @@ type Step = {
 
 const STEPS: Step[] = [
   {
-    label: "idle",
+    label: "pipe open",
     clientActive: [],
     serverActive: [],
     clientChip: "ready",

--- a/app/posts/mcps-explained/widgets/HandshakeWalkthrough.tsx
+++ b/app/posts/mcps-explained/widgets/HandshakeWalkthrough.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { memo, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * §3 widget — scripted stepper through the three messages of every MCP
+ * session. Two stylised JSON panes (client | server). Each step illuminates
+ * one line range in the active pane and surfaces a chip annotation on the
+ * relevant side. The frame stays the same size step-to-step (R6); the line
+ * highlight is an absolutely-positioned overlay.
+ *
+ * One verb: step (via WidgetNav).
+ *
+ * The JSON shown here is a stylised summary, not bytes-on-wire. The full
+ * envelopes live in `snippets.ts` and ship through page.tsx (Shiki). This
+ * widget's job is to visualise the dance, not to render the bytes.
+ * --------------------------------------------------------------------------*/
+
+const CLIENT_LINES = [
+  `// Client → Server`,
+  `{`,
+  `  "method": "initialize",`,
+  `  "params": {`,
+  `    "protocolVersion": "2025-06-18",`,
+  `    "capabilities": {`,
+  `      "roots": { "listChanged": true },`,
+  `      "sampling": {},`,
+  `      "elicitation": {}`,
+  `    },`,
+  `    "clientInfo": { "name": "Cli", "version": "1.0.0" }`,
+  `  }`,
+  `}`,
+  ``,
+  `// Client → Server (notification)`,
+  `{`,
+  `  "method": "notifications/initialized"`,
+  `}`,
+];
+
+const SERVER_LINES = [
+  `// Server → Client (response)`,
+  `{`,
+  `  "id": 1,`,
+  `  "result": {`,
+  `    "protocolVersion": "2025-06-18",`,
+  `    "capabilities": {`,
+  `      "tools": { "listChanged": true },`,
+  `      "resources": { "subscribe": true },`,
+  `      "prompts": {}`,
+  `    },`,
+  `    "serverInfo": { "name": "fs", "version": "0.4.2" },`,
+  `    "instructions": "Files exposed under roots."`,
+  `  }`,
+  `}`,
+];
+
+type Step = {
+  label: string;
+  clientActive: number[];
+  serverActive: number[];
+  clientChip: string | null;
+  serverChip: string | null;
+  caption: React.ReactNode;
+};
+
+const STEPS: Step[] = [
+  {
+    label: "idle",
+    clientActive: [],
+    serverActive: [],
+    clientChip: "ready",
+    serverChip: "ready",
+    caption: (
+      <>
+        <CaptionCue>Both sides are silent.</CaptionCue> The client just opened a
+        pipe to the server. Until the handshake completes, neither may send
+        anything but ping or logging.
+      </>
+    ),
+  },
+  {
+    label: "init · req",
+    clientActive: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    serverActive: [],
+    clientChip: "→ initialize",
+    serverChip: "reading",
+    caption: (
+      <>
+        <CaptionCue>Step 1 — the request.</CaptionCue> The client declares its
+        protocol version and the capabilities it supports. Note that{" "}
+        <code className="font-mono">tools</code> is{" "}
+        <em>absent</em>: clients don&apos;t expose tools, only servers do. The
+        client is offering <code className="font-mono">roots</code>,{" "}
+        <code className="font-mono">sampling</code>, and{" "}
+        <code className="font-mono">elicitation</code>.
+      </>
+    ),
+  },
+  {
+    label: "init · res",
+    clientActive: [],
+    serverActive: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+    clientChip: "reading",
+    serverChip: "← capabilities",
+    caption: (
+      <>
+        <CaptionCue>Step 2 — the contract.</CaptionCue> The server replies with
+        what <em>it</em> supports — three primitives in this case:{" "}
+        <code className="font-mono">tools</code>,{" "}
+        <code className="font-mono">resources</code>, and{" "}
+        <code className="font-mono">prompts</code>. The session is now pinned to
+        the intersection. No surprises later.
+      </>
+    ),
+  },
+  {
+    label: "ready",
+    clientActive: [14, 15, 16, 17],
+    serverActive: [],
+    clientChip: "→ initialized",
+    serverChip: "open",
+    caption: (
+      <>
+        <CaptionCue>Step 3 — the green light.</CaptionCue> The client confirms
+        with a one-way <code className="font-mono">notifications/initialized</code>
+        . No <code className="font-mono">id</code>, no response expected. From
+        this point on, every <code className="font-mono">tools/list</code>,{" "}
+        <code className="font-mono">tools/call</code>,{" "}
+        <code className="font-mono">resources/read</code>, and{" "}
+        <code className="font-mono">sampling/createMessage</code> is just
+        JSON-RPC riding the same connection.
+      </>
+    ),
+  },
+];
+
+function CodePane({
+  title,
+  lines,
+  active,
+  chip,
+}: {
+  title: string;
+  lines: string[];
+  active: number[];
+  chip: string | null;
+}) {
+  const LINE_H = 18;
+  const PADDING = 10;
+  const reservedLines = Math.max(CLIENT_LINES.length, SERVER_LINES.length);
+  const minH = reservedLines * LINE_H + PADDING * 2;
+  const isProto = chip ? /initialize|capabilities|initialized/i.test(chip) : false;
+  return (
+    <div className="flex flex-col gap-[var(--spacing-2xs)]">
+      <div
+        className="flex items-center justify-between"
+        style={{
+          fontSize: "var(--text-ui)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        <span className="font-sans">{title}</span>
+        <AnimatePresence mode="wait" initial={false}>
+          {chip ? (
+            <motion.span
+              key={chip}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={SPRING.snappy}
+              className="font-mono"
+              style={{
+                fontSize: 11,
+                padding: "2px 8px",
+                borderRadius: 3,
+                background: isProto ? "var(--color-accent)" : "transparent",
+                color: isProto
+                  ? "var(--color-bg)"
+                  : "var(--color-text-muted)",
+                border: isProto ? "none" : "1px solid var(--color-rule)",
+              }}
+            >
+              {chip}
+            </motion.span>
+          ) : (
+            <span style={{ visibility: "hidden", fontSize: 11 }}>·</span>
+          )}
+        </AnimatePresence>
+      </div>
+      <div
+        className="relative font-mono"
+        style={{
+          background:
+            "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          padding: PADDING,
+          borderRadius: "var(--radius-sm)",
+          minHeight: minH,
+          fontSize: 11,
+          lineHeight: `${LINE_H}px`,
+          color: "var(--color-text)",
+          overflowX: "auto",
+        }}
+      >
+        {lines.map((line, i) => {
+          const isActive = active.includes(i);
+          return (
+            <div key={i} style={{ position: "relative", paddingLeft: 4 }}>
+              {isActive ? (
+                <motion.span
+                  initial={false}
+                  animate={{ opacity: 1 }}
+                  transition={SPRING.snappy}
+                  style={{
+                    position: "absolute",
+                    inset: `0 -6px 0 -6px`,
+                    background:
+                      "color-mix(in oklab, var(--color-accent) 18%, transparent)",
+                    borderRadius: 2,
+                    pointerEvents: "none",
+                  }}
+                />
+              ) : null}
+              <span
+                style={{
+                  position: "relative",
+                  color: isActive
+                    ? "var(--color-text)"
+                    : "var(--color-text-muted)",
+                  whiteSpace: "pre",
+                }}
+              >
+                {line || " "}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const MemoCodePane = memo(CodePane);
+
+/**
+ * HandshakeWalkthrough (§3) — the three-message dance, walked tick-by-tick.
+ *
+ * One verb: step (via WidgetNav).
+ *
+ * Frame stability (R6): both panes have a fixed `min-height` set to the
+ * longest variant. Line highlight is an absolutely-positioned overlay;
+ * nothing reflows.
+ *
+ * Mobile-first: panes stack on narrow containers; flip side-by-side at the
+ * `widget` container query 600 px breakpoint. Audio: WidgetNav already
+ * fires `Progress-Tick` per step (Tier-1, audio playbook).
+ */
+export function HandshakeWalkthrough() {
+  const [step, setStep] = useState(0);
+  const tick = STEPS[step];
+
+  return (
+    <WidgetShell
+      title="initialize · capabilities · initialized"
+      measurements={`${step} / 3`}
+      caption={tick.caption}
+      captionTone="prominent"
+      controls={
+        <div className="flex items-center justify-center w-full">
+          <WidgetNav
+            value={step}
+            total={STEPS.length}
+            onChange={setStep}
+            counterNoun="step"
+          />
+        </div>
+      }
+    >
+      <div
+        className="grid gap-[var(--spacing-md)]"
+        style={{ gridTemplateColumns: "minmax(0, 1fr)" }}
+      >
+        <div className="bs-handshake-grid">
+          <MemoCodePane
+            title="client"
+            lines={CLIENT_LINES}
+            active={tick.clientActive}
+            chip={tick.clientChip}
+          />
+          <MemoCodePane
+            title="server"
+            lines={SERVER_LINES}
+            active={tick.serverActive}
+            chip={tick.serverChip}
+          />
+        </div>
+        <style>{`
+          .bs-handshake-grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-md);
+          }
+          @container widget (min-width: 600px) {
+            .bs-handshake-grid {
+              grid-template-columns: 1fr 1fr;
+            }
+          }
+        `}</style>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/mcps-explained/widgets/PredictTheHandshake.tsx
+++ b/app/posts/mcps-explained/widgets/PredictTheHandshake.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { TextHighlighter } from "@/components/fancy";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { Quiz } from "@/components/widgets/Quiz";
+import { playSound } from "@/lib/audio";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+/* ---------------------------------------------------------------------------
+ * §0 premise-quiz opener. Reader sees a canonical `initialize` JSON-RPC
+ * envelope and is asked: what comes back next? Four options, only one right.
+ * Most readers reach for option 1 ("a tool list") because they think of MCP
+ * as a manifest dump. The protocol is actually a negotiation: capabilities
+ * come back, then the client confirms with a one-way `notifications/
+ * initialized`. The wrong-answer demand fuels the rest of the post.
+ *
+ * Per the post-author contract: leans on the shared <Quiz> wrapper for
+ * shuffle / focus / pulse / verdict; this file owns the surrounding shell
+ * and the answered-state mirror so the shell's caption + measurements
+ * track the same lifecycle.
+ *
+ * Frame stability (R6): code pane has its own min-height via <CodeBlock>;
+ * <Quiz>'s verdict slot reserves space before the answer is given.
+ * --------------------------------------------------------------------------*/
+
+const CORRECT_ID = "negotiate";
+
+const OPTIONS = [
+  // Common wrong: treats MCP as a REST manifest.
+  {
+    id: "tool-list",
+    label: "A list of available tools, resources, and prompts.",
+  },
+  // Correct.
+  {
+    id: "negotiate",
+    label:
+      "A capability response, then a one-way notifications/initialized from the client.",
+  },
+  // Treats MCP as a chat API.
+  { id: "first-prompt", label: "The server's first system prompt for the model." },
+  // Treats MCP as agent runtime.
+  {
+    id: "model-stream",
+    label: "An SSE stream of model tokens for the user's request.",
+  },
+];
+
+type Props = {
+  /** Pre-rendered Shiki block for the opener snippet (see page.tsx). */
+  codeSlot: React.ReactNode;
+};
+
+export function PredictTheHandshake({ codeSlot }: Props) {
+  const [answered, setAnswered] = useState<null | { correct: boolean }>(null);
+  const swooshFiredRef = useRef(false);
+
+  return (
+    <WidgetShell
+      title="predict the handshake"
+      measurements={
+        answered === null
+          ? "1 message in · ? back"
+          : answered.correct
+            ? "got it"
+            : "most miss this"
+      }
+      caption={
+        answered === null ? (
+          <>
+            <CaptionCue>What comes back next?</CaptionCue> The client just
+            opened a session. Most readers expect a tool list — and most are
+            wrong. The gap between the intuitive guess and the real answer is
+            the whole shape of MCP.
+          </>
+        ) : answered.correct ? (
+          <>
+            <CaptionCue>You&apos;ve seen this dance before.</CaptionCue> Now
+            we&apos;ll trace why every MCP server in the world is built on this
+            single negotiation — and what rides it after.
+          </>
+        ) : (
+          <>
+            <CaptionCue>Most readers pick option 1.</CaptionCue> MCP doesn&apos;t
+            dump a manifest — it negotiates a contract first. Keep this snippet
+            in mind; by §3 the right answer will look obvious.
+          </>
+        )
+      }
+      captionTone="prominent"
+    >
+      <div className="flex flex-col gap-[var(--spacing-sm)]">
+        {codeSlot}
+
+        <Quiz
+          question={null}
+          options={OPTIONS}
+          correctId={CORRECT_ID}
+          onAnswered={(correct) => {
+            setAnswered({ correct });
+            if (!swooshFiredRef.current) {
+              swooshFiredRef.current = true;
+              playSound("Swoosh");
+            }
+          }}
+          rightVerdict={
+            <>
+              <span style={{ color: "var(--color-accent)" }}>answer</span>
+              {"  "}
+              <span style={{ color: "var(--color-text)" }}>
+                The server replies with its capabilities; the client confirms
+                with a fire-and-forget <code className="font-mono">notifications/initialized</code>.
+                Tools come later, on demand.
+              </span>
+            </>
+          }
+          wrongVerdict={
+            <>
+              <span style={{ color: "var(--color-accent)" }}>answer</span>
+              {"  "}
+              <span style={{ color: "var(--color-text)" }}>
+                The server replies with its capabilities; the client confirms
+                with a fire-and-forget <code className="font-mono">notifications/initialized</code>.
+                Tools come later, on demand.
+              </span>
+            </>
+          }
+          randomize
+        />
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/mcps-explained/widgets/PredictTheHandshake.tsx
+++ b/app/posts/mcps-explained/widgets/PredictTheHandshake.tsx
@@ -55,10 +55,11 @@ const OPTIONS = [
   },
   // Treats MCP as a chat API.
   { id: "first-prompt", label: "The server's first system prompt for the model." },
-  // Treats MCP as agent runtime.
+  // Plausible-but-wrong: assumes a strict-auth-first protocol shape.
   {
-    id: "model-stream",
-    label: "An SSE stream of model tokens for the user's request.",
+    id: "auth-error",
+    label:
+      "An error response: the request is missing the protocol version's required field.",
   },
 ];
 
@@ -79,7 +80,7 @@ export function PredictTheHandshake({ codeSlot }: Props) {
           ? "1 message in · ? back"
           : answered.correct
             ? "got it"
-            : "most miss this"
+            : "worth re-reading"
       }
       caption={
         answered === null ? (

--- a/app/posts/mcps-explained/widgets/RoleTopology.tsx
+++ b/app/posts/mcps-explained/widgets/RoleTopology.tsx
@@ -32,10 +32,10 @@ type Server = {
 };
 
 const SERVERS: Server[] = [
-  { id: "fs", name: "Filesystem", caps: "tools · resources · roots" },
-  { id: "github", name: "GitHub", caps: "tools · resources" },
-  { id: "notion", name: "Notion", caps: "tools · prompts · sampling" },
-  { id: "slack", name: "Slack", caps: "tools · prompts" },
+  { id: "fs", name: "Filesystem", caps: "file r/w" },
+  { id: "github", name: "GitHub", caps: "git ops" },
+  { id: "notion", name: "Notion", caps: "docs" },
+  { id: "slack", name: "Slack", caps: "messages" },
 ];
 
 const VERDICTS: Record<ServerId, React.ReactNode> = {
@@ -200,14 +200,11 @@ export function RoleTopology() {
             <em>“Summarise yesterday&apos;s commits to the auth repo.”</em>
           </div>
           <div
-            className="mt-[var(--spacing-2xs)] flex flex-wrap gap-[var(--spacing-2xs)] font-mono"
+            className="mt-[var(--spacing-2xs)] font-mono"
             style={{ fontSize: 11, color: "var(--color-text-muted)" }}
             aria-label="four MCP clients, one per server"
           >
-            <span>· client → fs</span>
-            <span>· client → github</span>
-            <span>· client → notion</span>
-            <span>· client → slack</span>
+            4 clients · fs · github · notion · slack
           </div>
         </motion.div>
 

--- a/app/posts/mcps-explained/widgets/RoleTopology.tsx
+++ b/app/posts/mcps-explained/widgets/RoleTopology.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+type ServerId = "fs" | "github" | "notion" | "slack";
+
+type Server = {
+  id: ServerId;
+  name: string;
+  caps: string;
+};
+
+const SERVERS: Server[] = [
+  { id: "fs", name: "Filesystem", caps: "tools · resources · roots" },
+  { id: "github", name: "GitHub", caps: "tools · resources" },
+  { id: "notion", name: "Notion", caps: "tools · prompts · sampling" },
+  { id: "slack", name: "Slack", caps: "tools · prompts" },
+];
+
+const VERDICTS: Record<ServerId, React.ReactNode> = {
+  fs: (
+    <>
+      <CaptionCue>Filesystem can&apos;t see anything else.</CaptionCue> Not the
+      conversation, not GitHub, not Notion, not Slack. Its world is the JSON-RPC
+      pipe and the roots it was given.
+    </>
+  ),
+  github: (
+    <>
+      <CaptionCue>GitHub can&apos;t see Notion.</CaptionCue> Each server runs in
+      its own client envelope — the host is the only piece of software that
+      sees both at once.
+    </>
+  ),
+  notion: (
+    <>
+      <CaptionCue>Notion can request a model completion.</CaptionCue> But via
+      sampling, gated by the host. It never reaches the model directly, and it
+      never sees what you typed before invoking it.
+    </>
+  ),
+  slack: (
+    <>
+      <CaptionCue>Slack can&apos;t see your conversation.</CaptionCue> Each
+      tool call is a fresh JSON-RPC envelope — no scrollback, no hidden
+      context unless the host explicitly attaches it.
+    </>
+  ),
+};
+
+/**
+ * RoleTopology (§2) — host / client / server topology with scan-reveal. The
+ * host card sits on top with the model glyph; four client pipes run inside;
+ * four server cards sit outside. Tap any server: that server highlights, the
+ * conversation pane and the other servers visibly grey out via opacity. The
+ * frame stays the same size; only opacity moves (DESIGN.md §9 — no
+ * width/height animations).
+ *
+ * Mobile-first: the layout is a flex column at narrow widths (host on top,
+ * servers stacked below as a chip strip). At 600 px container width and up,
+ * a CSS grid puts host above and servers in a 4-up row. The outer frame
+ * height is reserved for the largest layout so the page never reflows.
+ *
+ * Audio: `Click` on server-tap (Tier-1 audio cue per audio playbook).
+ *
+ * Accessibility: server cards are buttons inside `role="group"`; the
+ * highlight is conveyed via opacity AND a leading "▸" mark (not colour
+ * alone — DESIGN.md a11y).
+ */
+export function RoleTopology() {
+  const [active, setActive] = useState<ServerId | null>(null);
+
+  const verdict = active ? VERDICTS[active] : null;
+
+  return (
+    <WidgetShell
+      title="three roles · one boundary"
+      measurements={active ? `viewing · ${active}` : "tap a server"}
+      captionTone="prominent"
+      caption={
+        active ? (
+          verdict
+        ) : (
+          <>
+            <CaptionCue>Tap a server</CaptionCue> to see what it can&apos;t see.
+            Each server lives behind its own client; the host is the only piece
+            of software that holds the user&apos;s trust and the model.
+          </>
+        )
+      }
+    >
+      <style>{`
+        .bs-rt-grid {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-md);
+        }
+        .bs-rt-servers {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--spacing-sm);
+        }
+        @container widget (min-width: 600px) {
+          .bs-rt-servers {
+            grid-template-columns: repeat(4, 1fr);
+          }
+        }
+        .bs-rt-server {
+          min-height: 78px;
+          padding: 10px 12px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          color: var(--color-text);
+          text-align: left;
+          cursor: pointer;
+          transition: opacity 220ms, border-color 220ms, background 220ms;
+        }
+        .bs-rt-server:hover:not(:disabled) {
+          border-color: color-mix(in oklab, var(--color-accent) 50%, var(--color-rule));
+        }
+        .bs-rt-server:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-rt-host {
+          min-height: 96px;
+          padding: var(--spacing-sm) var(--spacing-md);
+          border-radius: var(--radius-md);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-accent) 6%, var(--color-surface));
+          transition: opacity 220ms;
+        }
+        .bs-rt-conv {
+          padding: 8px 12px;
+          border-radius: var(--radius-sm);
+          background: var(--color-bg);
+          border: 1px dashed var(--color-rule);
+          color: var(--color-text-muted);
+          font-size: var(--text-small);
+          line-height: 1.4;
+          transition: opacity 220ms;
+        }
+      `}</style>
+
+      <div className="bs-rt-grid">
+        {/* Host card with model + conversation. Dims when a server is active. */}
+        <motion.div
+          className="bs-rt-host"
+          animate={{ opacity: active ? 0.45 : 1 }}
+          transition={SPRING.smooth}
+        >
+          <div
+            className="flex items-baseline justify-between"
+            style={{ fontSize: "var(--text-small)" }}
+          >
+            <span
+              className="font-mono"
+              style={{
+                color: "var(--color-text-muted)",
+                letterSpacing: "0.04em",
+                textTransform: "uppercase",
+              }}
+            >
+              host · Claude Desktop
+            </span>
+            <span
+              className="font-mono"
+              style={{ color: "var(--color-accent)" }}
+              aria-label="model"
+            >
+              ◆ Sonnet 4.5
+            </span>
+          </div>
+          <div
+            className="bs-rt-conv mt-[var(--spacing-2xs)] font-serif"
+            aria-label="user conversation"
+          >
+            <em>“Summarise yesterday&apos;s commits to the auth repo.”</em>
+          </div>
+          <div
+            className="mt-[var(--spacing-2xs)] flex flex-wrap gap-[var(--spacing-2xs)] font-mono"
+            style={{ fontSize: 11, color: "var(--color-text-muted)" }}
+            aria-label="four MCP clients, one per server"
+          >
+            <span>· client → fs</span>
+            <span>· client → github</span>
+            <span>· client → notion</span>
+            <span>· client → slack</span>
+          </div>
+        </motion.div>
+
+        {/* Server row. Each card a button — tap to scan-reveal. */}
+        <div
+          role="group"
+          aria-label="MCP servers"
+          className="bs-rt-servers"
+        >
+          {SERVERS.map((s) => {
+            const isActive = active === s.id;
+            const isDimmed = active !== null && !isActive;
+            return (
+              <motion.button
+                key={s.id}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => {
+                  playSound("Click");
+                  setActive((prev) => (prev === s.id ? null : s.id));
+                }}
+                className="bs-rt-server"
+                animate={{
+                  opacity: isDimmed ? 0.3 : 1,
+                }}
+                transition={SPRING.smooth}
+                style={{
+                  borderColor: isActive
+                    ? "var(--color-accent)"
+                    : "var(--color-rule)",
+                  background: isActive
+                    ? "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                    : undefined,
+                }}
+              >
+                <div
+                  className="flex items-baseline justify-between font-mono"
+                  style={{ fontSize: "var(--text-small)" }}
+                >
+                  <span
+                    style={{
+                      color: isActive
+                        ? "var(--color-accent)"
+                        : "var(--color-text)",
+                      fontWeight: 600,
+                    }}
+                  >
+                    <span aria-hidden style={{ marginRight: 6 }}>
+                      {isActive ? "▸" : "·"}
+                    </span>
+                    {s.name}
+                  </span>
+                </div>
+                <div
+                  className="mt-[var(--spacing-2xs)] font-mono"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {s.caps}
+                </div>
+              </motion.button>
+            );
+          })}
+        </div>
+
+        {/* Isolation envelope — what the active server can't see. Only mounts
+            when a server is active so unanimated state stays minimal. */}
+        <div style={{ minHeight: 56 }}>
+          <AnimatePresence mode="wait" initial={false}>
+            {active ? (
+              <motion.div
+                key={active}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={SPRING.smooth}
+                className="font-mono"
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-text-muted)",
+                  padding: "8px 12px",
+                  borderRadius: "var(--radius-sm)",
+                  border: "1px dashed color-mix(in oklab, var(--color-accent) 50%, var(--color-rule))",
+                  background:
+                    "color-mix(in oklab, var(--color-accent) 4%, transparent)",
+                }}
+              >
+                <span style={{ color: "var(--color-accent)" }}>cannot see</span>
+                {"  "}
+                <span>
+                  · the conversation · the other three servers · the model (except
+                  via sampling, which the host gates)
+                </span>
+              </motion.div>
+            ) : (
+              <span aria-hidden style={{ display: "block", height: 0 }} />
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/mcps-explained/widgets/SixPrimitives.tsx
+++ b/app/posts/mcps-explained/widgets/SixPrimitives.tsx
@@ -425,15 +425,14 @@ export function SixPrimitives() {
                 transition={SPRING.smooth}
                 className="font-sans flex items-center justify-center"
                 style={{
-                  minHeight: 280,
                   color: "var(--color-text-muted)",
                   fontSize: "var(--text-small)",
                   textAlign: "center",
+                  paddingBlock: "var(--spacing-sm)",
                 }}
               >
                 <span>
-                  Pick any of the six. The sampling chip is the longest read —
-                  it&apos;s where the protocol genuinely surprises you.
+                  Pick any chip. The sampling chip is the longest read.
                 </span>
               </motion.div>
             )}

--- a/app/posts/mcps-explained/widgets/SixPrimitives.tsx
+++ b/app/posts/mcps-explained/widgets/SixPrimitives.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+type PrimitiveId =
+  | "tools"
+  | "resources"
+  | "prompts"
+  | "sampling"
+  | "roots"
+  | "elicitation";
+
+type PrimitiveDef = {
+  id: PrimitiveId;
+  name: string;
+  side: "server" | "client";
+  controlled: string;
+  /** Direction of the primary call. */
+  arrow: "client→server" | "server→client";
+  envelope: string;
+  detail: React.ReactNode;
+};
+
+const ARROW_LABEL: Record<PrimitiveDef["arrow"], string> = {
+  "client→server": "client → server",
+  "server→client": "server → client",
+};
+
+const PRIMITIVES: PrimitiveDef[] = [
+  {
+    id: "tools",
+    name: "tools",
+    side: "server",
+    controlled: "model-controlled",
+    arrow: "client→server",
+    envelope: `// tools/call — the model decides to invoke
+{ "method": "tools/call",
+  "params": {
+    "name": "search_files",
+    "arguments": { "pattern": "auth.ts" }
+  } }`,
+    detail: (
+      <>
+        Tools are arbitrary code the server agrees to run on the model&apos;s
+        behalf. Each declares a JSON Schema for its inputs (and, since{" "}
+        <code className="font-mono">2025-06-18</code>, an{" "}
+        <code className="font-mono">outputSchema</code> for{" "}
+        <em>structured</em> tool output). Annotations like{" "}
+        <code className="font-mono">readOnlyHint</code> or{" "}
+        <code className="font-mono">destructiveHint</code> are{" "}
+        <strong>advisory only</strong> — the spec says to treat them as
+        untrusted unless the server itself is trusted.
+      </>
+    ),
+  },
+  {
+    id: "resources",
+    name: "resources",
+    side: "server",
+    controlled: "app-controlled",
+    arrow: "client→server",
+    envelope: `// resources/read — the host decides what to inject
+{ "method": "resources/read",
+  "params": { "uri": "file:///workspace/auth.ts" } }`,
+    detail: (
+      <>
+        Resources are URI-keyed read-only context the host injects into the
+        model&apos;s working set. The model doesn&apos;t request them; the host
+        does (sometimes triggered by the user, sometimes by ambient policy).
+        URIs follow RFC 6570 templates —{" "}
+        <code className="font-mono">file:///&#123;path&#125;</code>,{" "}
+        <code className="font-mono">git://&#123;repo&#125;/&#123;ref&#125;</code>, whatever the server
+        defines. Subscriptions push{" "}
+        <code className="font-mono">notifications/resources/updated</code> when
+        the resource changes.
+      </>
+    ),
+  },
+  {
+    id: "prompts",
+    name: "prompts",
+    side: "server",
+    controlled: "user-controlled",
+    arrow: "client→server",
+    envelope: `// prompts/get — the user picks a slash-command
+{ "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": { "lang": "typescript" }
+  } }`,
+    detail: (
+      <>
+        Prompts are templated chat seeds the user invokes deliberately —
+        usually surfaced as slash-commands in the host UI. The server returns a{" "}
+        <code className="font-mono">messages[]</code> array that becomes the
+        opening of a fresh turn. They&apos;re user-controlled by design, which
+        is why they&apos;re the safest of the three: nothing fires unless the
+        user typed the slash.
+      </>
+    ),
+  },
+  {
+    id: "sampling",
+    name: "sampling",
+    side: "client",
+    controlled: "human-gated",
+    arrow: "server→client",
+    envelope: `// sampling/createMessage — the SERVER asks for a completion
+{ "method": "sampling/createMessage",
+  "params": {
+    "messages": [{ "role": "user", "content": { "type": "text",
+      "text": "Summarise this diff in one sentence." } }],
+    "modelPreferences": {
+      "hints": [{ "name": "claude-sonnet" }],
+      "intelligencePriority": 0.6
+    },
+    "maxTokens": 256
+  } }`,
+    detail: (
+      <>
+        <strong>The surprising one.</strong> Sampling lets the server ask the
+        host&apos;s model for a completion — and the request goes through{" "}
+        <strong>two human-in-the-loop gates</strong> on the way:
+        <ol
+          className="mt-[var(--spacing-2xs)] pl-[var(--spacing-md)]"
+          style={{ listStyle: "decimal" }}
+        >
+          <li>
+            <strong>HITL #1 · before send.</strong> The client surfaces the
+            request to the user — messages, system prompt, model preferences —
+            and waits for approve / edit / reject.
+          </li>
+          <li>
+            <strong>HITL #2 · before return.</strong> The model&apos;s response
+            is shown to the user before it reaches the server. Same three
+            options.
+          </li>
+        </ol>
+        <p className="mt-[var(--spacing-2xs)]">
+          <code className="font-mono">modelPreferences</code> are{" "}
+          <em>hints</em>, not contracts. The host picks the actual model — a
+          Sonnet-preferring server can wind up running on Haiku, or a hosted
+          model the user pays for. The server never sees an API key. The
+          server never sees the user&apos;s broader conversation unless it
+          asks for{" "}
+          <code className="font-mono">includeContext: &quot;thisServer&quot;</code>.
+        </p>
+      </>
+    ),
+  },
+  {
+    id: "roots",
+    name: "roots",
+    side: "client",
+    controlled: "filesystem boundary",
+    arrow: "server→client",
+    envelope: `// roots/list — server asks "what may I touch?"
+{ "method": "roots/list" }
+// → response
+{ "result": {
+    "roots": [
+      { "uri": "file:///workspace/api", "name": "api" },
+      { "uri": "file:///workspace/web", "name": "web" }
+    ] } }`,
+    detail: (
+      <>
+        Roots are the filesystem boundary the client tells the server it&apos;s
+        allowed to operate inside. URIs are always{" "}
+        <code className="font-mono">file://</code>. When the user opens a new
+        workspace the client fires{" "}
+        <code className="font-mono">notifications/roots/list_changed</code>{" "}
+        (sub-flag) so the server can refresh. A filesystem MCP server that
+        ignores roots is a host-side bug waiting to happen.
+      </>
+    ),
+  },
+  {
+    id: "elicitation",
+    name: "elicitation",
+    side: "client",
+    controlled: "user form",
+    arrow: "server→client",
+    envelope: `// elicitation/create — server asks the user a follow-up
+{ "method": "elicitation/create",
+  "params": {
+    "message": "Which calendar should I use?",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "calendar": { "type": "string",
+          "enum": ["personal", "work"] }
+      } } } }`,
+    detail: (
+      <>
+        Added in <code className="font-mono">2025-06-18</code>. Mid-tool-call,
+        the server can ask the user a question with a JSON-Schema-shaped reply.
+        The client renders a form, the user fills it, the client returns the
+        reply. It lets servers ask for missing parameters without hard-coding
+        every choice into the tool input schema. Schema is restricted to
+        primitive types — string, number, boolean, enums — so the form is
+        always render-able as a single screen.
+      </>
+    ),
+  },
+];
+
+const SERVER_PRIMITIVES = PRIMITIVES.filter((p) => p.side === "server");
+const CLIENT_PRIMITIVES = PRIMITIVES.filter((p) => p.side === "client");
+
+/**
+ * SixPrimitives (§4–§5) — the unifying canvas. Six chips, tap any to expand
+ * its detail. Top group: server-side trio (tools / resources / prompts).
+ * Bottom group: client-side trio (sampling / roots / elicitation). The
+ * single canvas keeps the "six names for one mechanism" frame visible the
+ * whole time (voice-profile §12.3).
+ *
+ * Frame stability (R6): the detail pane has a reserved min-height. The
+ * outer frame never grows or shrinks during interaction — only opacity
+ * and content swaps move. Mobile-first: chips stack 1×3 on narrow widths,
+ * 3×2 on wider widget breakpoints.
+ *
+ * Audio: `Click` on chip expand/collapse (Tier-1 per audio playbook).
+ *
+ * Accessibility: chips are buttons in a `role="group"`. Active state via
+ * `aria-pressed` plus a leading "▸" mark — never colour alone.
+ */
+export function SixPrimitives() {
+  const [active, setActive] = useState<PrimitiveId | null>(null);
+  const def = active ? PRIMITIVES.find((p) => p.id === active) ?? null : null;
+
+  return (
+    <WidgetShell
+      title="six primitives · one session"
+      measurements={
+        active ? `viewing · ${active}` : "tap a primitive"
+      }
+      captionTone="prominent"
+      caption={
+        def ? (
+          <>
+            <CaptionCue>
+              {def.name} · {def.controlled}
+            </CaptionCue>{" "}
+            <span style={{ color: "var(--color-text-muted)" }}>
+              ({ARROW_LABEL[def.arrow]})
+            </span>
+          </>
+        ) : (
+          <>
+            <CaptionCue>Three each direction.</CaptionCue> Tap any chip to see
+            its envelope shape and who pulls the trigger. Servers offer tools,
+            resources, and prompts. Clients offer sampling, roots, and
+            elicitation. Same JSON-RPC, six different gestures.
+          </>
+        )
+      }
+    >
+      <style>{`
+        .bs-six-grid {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-md);
+        }
+        .bs-six-row {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-2xs);
+        }
+        @container widget (min-width: 480px) {
+          .bs-six-row {
+            grid-template-columns: repeat(3, 1fr);
+          }
+        }
+        .bs-six-eyebrow {
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--color-text-muted);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          padding-bottom: 4px;
+        }
+        .bs-six-chip {
+          min-height: 64px;
+          padding: 10px 12px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          color: var(--color-text);
+          text-align: left;
+          cursor: pointer;
+          transition: opacity 220ms, border-color 220ms, background 220ms;
+        }
+        .bs-six-chip:hover:not(:disabled) {
+          border-color: color-mix(in oklab, var(--color-accent) 50%, var(--color-rule));
+        }
+        .bs-six-chip:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-six-detail {
+          min-height: 320px;
+          border-radius: var(--radius-sm);
+          background: color-mix(in oklab, var(--color-surface) 40%, transparent);
+          border: 1px dashed var(--color-rule);
+          padding: var(--spacing-sm) var(--spacing-md);
+        }
+        .bs-six-detail-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-md);
+        }
+        @container widget (min-width: 720px) {
+          .bs-six-detail-grid {
+            grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.55fr);
+          }
+        }
+        .bs-six-envelope {
+          font-family: var(--font-mono);
+          font-size: 11px;
+          line-height: 1.5;
+          padding: 10px 12px;
+          border-radius: var(--radius-sm);
+          background: var(--color-bg);
+          border: 1px solid var(--color-rule);
+          color: var(--color-text);
+          white-space: pre;
+          overflow-x: auto;
+        }
+      `}</style>
+
+      <div className="bs-six-grid">
+        {/* Server-side trio */}
+        <div role="group" aria-label="server-side primitives">
+          <div className="bs-six-eyebrow">
+            servers expose · client → server
+          </div>
+          <div className="bs-six-row">
+            {SERVER_PRIMITIVES.map((p) => (
+              <Chip
+                key={p.id}
+                p={p}
+                isActive={active === p.id}
+                isDimmed={active !== null && active !== p.id}
+                onClick={() => {
+                  playSound("Click");
+                  setActive((prev) => (prev === p.id ? null : p.id));
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Client-side trio */}
+        <div role="group" aria-label="client-side primitives">
+          <div className="bs-six-eyebrow">
+            clients expose · server → client
+          </div>
+          <div className="bs-six-row">
+            {CLIENT_PRIMITIVES.map((p) => (
+              <Chip
+                key={p.id}
+                p={p}
+                isActive={active === p.id}
+                isDimmed={active !== null && active !== p.id}
+                onClick={() => {
+                  playSound("Click");
+                  setActive((prev) => (prev === p.id ? null : p.id));
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Detail pane — fixed min-height; content swaps inside it. */}
+        <div className="bs-six-detail">
+          <AnimatePresence mode="wait" initial={false}>
+            {def ? (
+              <motion.div
+                key={def.id}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={SPRING.smooth}
+                className="bs-six-detail-grid"
+              >
+                <div className="bs-six-envelope">{def.envelope}</div>
+                <div
+                  className="font-serif"
+                  style={{
+                    fontSize: "var(--text-body)",
+                    lineHeight: 1.55,
+                    color: "var(--color-text)",
+                  }}
+                >
+                  {def.detail}
+                </div>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="hint"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.smooth}
+                className="font-sans flex items-center justify-center"
+                style={{
+                  minHeight: 280,
+                  color: "var(--color-text-muted)",
+                  fontSize: "var(--text-small)",
+                  textAlign: "center",
+                }}
+              >
+                <span>
+                  Pick any of the six. The sampling chip is the longest read —
+                  it&apos;s where the protocol genuinely surprises you.
+                </span>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+function Chip({
+  p,
+  isActive,
+  isDimmed,
+  onClick,
+}: {
+  p: PrimitiveDef;
+  isActive: boolean;
+  isDimmed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <motion.button
+      type="button"
+      aria-pressed={isActive}
+      onClick={onClick}
+      className="bs-six-chip"
+      animate={{ opacity: isDimmed ? 0.4 : 1 }}
+      transition={SPRING.smooth}
+      style={{
+        borderColor: isActive ? "var(--color-accent)" : "var(--color-rule)",
+        background: isActive
+          ? "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+          : undefined,
+      }}
+    >
+      <div
+        className="flex items-baseline justify-between font-mono"
+        style={{ fontSize: "var(--text-small)" }}
+      >
+        <span
+          style={{
+            color: isActive ? "var(--color-accent)" : "var(--color-text)",
+            fontWeight: 600,
+          }}
+        >
+          <span aria-hidden style={{ marginRight: 6 }}>
+            {isActive ? "▸" : "·"}
+          </span>
+          {p.name}
+        </span>
+      </div>
+      <div
+        className="mt-[var(--spacing-2xs)] font-mono"
+        style={{
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {p.controlled}
+      </div>
+    </motion.button>
+  );
+}

--- a/app/posts/mcps-explained/widgets/TransportToggle.tsx
+++ b/app/posts/mcps-explained/widgets/TransportToggle.tsx
@@ -59,7 +59,7 @@ const CAPTIONS: Record<Transport, React.ReactNode> = {
 
 const MEASUREMENT: Record<Transport, string> = {
   stdio: "subprocess · newline-delimited",
-  http: "one endpoint · sessioned",
+  http: "one endpoint · session-tracked",
 };
 
 /**

--- a/app/posts/mcps-explained/widgets/TransportToggle.tsx
+++ b/app/posts/mcps-explained/widgets/TransportToggle.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { TextHighlighter } from "@/components/fancy";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+
+function CaptionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      triggerType="auto"
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+type Transport = "stdio" | "http";
+
+type Pane = {
+  /** Pre-rendered Shiki block. Threaded in from page.tsx (RSC). */
+  node: React.ReactNode;
+};
+
+type Props = {
+  panes: Record<Transport, Pane>;
+};
+
+const CAPTIONS: Record<Transport, React.ReactNode> = {
+  stdio: (
+    <>
+      <CaptionCue>Same dance, two wires.</CaptionCue> Over stdio, every JSON
+      message is one line on stdin or stdout. The client launches the server as
+      a subprocess; <strong>stdout is the protocol</strong> — a stray{" "}
+      <code className="font-mono">console.log</code> there will corrupt the
+      session. stderr is free-form logs. Single client, dies with the parent.
+    </>
+  ),
+  http: (
+    <>
+      <CaptionCue>One endpoint, both directions.</CaptionCue> POST is
+      client→server; the response can be a single JSON object or an SSE stream.
+      GET opens a server→client SSE channel. The{" "}
+      <code className="font-mono">Mcp-Session-Id</code> header pins the session;
+      lose it and the server returns 404. Reconnect with{" "}
+      <code className="font-mono">Last-Event-ID</code> to replay missed
+      messages.
+    </>
+  ),
+};
+
+const MEASUREMENT: Record<Transport, string> = {
+  stdio: "subprocess · newline-delimited",
+  http: "one endpoint · sessioned",
+};
+
+/**
+ * TransportToggle (§6) — segmented control over two pre-rendered Shiki
+ * panes. Same `initialize` exchange, two wire formats. The frame stays the
+ * same size on toggle (R6); only the contents fade in/out.
+ *
+ * The two snippets are pre-rendered through `<CodeBlock>` in page.tsx and
+ * threaded in via the `panes` prop — keeps the client bundle small.
+ *
+ * Audio: `Radio` on segmented control change (Tier-1 per audio playbook —
+ * Radio is the canonical "segmented selection" sound, see ParseVsRender).
+ *
+ * Accessibility: tabs are real `role="tab"` / `aria-selected` pair; the
+ * pane is a single region beneath. Hit targets are ≥ 44 × 44.
+ */
+export function TransportToggle({ panes }: Props) {
+  const [transport, setTransport] = useState<Transport>("stdio");
+
+  return (
+    <WidgetShell
+      title="two transports · one protocol"
+      measurements={MEASUREMENT[transport]}
+      captionTone="prominent"
+      caption={CAPTIONS[transport]}
+      controls={
+        <div
+          role="tablist"
+          aria-label="MCP transport"
+          className="inline-flex rounded-[var(--radius-sm)] font-sans"
+          style={{
+            fontSize: "var(--text-ui)",
+            border: "1px solid var(--color-rule)",
+            overflow: "hidden",
+          }}
+        >
+          {(["stdio", "http"] as Transport[]).map((t) => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={transport === t}
+              onClick={() => {
+                if (transport !== t) playSound("Radio");
+                setTransport(t);
+              }}
+              className="px-[var(--spacing-md)] py-[var(--spacing-2xs)] min-h-[44px] transition-colors"
+              style={{
+                background:
+                  transport === t
+                    ? "color-mix(in oklab, var(--color-accent) 20%, transparent)"
+                    : "transparent",
+                color:
+                  transport === t
+                    ? "var(--color-text)"
+                    : "var(--color-text-muted)",
+                fontWeight: transport === t ? 600 : 500,
+                minWidth: 96,
+              }}
+            >
+              {t === "stdio" ? "stdio" : "Streamable HTTP"}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      <div className="relative" style={{ minHeight: 320 }}>
+        <AnimatePresence initial={false} mode="wait">
+          <motion.div
+            key={transport}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={SPRING.smooth}
+          >
+            {panes[transport].node}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/app/posts/mcps-explained/widgets/index.ts
+++ b/app/posts/mcps-explained/widgets/index.ts
@@ -1,0 +1,5 @@
+export { PredictTheHandshake } from "./PredictTheHandshake";
+export { RoleTopology } from "./RoleTopology";
+export { HandshakeWalkthrough } from "./HandshakeWalkthrough";
+export { SixPrimitives } from "./SixPrimitives";
+export { TransportToggle } from "./TransportToggle";

--- a/app/posts/mcps-explained/widgets/snippets.ts
+++ b/app/posts/mcps-explained/widgets/snippets.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared code snippets for the MCPs Explained post. Pre-rendered through
+ * `<CodeBlock>` in `page.tsx` (Shiki, dual-theme) and threaded into widgets
+ * via `codeSlot` props (RSC pattern — keeps client bundles small).
+ */
+
+/** §0 — the article's opening hook. The canonical `initialize` request. */
+export const INITIALIZE_REQUEST_SNIPPET = `// Client → Server, on every new MCP session
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "roots": { "listChanged": true },
+      "sampling": {},
+      "elicitation": {}
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "version": "1.0.0"
+    }
+  }
+}`;
+
+/** §3 — the `initialize` response. */
+export const INITIALIZE_RESPONSE_SNIPPET = `// Server → Client, in reply
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "tools": { "listChanged": true },
+      "resources": { "subscribe": true, "listChanged": true },
+      "prompts": { "listChanged": true },
+      "logging": {}
+    },
+    "serverInfo": {
+      "name": "FilesystemServer",
+      "version": "0.4.2"
+    },
+    "instructions": "Files are exposed under the configured roots."
+  }
+}`;
+
+/** §3 — the fire-and-forget `initialized` notification. */
+export const INITIALIZED_NOTIFICATION_SNIPPET = `// Client → Server, no id, no response
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}`;
+
+/** §6 — same `initialize` over stdio (newline-delimited). */
+export const TRANSPORT_STDIO_SNIPPET = `# Server launched as a subprocess; one JSON message per line.
+# stdin  = client → server   ·   stdout = server → client
+# stderr = server logs (free-form, never the protocol)
+
+# Client writes (one line, no embedded newlines):
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"Cli","version":"1.0.0"}}}
+
+# Server replies (one line back on stdout):
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"fs","version":"0.4.2"}}}
+
+# Client confirms (notification — no id, no response expected):
+{"jsonrpc":"2.0","method":"notifications/initialized"}`;
+
+/** §6 — same `initialize` over Streamable HTTP. */
+export const TRANSPORT_HTTP_SNIPPET = `# One endpoint, both directions multiplexed.
+# Header set on every post-init request (added 2025-06-18):
+#   MCP-Protocol-Version: 2025-06-18
+
+POST /mcp HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Accept: application/json, text/event-stream
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"WebClient","version":"1.0.0"}}}
+
+# Server response, with a session id assigned by the server:
+HTTP/1.1 200 OK
+Mcp-Session-Id: 1868a90c-f7b6-4a6d-9c55-7c2a8e08e4b1
+Content-Type: application/json
+
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{}},"serverInfo":{"name":"fs","version":"0.4.2"}}}
+
+# All later requests echo the session id; lose it, get a 404.`;

--- a/components/covers/McpsExplainedCover.tsx
+++ b/components/covers/McpsExplainedCover.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useCoverInView } from "./_CoverFrame";
+
+/**
+ * McpsExplainedCover — the three-message handshake.
+ *
+ * One sentence:
+ *   The handshake IS the protocol — three message envelopes cross the gap
+ *   between client and server, and a contract pins them at the end.
+ *
+ * Composition (10 load-bearing elements, ≤14 budget per playbook §2):
+ *  1.  Client lane rect (top, translucent accent tint)
+ *  2.  Server lane rect (bottom, muted surface)
+ *  3.  Client label dot (left of client lane, accent)
+ *  4.  Server label dot (left of server lane, muted)
+ *  5.  m1 envelope group — "initialize", client → server (rightward draw)
+ *  6.  m2 envelope group — "capabilities", server → client (leftward draw)
+ *  7.  m3 envelope group — "initialized", client → server (rightward draw, smaller)
+ *  8.  Contract bracket left half — appears at end of m3, holds
+ *  9.  Contract bracket right half — appears at end of m3, holds
+ *  10. Faint guide line through the gap (single chrome line)
+ *
+ * Register: refined pedagogical / reveal (playbook §14).
+ *  - Translucent fills + thin strokes on chrome lanes; solid terracotta
+ *    only on the three envelopes (the hero gesture).
+ *  - Opacity-led motion. No scale-led pulses on chrome.
+ *  - Single hero gesture per envelope: a clean reveal across the gap.
+ *
+ * Motion (5.5s loop, continuous, no idle gap):
+ *  - 0.00–0.25: m1 envelope reveals + travels rightward.
+ *  - 0.25–0.50: m2 envelope reveals + travels leftward.
+ *  - 0.50–0.75: m3 envelope reveals + travels rightward (smaller).
+ *  - 0.75–0.90: contract bracket fades in; envelopes hold.
+ *  - 0.90–1.00: bracket holds; loop wraps cleanly.
+ *
+ * Reduced-motion end-state: all three envelopes delivered; contract bracket
+ * visible in the gap. The "handshake completed" frame.
+ *
+ * Frame-stability R6: only opacity / pathLength / transform animate. Tokens-only.
+ */
+export function McpsExplainedCover() {
+  const inView = useCoverInView();
+  const reduced = useReducedMotion();
+  const animate = inView && !reduced;
+
+  // ─── Geometry ───────────────────────────────────────────────
+  const laneX = 28;
+  const laneW = 144;
+  const laneH = 28;
+  const clientY = 48;
+  const serverY = 124;
+
+  // Envelope ride midY's — staggered vertically so all three remain visible
+  // when settled in the static end-state.
+  const m1Y = 86;
+  const m2Y = 100;
+  const m3Y = 114;
+
+  return (
+    <g>
+      {/* ─── 1. Client lane (top, translucent accent tint) ─── */}
+      <rect
+        x={laneX}
+        y={clientY}
+        width={laneW}
+        height={laneH}
+        rx={6}
+        fill="color-mix(in oklab, var(--color-accent) 10%, transparent)"
+        stroke="color-mix(in oklab, var(--color-accent) 32%, transparent)"
+        strokeWidth={1.2}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── 2. Server lane (bottom, muted surface) ─── */}
+      <rect
+        x={laneX}
+        y={serverY}
+        width={laneW}
+        height={laneH}
+        rx={6}
+        fill="var(--color-surface)"
+        stroke="var(--color-rule)"
+        strokeWidth={1.2}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── 3. Client label dot ─── */}
+      <circle
+        cx={laneX - 10}
+        cy={clientY + laneH / 2}
+        r={2.4}
+        fill="var(--color-accent)"
+      />
+
+      {/* ─── 4. Server label dot ─── */}
+      <circle
+        cx={laneX - 10}
+        cy={serverY + laneH / 2}
+        r={2.4}
+        fill="var(--color-text-muted)"
+      />
+
+      {/* ─── 10. Faint guide line through the gap ─── */}
+      <line
+        x1={laneX + 4}
+        y1={100}
+        x2={laneX + laneW - 4}
+        y2={100}
+        stroke="var(--color-rule)"
+        strokeWidth={0.8}
+        strokeDasharray="2 4"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.55}
+      />
+
+      {/* ─── 5. m1 envelope: client → server (rightward) ─── */}
+      <Envelope
+        startX={laneX + 6}
+        endX={laneX + laneW - 28}
+        midY={m1Y}
+        w={26}
+        h={14}
+        animate={animate}
+        // Opacity + x keyframes share the same 5-step times.
+        // Reveal window: 0.00 → 0.25.
+        opacityKeys={[0, 1, 1, 1, 1]}
+        xKeyFrac={[0, 1, 1, 1, 1]}
+        times={[0, 0.25, 0.55, 0.85, 1]}
+        flapDir="right"
+      />
+
+      {/* ─── 6. m2 envelope: server → client (leftward) ─── */}
+      <Envelope
+        startX={laneX + laneW - 28 - 6}
+        endX={laneX + 8}
+        midY={m2Y}
+        w={26}
+        h={14}
+        animate={animate}
+        // Reveal window: 0.25 → 0.50.
+        opacityKeys={[0, 0, 1, 1, 1]}
+        xKeyFrac={[0, 0, 1, 1, 1]}
+        times={[0, 0.25, 0.5, 0.85, 1]}
+        flapDir="left"
+      />
+
+      {/* ─── 7. m3 envelope: client → server (rightward, smaller, notification) ─── */}
+      <Envelope
+        startX={laneX + 6}
+        endX={laneX + laneW - 24}
+        midY={m3Y}
+        w={20}
+        h={12}
+        animate={animate}
+        // Reveal window: 0.50 → 0.75.
+        opacityKeys={[0, 0, 0, 1, 1]}
+        xKeyFrac={[0, 0, 0, 1, 1]}
+        times={[0, 0.25, 0.5, 0.75, 1]}
+        flapDir="right"
+        notification
+      />
+
+      {/* ─── 8 & 9. Contract bracket — fades in at end of m3 ─── */}
+      <ContractBracket animate={animate} />
+    </g>
+  );
+}
+
+/**
+ * Envelope — small rect + flap V, optionally a notification dot.
+ *
+ * Motion: parent motion.g translates from startX to endX on a 5.5s loop;
+ * inner content fades in via opacity at the assigned reveal window.
+ */
+function Envelope({
+  startX,
+  endX,
+  midY,
+  w,
+  h,
+  animate,
+  opacityKeys,
+  xKeyFrac,
+  times,
+  flapDir,
+  notification = false,
+}: {
+  startX: number;
+  endX: number;
+  midY: number;
+  w: number;
+  h: number;
+  animate: boolean;
+  opacityKeys: number[];
+  xKeyFrac: number[];
+  times: number[];
+  flapDir: "left" | "right";
+  notification?: boolean;
+}) {
+  const xKeys = xKeyFrac.map((f) => startX + (endX - startX) * f);
+  // Apex of flap V — slight asymmetric tilt favouring the travel direction.
+  const apexShift = flapDir === "right" ? 1.5 : -1.5;
+
+  return (
+    <motion.g
+      initial={{ opacity: 0, x: startX }}
+      animate={
+        animate
+          ? { opacity: opacityKeys, x: xKeys }
+          : { opacity: 1, x: endX }
+      }
+      transition={
+        animate
+          ? {
+              duration: 5.5,
+              repeat: Infinity,
+              ease: "easeInOut",
+              times,
+            }
+          : undefined
+      }
+    >
+      <rect
+        x={-w / 2}
+        y={midY - h / 2}
+        width={w}
+        height={h}
+        rx={1.5}
+        fill="color-mix(in oklab, var(--color-accent) 18%, transparent)"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d={`M ${-w / 2} ${midY - h / 2} L ${apexShift} ${midY - h / 2 + 3.4} L ${w / 2} ${midY - h / 2}`}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      {notification && (
+        <circle
+          cx={w / 2 + 4}
+          cy={midY - h / 2 + 1}
+          r={1}
+          fill="var(--color-accent)"
+        />
+      )}
+    </motion.g>
+  );
+}
+
+/**
+ * ContractBracket — two thin terracotta brackets that frame the gap centre,
+ * fade in at the end of m3, and hold for the static end-state.
+ *
+ * The single quiet support gesture per playbook §14 — opacity-led, gentle.
+ */
+function ContractBracket({ animate }: { animate: boolean }) {
+  const cy = 100;
+  const halfSpan = 18;
+  const bracketH = 18;
+  const tabW = 5;
+
+  // Opacity keys: hidden until 0.75 (m3 settled), fades in 0.75 → 0.90, holds.
+  const opacityKeys = [0, 0, 0, 0, 1, 1];
+  const times = [0, 0.25, 0.5, 0.75, 0.9, 1];
+
+  const leftX = -halfSpan;
+  const leftPath = `M ${leftX + tabW} ${cy - bracketH / 2} L ${leftX} ${cy - bracketH / 2} L ${leftX} ${cy + bracketH / 2} L ${leftX + tabW} ${cy + bracketH / 2}`;
+  const rightX = halfSpan;
+  const rightPath = `M ${rightX - tabW} ${cy - bracketH / 2} L ${rightX} ${cy - bracketH / 2} L ${rightX} ${cy + bracketH / 2} L ${rightX - tabW} ${cy + bracketH / 2}`;
+
+  return (
+    <motion.g
+      transform="translate(100 0)"
+      initial={{ opacity: 0 }}
+      animate={animate ? { opacity: opacityKeys } : { opacity: 1 }}
+      transition={
+        animate
+          ? {
+              duration: 5.5,
+              repeat: Infinity,
+              ease: "easeInOut",
+              times,
+            }
+          : undefined
+      }
+    >
+      <path
+        d={leftPath}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <path
+        d={rightPath}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </motion.g>
+  );
+}
+
+/**
+ * McpsExplainedCoverStatic — Satori-safe pure-JSX export.
+ *
+ * Reduced-motion end-state: all three envelopes have been delivered to their
+ * destinations; contract bracket holds in the gap. Reads as "the handshake
+ * completed — three envelopes pinned by a contract."
+ *
+ * Hex palette inlined per static-registry.ts contract. color-mix() values
+ * approximated against BG #0e1114.
+ */
+export function McpsExplainedCoverStatic() {
+  const ACCENT = "#d97341";
+  const MUTED = "#7a7570";
+  const SURFACE = "#1a1714";
+  const RULE = "#2a2622";
+  // Approximations of color-mix(accent X% + transparent) over BG #0e1114:
+  const ACCENT_TINT_FILL = "#221814";
+  const ACCENT_TINT_STROKE = "#4f2f24";
+  const ENVELOPE_FILL = "#2e1d18";
+
+  const laneX = 28;
+  const laneW = 144;
+  const laneH = 28;
+  const clientY = 48;
+  const serverY = 124;
+
+  // Envelope rest positions (after delivery).
+  const m1RestX = laneX + laneW - 28;
+  const m2RestX = laneX + 8;
+  const m3RestX = laneX + laneW - 24;
+  const m1Y = 86;
+  const m2Y = 100;
+  const m3Y = 114;
+
+  // Contract bracket geometry (viewBox-centred at x=100).
+  const cy = 100;
+  const halfSpan = 18;
+  const bracketH = 18;
+  const tabW = 5;
+
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      xmlns="http://www.w3.org/2000/svg"
+      width="100%"
+      height="100%"
+    >
+      {/* Client lane */}
+      <rect
+        x={laneX}
+        y={clientY}
+        width={laneW}
+        height={laneH}
+        rx={6}
+        fill={ACCENT_TINT_FILL}
+        stroke={ACCENT_TINT_STROKE}
+        strokeWidth={1.2}
+      />
+      {/* Server lane */}
+      <rect
+        x={laneX}
+        y={serverY}
+        width={laneW}
+        height={laneH}
+        rx={6}
+        fill={SURFACE}
+        stroke={RULE}
+        strokeWidth={1.2}
+      />
+      {/* Lane label dots */}
+      <circle cx={laneX - 10} cy={clientY + laneH / 2} r={2.4} fill={ACCENT} />
+      <circle cx={laneX - 10} cy={serverY + laneH / 2} r={2.4} fill={MUTED} />
+
+      {/* Gap guide line */}
+      <line
+        x1={laneX + 4}
+        y1={100}
+        x2={laneX + laneW - 4}
+        y2={100}
+        stroke={RULE}
+        strokeWidth={0.8}
+        strokeDasharray="2 4"
+        opacity={0.55}
+      />
+
+      {/* m1 envelope — delivered right (client → server) */}
+      <g transform={`translate(${m1RestX} 0)`}>
+        <rect
+          x={-13}
+          y={m1Y - 7}
+          width={26}
+          height={14}
+          rx={1.5}
+          fill={ENVELOPE_FILL}
+          stroke={ACCENT}
+          strokeWidth={1.6}
+        />
+        <path
+          d={`M -13 ${m1Y - 7} L 1.5 ${m1Y - 7 + 3.4} L 13 ${m1Y - 7}`}
+          fill="none"
+          stroke={ACCENT}
+          strokeWidth={1.4}
+          strokeLinecap="round"
+        />
+      </g>
+
+      {/* m2 envelope — delivered left (server → client) */}
+      <g transform={`translate(${m2RestX} 0)`}>
+        <rect
+          x={-13}
+          y={m2Y - 7}
+          width={26}
+          height={14}
+          rx={1.5}
+          fill={ENVELOPE_FILL}
+          stroke={ACCENT}
+          strokeWidth={1.6}
+        />
+        <path
+          d={`M -13 ${m2Y - 7} L -1.5 ${m2Y - 7 + 3.4} L 13 ${m2Y - 7}`}
+          fill="none"
+          stroke={ACCENT}
+          strokeWidth={1.4}
+          strokeLinecap="round"
+        />
+      </g>
+
+      {/* m3 envelope — delivered right (client → server, smaller, notification) */}
+      <g transform={`translate(${m3RestX} 0)`}>
+        <rect
+          x={-10}
+          y={m3Y - 6}
+          width={20}
+          height={12}
+          rx={1.5}
+          fill={ENVELOPE_FILL}
+          stroke={ACCENT}
+          strokeWidth={1.6}
+        />
+        <path
+          d={`M -10 ${m3Y - 6} L 1.5 ${m3Y - 6 + 3} L 10 ${m3Y - 6}`}
+          fill="none"
+          stroke={ACCENT}
+          strokeWidth={1.4}
+          strokeLinecap="round"
+        />
+        <circle cx={14} cy={m3Y - 6 + 1} r={1} fill={ACCENT} />
+      </g>
+
+      {/* Contract bracket — settled in the gap */}
+      <g transform="translate(100 0)">
+        <path
+          d={`M ${-halfSpan + tabW} ${cy - bracketH / 2} L ${-halfSpan} ${cy - bracketH / 2} L ${-halfSpan} ${cy + bracketH / 2} L ${-halfSpan + tabW} ${cy + bracketH / 2}`}
+          fill="none"
+          stroke={ACCENT}
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d={`M ${halfSpan - tabW} ${cy - bracketH / 2} L ${halfSpan} ${cy - bracketH / 2} L ${halfSpan} ${cy + bracketH / 2} L ${halfSpan - tabW} ${cy + bracketH / 2}`}
+          fill="none"
+          stroke={ACCENT}
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/components/covers/PostCover.tsx
+++ b/components/covers/PostCover.tsx
@@ -8,6 +8,7 @@ import { FunctionRememberedCover } from "./FunctionRememberedCover";
 import { WebpageReadsAgentCover } from "./WebpageReadsAgentCover";
 import { LineThatWaitsItsTurnCover } from "./LineThatWaitsItsTurnCover";
 import { HowJavascriptReadsItsOwnFutureCover } from "./HowJavascriptReadsItsOwnFutureCover";
+import { McpsExplainedCover } from "./McpsExplainedCover";
 
 /**
  * Slug → cover-component registry.
@@ -24,6 +25,7 @@ const REGISTRY: Record<string, () => React.ReactNode> = {
   "the-webpage-that-reads-the-agent": WebpageReadsAgentCover,
   "the-line-that-waits-its-turn": LineThatWaitsItsTurnCover,
   "how-javascript-reads-its-own-future": HowJavascriptReadsItsOwnFutureCover,
+  "mcps-explained": McpsExplainedCover,
 };
 
 type Size = "thumb" | "hero";

--- a/components/covers/static-registry.ts
+++ b/components/covers/static-registry.ts
@@ -6,6 +6,7 @@ import { FunctionRememberedCoverStatic } from "./FunctionRememberedCover";
 import { WebpageReadsAgentCoverStatic } from "./WebpageReadsAgentCover";
 import { LineThatWaitsItsTurnCoverStatic } from "./LineThatWaitsItsTurnCover";
 import { HowJavascriptReadsItsOwnFutureCoverStatic } from "./HowJavascriptReadsItsOwnFutureCover";
+import { McpsExplainedCoverStatic } from "./McpsExplainedCover";
 
 /**
  * Server-safe registry of pure-JSX static cover components, keyed by post slug.
@@ -40,4 +41,5 @@ export const STATIC_COVERS: Record<string, () => JSX.Element> = {
   "the-webpage-that-reads-the-agent": WebpageReadsAgentCoverStatic,
   "the-line-that-waits-its-turn": LineThatWaitsItsTurnCoverStatic,
   "how-javascript-reads-its-own-future": HowJavascriptReadsItsOwnFutureCoverStatic,
+  "mcps-explained": McpsExplainedCoverStatic,
 };

--- a/content/posts-manifest.ts
+++ b/content/posts-manifest.ts
@@ -27,6 +27,15 @@ export type PostMeta = {
 
 export const POSTS: PostMeta[] = [
   {
+    slug: "mcps-explained",
+    title: "MCPs Explained: What They Are and How They Work",
+    date: "2026-04-28",
+    hook:
+      "the handshake that opens every MCP session, the six primitives that ride it, two transports, one boundary — why every published attack is a host-side trust failure, not a protocol flaw.",
+    readingMinutes: 17,
+    tags: ["ai", "agents", "protocols"],
+  },
+  {
     slug: "how-javascript-reads-its-own-future",
     title: "JavaScript Hoisting, the TDZ, and the Call Stack Explained",
     date: "2026-04-25",


### PR DESCRIPTION
## Summary

A deep-dive on Model Context Protocol — end-to-end. The article's spine is the three-message handshake; once the reader sees that, the six primitives, two transports, and the security model all snap onto the same canvas.

The post collapses to one sentence: *MCP is a handshake, not a model.* The model lives in the host; MCP just teaches every host and every server to speak the same boring sentence — `here's who I am, here's what I can do, call me when you need me`. The closer loops back to the §0 premise quiz: *option 2 was the entire shape.*

## What shipped

**One post, eight sections (§0 premise quiz → §8 closer), 817 lines, ~1900 words.**

Five post-local widgets (`app/posts/mcps-explained/widgets/`):
- `PredictTheHandshake` — the W0 quiz opener (anchor pattern from the two-flagship template).
- `RoleTopology` — host/client/server boundary, click-to-select role cards.
- `HandshakeWalkthrough` — line-highlight scrub of an `initialize` envelope, with three message states.
- `SixPrimitives` — server-side and client-side primitive chips, click for short pedagogy on each.
- `TransportToggle` — stdio vs Streamable HTTP, tablist with side-by-side snippets.

Tier-1 audio cues wired per `docs/audio-playbook.md` — `Click` on nav buttons, `Toggle-On` on segmented controls, no inventions.

**Animated SVG cover** (`components/covers/McpsExplainedCover.tsx`) — Concept A, the three-message handshake. 10 load-bearing elements, refined pedagogical / reveal register per `docs/svg-cover-playbook.md §14`. Static sibling `McpsExplainedCoverStatic` registered for OG / share-preview.

## Action items resolved

Phase F six-skill review wrote 13 actionable findings (1 P0, 5 P1, 7 P2) plus 7 rejected suggestions with reasoning. Phase G applied all 13 — full breakdown:

- **P0 (1)**: F-CR-1 — swapped `PredictTheHandshake` option 4 from \"SSE token stream\" to a strict-auth-error distractor (the SSE option was too easy to dismiss given the JSON shown).
- **P1 (5)**: server caps strip → role-flavored verbs; host card client strip flattened (no arrow collisions with §4–§5 directional language); two `<Dots />` ornaments inserted in §5 to break the ~900-word run; §1 voice tightened (drop \"predictably,\" + soften \"structural symmetry hit him immediately\"); §3 closer compacted from three beats to two.
- **P2 (7)**: measurement strings, sentence-opener variation, label rename (idle → pipe open), empty-state hint trim, detail-pane min-height removal, host-vs-client clarification in §5 HITL #1.

7 rejected suggestions are documented inline in `research/mcps-explained/action-items.md` with reasoning (mostly DESIGN.md-ban hits or carpet-bomb traps).

## Validation highlights

| Check | Status |
|---|---|
| Technical correctness | ✓ PASS — every load-bearing claim cited |
| Code correctness | ✓ PASS — new code clean (typecheck + lint) |
| A11y | ✓ PASS — real buttons, `aria-pressed` + leading-mark state, real tablist on `TransportToggle`, focus-visible per token; motion vocabulary self-mitigating |
| Build + Lighthouse | DEFERRED — pre-existing `@web-kits/audio` module-resolution issue on main (PR #66). Will run on the Vercel preview once the housekeeping pass lands. |
| Reading-sanity | ✓ PASS — voice register holds; §0 quiz / §8 closer loop clean; HL cadence below carpet-bomb threshold; `VerticalCutReveal` not used; closer matches flagship template |

Full validation report: `research/mcps-explained/validation.md` (gitignored).

## Cliffhanger

The post hands the reader the boundary, the primitives, and the attacks-as-boundary-violations. The next thread to pull: *what does it look like when the host gets that boundary right?* — i.e., a concrete walk-through of a hardened host that survives the lethal trifecta. Different post.

## Test plan

- [ ] Open the Vercel preview when it lands and walk every widget interaction (predict → role-cards → handshake → six-primitives → transport toggle).
- [ ] Verify the cover at 64 px on the home list and at hero size on the post page.
- [ ] Toggle theme; check focus rings and `prefers-reduced-motion` end-state.
- [ ] Keyboard-only run through the post.
- [ ] Spot-check three load-bearing claims against `validation.md` cites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)