### PR TITLE
feat(courses/mcps): chapter 1 — The room before the protocol

### DIFF
--- a/app/courses/[courseSlug]/[chapterSlug]/page.tsx
+++ b/app/courses/[courseSlug]/[chapterSlug]/page.tsx
@@ -25,7 +25,7 @@ function getChapterContent(
     return MCPS_CONTENT[chapterSlug] ?? null;
   }
   return null;
-}: chapter 4 — The handshake)
+}
 
 /**
  * Chapter page.
@@ -74,11 +74,6 @@ export default async function CourseChapterPage({
   const found = findChapter(courseSlug, chapterSlug);
   if (!found) notFound();
   const { course, chapter, index } = found;
-
-  // Resolve chapter content if a module is registered. Chapters without a
-  // registered module render the placeholder paragraph below.
-  const loader = CHAPTER_CONTENT[course.slug]?.[chapter.slug];
-  const Content = loader ? (await loader()).default : null;
 
   return (
     <div
@@ -175,7 +170,7 @@ export default async function CourseChapterPage({
                 will land here next.
               </p>
             );
-          })()}: chapter 4 — The handshake)
+          })()}
         </div>
       </Prose>
 

--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -16,10 +16,12 @@
 
 import type { ComponentType } from "react";
 import HostClientServerContent from "./host-client-server/Content";
+import TheRoomBeforeProtocolContent from "./the-room-before-the-protocol/Content";
 import JsonRpcTheWireContent from "./json-rpc-the-wire/Content";
 import TheHandshakeContent from "./the-handshake/Content";
 
 export const MCPS_CONTENT: Record<string, ComponentType> = {
+  "the-room-before-the-protocol": TheRoomBeforeProtocolContent,
   "host-client-server": HostClientServerContent,
   "json-rpc-the-wire": JsonRpcTheWireContent,
   "the-handshake": TheHandshakeContent,

--- a/app/courses/mcps/_content/the-room-before-the-protocol/Content.tsx
+++ b/app/courses/mcps/_content/the-room-before-the-protocol/Content.tsx
@@ -1,0 +1,224 @@
+/**
+ * Chapter 1 — The room before the protocol.
+ *
+ * Server component. Renders the chapter's prose arc with the three widgets
+ * threaded into the narrative beats called out in the brainstormer brief:
+ *
+ *   1. PreMcpQuiz opener (premise quiz, voice §12.1)
+ *   2. Scene-setting prose
+ *   3. Reframe paragraph (M·N adapters)
+ *   4. MxNExplorer — the load-bearing widget
+ *   5. "USB-C for AI" reveal
+ *   6. AdapterTimeline — the four pre-MCP eras
+ *   7. First glimpse of `tools/list` flying across stdio (visual only)
+ *   8. IntegrationCountQuiz — comprehension check
+ *   9. Cliffhanger to chapter 2
+ *
+ * Voice rules baked in: <Term> on first appearance of every spec word that
+ * gets formal treatment later (MCP, host, client, server, tool, JSON-RPC,
+ * tools/list); no <hr>, no <br>, no horizontal section dividers — section
+ * pacing is carried by typography and widget placement only.
+ */
+
+import Link from "next/link";
+import { P, H2, Term, Code } from "@/components/prose";
+import { MxNExplorer } from "./widgets/MxNExplorer";
+import { PreMcpQuiz } from "./widgets/PreMcpQuiz";
+import { AdapterTimeline } from "./widgets/AdapterTimeline";
+import { IntegrationCountQuiz } from "./widgets/IntegrationCountQuiz";
+
+export function Chapter1Content() {
+  return (
+    <>
+      {/* 1. Premise-quiz opener — voice §12.1. The reader earns agency
+          before they earn explanation. */}
+      <PreMcpQuiz />
+
+      {/* 2. Scene. Second-person, present tense, one short paragraph. */}
+      <P>
+        You ask Claude to summarise your Notion doc. Two months ago it
+        couldn&apos;t. What changed wasn&apos;t the model — it was the wiring
+        between the model and your data.
+      </P>
+
+      <P>
+        And if you read this as <em>"oh, function-calling, but newer"</em>,
+        you&apos;re missing what the wiring used to cost.
+      </P>
+
+      <H2>The bill nobody added up</H2>
+
+      <P>
+        Before late 2024, every pairing of an AI app and an external system
+        was a custom adapter. Cursor wanted to read your filesystem? Cursor
+        wrote that adapter. Claude Desktop wanted the same? Anthropic&apos;s
+        team wrote a different one. Your internal Slack bot wanted it? You
+        wrote a third.
+      </P>
+
+      <P>
+        With <em>M</em> hosts and <em>N</em> tools, you got{" "}
+        <em>M × N</em> adapters. Three hosts × five tools is fifteen
+        integrations to author and — quietly worse — fifteen integrations to
+        keep alive when any one of them changes shape.
+      </P>
+
+      {/* 4. Load-bearing widget — the felt aha. */}
+      <MxNExplorer />
+
+      <P>
+        Crank M to 4 and N to 9 — a small team with a handful of
+        SaaS surfaces — and the count is 36. Toggle the protocol on and it
+        collapses to 13. Same hosts. Same tools. One layer between them.
+      </P>
+
+      <H2>USB-C for AI</H2>
+
+      <P>
+        That&apos;s the elevator pitch the spec leans on, and the metaphor is
+        load-bearing. <Term>MCP</Term> — the Model Context Protocol — is the
+        single shared shape that sits between hosts and tools, so every host
+        learns the protocol once and every tool exposes itself once. The
+        cable in the middle does the translation. Anthropic shipped the open
+        spec in November 2024; by Q1 2026 the supported-clients list reads
+        like the AI tools page of a current laptop: Claude, ChatGPT, VS
+        Code, Cursor, Zed, Replit, Codeium, Sourcegraph.
+      </P>
+
+      <P>
+        The metaphor breaks where you&apos;d expect — USB-C carries power and
+        bytes; MCP carries <em>capabilities</em>, and capabilities have to be
+        negotiated. We&apos;ll get there. For now, hold onto the shape: one
+        protocol, M + N integrations, every host and every tool meeting in
+        the middle.
+      </P>
+
+      <H2>How we got here</H2>
+
+      <P>
+        The protocol didn&apos;t arrive in a vacuum. Each of the four pre-MCP
+        eras moved <em>some</em> of the burden — but the M × N never
+        collapsed.
+      </P>
+
+      {/* 6. AdapterTimeline. */}
+      <AdapterTimeline />
+
+      <P>
+        Read those panels in order and a pattern shows up: every era moved
+        the burden one layer further from the application code, but always
+        stopped short of the boundary that mattered. Schemas got typed but
+        stayed inside one host&apos;s SDK. Frameworks abstracted vendors but
+        stayed inside one runtime. The integration point — the place where
+        a host meets a tool — kept getting re-implemented per host.
+      </P>
+
+      <P>
+        MCP closes that boundary by naming three roles — a{" "}
+        <Term>host</Term> (Claude Desktop, Cursor, VS Code), a{" "}
+        <Term>client</Term> (the per-server connection manager that lives
+        inside the host), and a <Term>server</Term> (the process that exposes
+        a tool, a resource, or a prompt). Chapter 2 formalises these. For
+        now, it&apos;s enough to know that one protocol speaks across all
+        three.
+      </P>
+
+      <H2>First glimpse: a message on the wire</H2>
+
+      <P>
+        You won&apos;t learn the wire here — that&apos;s chapter 3 — but
+        it&apos;s worth seeing one message before we go further. When a host
+        first connects to a server, one of the earliest things it asks is{" "}
+        <Code>tools/list</Code>: <em>what can you do?</em>
+      </P>
+
+      {/* Inline visual-only glimpse of the tools/list message. Not a real
+          JSON-RPC document — just the shape, framed as a card so the eye
+          knows it's a screenshot of the wire, not body prose. */}
+      <div
+        className="my-[var(--spacing-lg)] font-mono"
+        style={{
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-md)",
+          padding: "var(--spacing-md)",
+          fontSize: "var(--text-small)",
+          lineHeight: 1.55,
+          overflowX: "auto",
+        }}
+      >
+        <div
+          style={{
+            color: "var(--color-text-muted)",
+            fontSize: "0.7rem",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            marginBottom: "0.5em",
+          }}
+        >
+          host → server, over stdio
+        </div>
+        <pre style={{ margin: 0, color: "var(--color-text)" }}>
+{`{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list"
+}`}
+        </pre>
+      </div>
+
+      <P>
+        Four fields. <Term>JSON-RPC</Term> 2.0, fifteen years older than the
+        protocol that uses it. The server replies with the list of tools it
+        offers, each described in a shape the client can render. We&apos;ll
+        read that response apart in chapter 3, decode it inside the
+        capability handshake in chapter 4, and watch a server hand-author
+        one in chapter 6.
+      </P>
+
+      <P>
+        For this chapter, what matters is that <em>this same message</em>{" "}
+        works whether the host is Claude or Cursor or your Slack bot, and
+        whether the tool is filesystem search or a Postgres query or a
+        flight-booking API. The cable in the middle no longer cares.
+      </P>
+
+      <H2>Predict the count</H2>
+
+      <P>
+        One last check before we move on. A new SaaS API ships tomorrow.
+        Your team — Claude Desktop, Cursor, and an internal Slack bot — wants
+        to use it. Pick the integration count, then read the verdict.
+      </P>
+
+      {/* 8. Comprehension check. */}
+      <IntegrationCountQuiz />
+
+      <P>
+        That ratio — one server, N hosts — is what makes MCP a protocol
+        instead of a framework. A framework lives inside one runtime. A
+        protocol crosses runtimes by naming the shape they have to share.
+      </P>
+
+      <H2>What&apos;s next</H2>
+
+      <P>
+        We&apos;ve named the problem and watched it collapse. Now: what does
+        the solution actually look like at the wire — what are the parts,
+        what does each one do, and who talks to whom?{" "}
+        <Link
+          href="/courses/mcps/host-client-server"
+          style={{
+            color: "var(--color-accent)",
+            textDecoration: "underline",
+            textUnderlineOffset: "3px",
+          }}
+        >
+          Chapter 2: three roles, one connection →
+        </Link>
+      </P>
+    </>
+  );
+}
+
+export default Chapter1Content;

--- a/app/courses/mcps/_content/the-room-before-the-protocol/widgets/AdapterTimeline.tsx
+++ b/app/courses/mcps/_content/the-room-before-the-protocol/widgets/AdapterTimeline.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+/**
+ * AdapterTimeline — 4-step scripted stepper through the four pre-MCP eras.
+ *
+ * Each tick shows two columns: "what moved" between LLM and external system,
+ * and "what stayed bespoke" (still M·N). The "moved" column grows; the
+ * "bespoke" column shrinks but never vanishes. Implicit fifth tick — MCP —
+ * is what the chapter is building toward.
+ *
+ * Implementation notes:
+ * - Uses the shipped <WidgetNav> primitive for prev/next/play. WidgetNav
+ *   already pauses autoplay off-screen, respects reduced motion, and meets
+ *   the 44 px hit-target rule.
+ * - The two-column body crossfades on step change. Reduced motion reduces
+ *   that to opacity-only.
+ * - On mobile the two columns stack — pure CSS via @container.
+ */
+
+import { useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { SPRING } from "@/lib/motion";
+
+type Step = {
+  era: string;
+  year: string;
+  blurb: string;
+  moved: string[];
+  bespoke: string[];
+};
+
+const STEPS: Step[] = [
+  {
+    era: "Direct REST",
+    year: "pre-2023",
+    blurb:
+      "An agent loop calls the SaaS REST endpoint directly. Prompt engineering glues the response back into the conversation.",
+    moved: ["nothing — the LLM still parses raw JSON"],
+    bespoke: [
+      "auth per host",
+      "request shape per tool",
+      "response stitching per host",
+      "every error path, hand-rolled",
+    ],
+  },
+  {
+    era: "OpenAPI plugins",
+    year: "2023",
+    blurb:
+      "ChatGPT lets a SaaS publish an OpenAPI spec; the host reads it and offers the endpoints as plugins. Host-specific.",
+    moved: [
+      "tool discovery (host reads the OpenAPI file)",
+      "schema-to-prompt translation",
+    ],
+    bespoke: [
+      "the manifest format is host-specific",
+      "auth flows are host-specific",
+      "every other host re-implements discovery",
+    ],
+  },
+  {
+    era: "Function-calling",
+    year: "2023",
+    blurb:
+      "OpenAI ships function-calling: structured tool schemas the model can invoke directly. The schema shape becomes part of the model's API.",
+    moved: [
+      "structured invocation (model emits a typed call, not a string)",
+      "argument validation, into the framework",
+    ],
+    bespoke: [
+      "tool schemas live inside each app",
+      "Anthropic's shape differs from OpenAI's",
+      "no shared registry across hosts",
+    ],
+  },
+  {
+    era: "LangChain tools",
+    year: "2023–2024",
+    blurb:
+      "A framework abstracts function-calling across providers. Tools become Python/TS classes you register on an agent.",
+    moved: [
+      "model-vendor abstraction (one tool, many backends)",
+      "execution loop, into the framework",
+    ],
+    bespoke: [
+      "tools are framework-specific, not protocol-level",
+      "Cursor, Claude Desktop, Zed don't speak LangChain",
+      "still M × N when crossing host boundaries",
+    ],
+  },
+];
+
+export function AdapterTimeline() {
+  const [step, setStep] = useState(0);
+  const reduce = useReducedMotion();
+  const current = STEPS[step];
+
+  return (
+    <WidgetShell
+      title="Four pre-MCP eras — what moved, what stayed bespoke"
+      measurements={`${step + 1} / ${STEPS.length}`}
+      caption={
+        <>
+          Each era moved <em>some</em> of the integration burden — but the
+          M × N didn't collapse. That's what the next page does.
+        </>
+      }
+      controls={
+        <WidgetNav
+          value={step}
+          total={STEPS.length}
+          onChange={setStep}
+          counterNoun="era"
+        />
+      }
+    >
+      <div
+        style={{
+          containerType: "inline-size",
+          containerName: "atimeline",
+          minHeight: 280,
+        }}
+      >
+        <style>{`
+          .bs-atl-cols {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-md);
+          }
+          @container atimeline (min-width: 540px) {
+            .bs-atl-cols {
+              grid-template-columns: 1fr 1fr;
+              gap: var(--spacing-lg);
+            }
+          }
+          .bs-atl-col {
+            border: 1px solid var(--color-rule);
+            border-radius: var(--radius-md);
+            padding: var(--spacing-md);
+            background: color-mix(in oklab, var(--color-surface) 30%, transparent);
+          }
+          .bs-atl-col h4 {
+            font-family: var(--font-mono);
+            font-size: var(--text-small);
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--color-text-muted);
+            margin: 0 0 var(--spacing-sm) 0;
+            font-weight: 600;
+          }
+          .bs-atl-col ul {
+            margin: 0;
+            padding-left: 1.1em;
+            font-family: var(--font-serif);
+            font-size: var(--text-small);
+            line-height: 1.55;
+            color: var(--color-text);
+          }
+          .bs-atl-col li { margin: 0 0 0.35em 0; }
+          .bs-atl-moved { border-color: color-mix(in oklab, var(--color-accent) 45%, var(--color-rule)); }
+        `}</style>
+
+        {/* Era header. */}
+        <div className="flex items-baseline gap-[var(--spacing-sm)] flex-wrap mb-[var(--spacing-sm)]">
+          <span
+            className="font-sans"
+            style={{
+              fontSize: "var(--text-h3, 1.25rem)",
+              fontWeight: 600,
+              letterSpacing: "-0.01em",
+              color: "var(--color-text)",
+            }}
+          >
+            {current.era}
+          </span>
+          <span
+            className="font-mono"
+            style={{
+              fontSize: "var(--text-small)",
+              color: "var(--color-text-muted)",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {current.year}
+          </span>
+        </div>
+
+        {/* Step body — crossfade on change. */}
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={step}
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 6 }}
+            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+            exit={reduce ? { opacity: 0 } : { opacity: 0, y: -6 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+          >
+            <p
+              className="font-serif"
+              style={{
+                fontSize: "var(--text-small)",
+                lineHeight: 1.55,
+                color: "var(--color-text)",
+                margin: "0 0 var(--spacing-md) 0",
+              }}
+            >
+              {current.blurb}
+            </p>
+            <div className="bs-atl-cols">
+              <div className="bs-atl-col bs-atl-moved">
+                <h4>What moved</h4>
+                <ul>
+                  {current.moved.map((m, i) => (
+                    <li key={i}>{m}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="bs-atl-col">
+                <h4>What stayed bespoke</h4>
+                <ul>
+                  {current.bespoke.map((b, i) => (
+                    <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+
+        {/* Tick rail — visual progress under the body. */}
+        <div
+          aria-hidden
+          className="mt-[var(--spacing-md)] flex items-center gap-[6px]"
+        >
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              style={{
+                display: "inline-block",
+                height: 2,
+                flex: 1,
+                background:
+                  i <= step
+                    ? "var(--color-accent)"
+                    : "color-mix(in oklab, var(--color-rule) 90%, transparent)",
+                transition: "background 200ms",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default AdapterTimeline;

--- a/app/courses/mcps/_content/the-room-before-the-protocol/widgets/IntegrationCountQuiz.tsx
+++ b/app/courses/mcps/_content/the-room-before-the-protocol/widgets/IntegrationCountQuiz.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * IntegrationCountQuiz — the chapter's comprehension check.
+ *
+ * Predict-the-output style: a new SaaS API ships tomorrow. The reader's
+ * team uses Claude Desktop, Cursor, and an internal Slack bot. How many
+ * integrations under MCP vs without? Reuses the shipped <Quiz> primitive
+ * for full a11y + reduced-motion parity with the opener.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+export function IntegrationCountQuiz() {
+  return (
+    <WidgetShell
+      title="A new SaaS ships tomorrow — count the integrations"
+      caption={
+        <>
+          Three hosts in your team. One new tool. Predict the integration
+          count under MCP versus without before you check.
+        </>
+      }
+    >
+      <Quiz
+        question={
+          <p
+            className="font-serif"
+            style={{
+              fontSize: "var(--text-body)",
+              lineHeight: 1.55,
+              margin: 0,
+            }}
+          >
+            A new SaaS API ships tomorrow. Your team uses Claude Desktop,
+            Cursor, and an internal Slack bot. How many integrations do you
+            write — under MCP, vs without?
+          </p>
+        }
+        correctId="one-vs-three"
+        rightVerdict={
+          <>
+            One MCP server. Three host configurations. Without MCP, three
+            bespoke adapters — one per host — and three teams to keep them
+            updated. <em>1 + 3 = 4 lines of work, vs 3 × N forever.</em>
+          </>
+        }
+        wrongVerdict={
+          <>
+            The right pick is <strong>1 vs 3</strong>. Under MCP you author
+            one server and configure three hosts to consume it. Without MCP,
+            each host needs its own adapter — same code, written three times,
+            maintained three times.
+          </>
+        }
+        options={[
+          {
+            id: "one-vs-one",
+            label: "1 vs 1 — the integration is the integration.",
+          },
+          {
+            id: "one-vs-three",
+            label:
+              "1 vs 3 — one MCP server vs one bespoke adapter per host.",
+          },
+          {
+            id: "three-vs-three",
+            label: "3 vs 3 — three teams ship code either way.",
+          },
+          {
+            id: "zero-vs-three",
+            label: "0 vs 3 — MCP servers come for free if upstream provides them.",
+          },
+        ]}
+      />
+    </WidgetShell>
+  );
+}
+
+export default IntegrationCountQuiz;

--- a/app/courses/mcps/_content/the-room-before-the-protocol/widgets/MxNExplorer.tsx
+++ b/app/courses/mcps/_content/the-room-before-the-protocol/widgets/MxNExplorer.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+/**
+ * MxNExplorer — the load-bearing widget for chapter 1 of the MCPs course.
+ *
+ * Two scrubbers (M = hosts, N = tools) drive a bipartite graph. A "with MCP"
+ * toggle collapses the graph from "every host wires to every tool" (M·N
+ * arrows) into a star topology through a hub (M + N arrows). The arrow count
+ * + delta in the measurements slot is the felt aha at M=4, N=9 (36 → 13).
+ *
+ * Decisions baked in (with judgement):
+ * - SVG is sized via viewBox; the parent `<WidgetShell>` provides the
+ *   responsive frame and hydration scaffold. We do not animate `width` or
+ *   `height` on the SVG itself — only `cx/cy/x1/y1/...` between layouts.
+ * - "without MCP" arrows use `--color-rule` (tonal, neutral). "with MCP"
+ *   arrows use `--color-accent` (terracotta). This is the one-accent rule.
+ * - Reduced motion: nodes snap between layouts (no spring tail); arrow
+ *   draw-in collapses to opacity. Frame stays the same size either way.
+ * - Mobile (< 480 px): scrubbers stack vertically below the canvas. The
+ *   SVG `viewBox` keeps the graph readable down to 320 px container width.
+ * - A11y: each scrubber is a real `<input type="range">` with a label and
+ *   ARIA-valuenow (Scrubber primitive handles this). The toggle is a real
+ *   `<button>` with `aria-pressed`.
+ */
+
+import { useMemo, useState, useId } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { Scrubber } from "@/components/viz/Scrubber";
+import { SPRING, PRESS } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+type Mode = "without" | "with";
+
+const M_MIN = 1;
+const M_MAX = 6;
+const N_MIN = 1;
+const N_MAX = 10;
+
+// Canvas geometry, in viewBox units. We design at 360×220 — readable down
+// to a 320 px container.
+const VB_W = 360;
+const VB_H = 220;
+const COL_X_LEFT = 60;
+const COL_X_RIGHT = VB_W - 60;
+const HUB_X = VB_W / 2;
+const HUB_Y = VB_H / 2;
+const COL_PADDING_Y = 24;
+
+function nodeY(i: number, count: number) {
+  if (count <= 1) return VB_H / 2;
+  const usable = VB_H - COL_PADDING_Y * 2;
+  return COL_PADDING_Y + (i / (count - 1)) * usable;
+}
+
+export function MxNExplorer() {
+  const reduce = useReducedMotion();
+  const [m, setM] = useState(4);
+  const [n, setN] = useState(9);
+  const [mode, setMode] = useState<Mode>("without");
+  const arrowMarkerId = useId();
+
+  const withoutCount = m * n;
+  const withCount = m + n;
+  const currentCount = mode === "with" ? withCount : withoutCount;
+  const delta = withoutCount - withCount;
+
+  const hosts = useMemo(
+    () => Array.from({ length: m }, (_, i) => ({ id: `h${i}`, x: COL_X_LEFT, y: nodeY(i, m) })),
+    [m],
+  );
+  const tools = useMemo(
+    () => Array.from({ length: n }, (_, i) => ({ id: `t${i}`, x: COL_X_RIGHT, y: nodeY(i, n) })),
+    [n],
+  );
+
+  // Edge list. In `without` mode we draw every (host, tool) pair. In `with`
+  // mode we draw host→hub and hub→tool — the star.
+  const edges = useMemo(() => {
+    if (mode === "without") {
+      const out: { id: string; x1: number; y1: number; x2: number; y2: number }[] = [];
+      for (const h of hosts) {
+        for (const t of tools) {
+          out.push({ id: `${h.id}-${t.id}`, x1: h.x, y1: h.y, x2: t.x, y2: t.y });
+        }
+      }
+      return out;
+    }
+    const out: { id: string; x1: number; y1: number; x2: number; y2: number }[] = [];
+    for (const h of hosts) {
+      out.push({ id: `${h.id}-hub`, x1: h.x, y1: h.y, x2: HUB_X, y2: HUB_Y });
+    }
+    for (const t of tools) {
+      out.push({ id: `hub-${t.id}`, x1: HUB_X, y1: HUB_Y, x2: t.x, y2: t.y });
+    }
+    return out;
+  }, [mode, hosts, tools]);
+
+  const edgeColor =
+    mode === "with"
+      ? "var(--color-accent)"
+      : "color-mix(in oklab, var(--color-text-muted) 50%, transparent)";
+
+  const measurements =
+    mode === "without"
+      ? `${withoutCount} adapters`
+      : `${withCount} adapters · −${delta}`;
+
+  const canvas = (
+    <div className="w-full" style={{ minHeight: 220 }}>
+      <svg
+        viewBox={`0 0 ${VB_W} ${VB_H}`}
+        width="100%"
+        height="100%"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={
+          mode === "with"
+            ? `Star topology — ${m} hosts and ${n} tools all route through one hub. ${withCount} arrows total.`
+            : `Bipartite graph — ${m} hosts each wire to all ${n} tools. ${withoutCount} arrows total.`
+        }
+        style={{ display: "block", maxHeight: 320 }}
+      >
+        <defs>
+          {/* Tiny arrowhead, sized to look right at 1.25px stroke. */}
+          <marker
+            id={arrowMarkerId}
+            viewBox="0 0 6 6"
+            refX="5.5"
+            refY="3"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L6,3 L0,6 Z" fill={edgeColor} />
+          </marker>
+        </defs>
+
+        {/* Edges. */}
+        {edges.map((e) => (
+          <motion.line
+            key={`${mode}:${e.id}`}
+            x1={e.x1}
+            y1={e.y1}
+            x2={e.x2}
+            y2={e.y2}
+            stroke={edgeColor}
+            strokeWidth={1.25}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            initial={reduce ? { opacity: 0 } : { opacity: 0, pathLength: 0 }}
+            animate={reduce ? { opacity: 0.9 } : { opacity: 0.9, pathLength: 1 }}
+            transition={reduce ? { duration: 0 } : { ...SPRING.smooth }}
+          />
+        ))}
+
+        {/* Hub — only in `with` mode. Slightly larger than nodes; terracotta
+            outlined to read as "the protocol". */}
+        {mode === "with" ? (
+          <motion.g
+            initial={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+            style={{ transformOrigin: `${HUB_X}px ${HUB_Y}px`, transformBox: "fill-box" }}
+          >
+            <rect
+              x={HUB_X - 9}
+              y={HUB_Y - 9}
+              width={18}
+              height={18}
+              fill="var(--color-accent)"
+              opacity={0.18}
+              rx={2}
+            />
+            <rect
+              x={HUB_X - 9}
+              y={HUB_Y - 9}
+              width={18}
+              height={18}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth={1.5}
+              vectorEffect="non-scaling-stroke"
+              rx={2}
+            />
+            <text
+              x={HUB_X}
+              y={HUB_Y + 22}
+              textAnchor="middle"
+              fontSize="9"
+              fill="var(--color-text-muted)"
+              fontFamily="var(--font-mono)"
+            >
+              MCP
+            </text>
+          </motion.g>
+        ) : null}
+
+        {/* Hosts column. */}
+        {hosts.map((h, i) => (
+          <motion.g
+            key={h.id}
+            initial={false}
+            animate={{ x: 0, y: 0 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+          >
+            <circle
+              cx={h.x}
+              cy={h.y}
+              r={5}
+              fill="var(--color-text)"
+              opacity={0.85}
+            />
+            {i === 0 ? (
+              <text
+                x={h.x}
+                y={COL_PADDING_Y - 8}
+                textAnchor="middle"
+                fontSize="9"
+                fill="var(--color-text-muted)"
+                fontFamily="var(--font-mono)"
+              >
+                hosts
+              </text>
+            ) : null}
+          </motion.g>
+        ))}
+
+        {/* Tools column. */}
+        {tools.map((t, i) => (
+          <motion.g
+            key={t.id}
+            initial={false}
+            animate={{ x: 0, y: 0 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+          >
+            <circle
+              cx={t.x}
+              cy={t.y}
+              r={5}
+              fill="var(--color-text)"
+              opacity={0.85}
+            />
+            {i === 0 ? (
+              <text
+                x={t.x}
+                y={COL_PADDING_Y - 8}
+                textAnchor="middle"
+                fontSize="9"
+                fill="var(--color-text-muted)"
+                fontFamily="var(--font-mono)"
+              >
+                tools
+              </text>
+            ) : null}
+          </motion.g>
+        ))}
+      </svg>
+    </div>
+  );
+
+  const onToggle = () => {
+    playSound("Click");
+    setMode((m) => (m === "with" ? "without" : "with"));
+  };
+
+  return (
+    <WidgetShell
+      title="M × N adapters, before and after one protocol"
+      measurements={measurements}
+      caption={
+        mode === "with" ? (
+          <>
+            With one protocol between hosts and tools, every host implements MCP once
+            and every tool exposes itself once. {m} + {n} = {withCount} integrations to write.
+          </>
+        ) : (
+          <>
+            Without a protocol, each (host, tool) pair gets its own bespoke adapter.
+            {" "}{m} × {n} = {withoutCount} integrations to write — and to maintain forever.
+          </>
+        )
+      }
+      controls={
+        <div
+          className="flex w-full flex-wrap items-center gap-x-[var(--spacing-md)] gap-y-[var(--spacing-sm)] justify-center"
+          style={{ maxWidth: 520 }}
+        >
+          <div style={{ minWidth: 200, flex: "1 1 200px" }}>
+            <Scrubber
+              label="M"
+              value={m}
+              min={M_MIN}
+              max={M_MAX}
+              onChange={setM}
+              format={(v) => `${v} host${v === 1 ? "" : "s"}`}
+            />
+          </div>
+          <div style={{ minWidth: 200, flex: "1 1 200px" }}>
+            <Scrubber
+              label="N"
+              value={n}
+              min={N_MIN}
+              max={N_MAX}
+              onChange={setN}
+              format={(v) => `${v} tool${v === 1 ? "" : "s"}`}
+            />
+          </div>
+          <motion.button
+            type="button"
+            onClick={onToggle}
+            aria-pressed={mode === "with"}
+            aria-label={mode === "with" ? "Disable MCP — see M × N adapters" : "Enable MCP — collapse to M + N"}
+            className="font-sans inline-flex items-center justify-center rounded-[var(--radius-md)] px-[var(--spacing-md)] py-[var(--spacing-2xs)] min-h-[36px]"
+            style={{
+              fontSize: "var(--text-ui)",
+              border: "1px solid var(--color-accent)",
+              background:
+                mode === "with"
+                  ? "color-mix(in oklab, var(--color-accent) 18%, transparent)"
+                  : "transparent",
+              color: mode === "with" ? "var(--color-accent)" : "var(--color-text)",
+              cursor: "pointer",
+            }}
+            {...PRESS}
+          >
+            {mode === "with" ? "with MCP ✓" : "with MCP"}
+          </motion.button>
+          <span
+            className="font-mono tabular-nums"
+            aria-live="polite"
+            style={{
+              fontSize: "var(--text-small)",
+              color: "var(--color-text-muted)",
+              minWidth: "8ch",
+              textAlign: "right",
+            }}
+          >
+            {currentCount}
+            {mode === "with" ? ` (−${delta})` : ""}
+          </span>
+        </div>
+      }
+    >
+      {canvas}
+    </WidgetShell>
+  );
+}
+
+export default MxNExplorer;

--- a/app/courses/mcps/_content/the-room-before-the-protocol/widgets/PreMcpQuiz.tsx
+++ b/app/courses/mcps/_content/the-room-before-the-protocol/widgets/PreMcpQuiz.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * PreMcpQuiz — premise-quiz opener for chapter 1 (voice §12.1).
+ *
+ * Shows a 12-line LangChain-style tool-registration snippet from 2023, then
+ * asks: "to add one new tool — getSlackThread() — what changes?" Most
+ * readers underestimate. The verdict on every wrong pick creates the demand
+ * for the chapter's reframe (M·N → M+N).
+ *
+ * Reuses the shipped <Quiz> primitive (components/widgets/Quiz.tsx) — that
+ * primitive already handles the radiogroup a11y, reduced-motion fallback,
+ * frame-stable verdict slot, and the one-accent terracotta highlight. We
+ * just supply question + options + verdicts.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const SNIPPET = `// agent.ts — a 2023-style LangChain agent
+import { initializeAgentExecutorWithOptions } from "langchain/agents";
+import { ChatOpenAI } from "@langchain/openai";
+import { searchFlights } from "./tools/searchFlights";
+import { lookupWeather } from "./tools/lookupWeather";
+
+const tools = [searchFlights, lookupWeather];
+const llm = new ChatOpenAI({ model: "gpt-4", temperature: 0 });
+
+export const agent = await initializeAgentExecutorWithOptions(tools, llm, {
+  agentType: "openai-functions",
+});`;
+
+export function PreMcpQuiz() {
+  return (
+    <WidgetShell
+      title="Pre-MCP, what does adding one tool actually cost?"
+      caption={
+        <>
+          Predict before you read on. The chapter exists because most teams in
+          2023 paid this bill three times — once per host — and stopped
+          noticing.
+        </>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        {/* Code snippet — read-only, monospace, scoped styling. */}
+        <pre
+          className="font-mono"
+          style={{
+            fontSize: "var(--text-small)",
+            lineHeight: 1.55,
+            background: "var(--color-surface)",
+            padding: "var(--spacing-md)",
+            borderRadius: "var(--radius-md)",
+            overflowX: "auto",
+            margin: 0,
+            color: "var(--color-text)",
+          }}
+        >
+          <code>{SNIPPET}</code>
+        </pre>
+
+        <Quiz
+          question={
+            <p
+              className="font-serif"
+              style={{
+                fontSize: "var(--text-body)",
+                lineHeight: 1.55,
+                margin: 0,
+              }}
+            >
+              You want to add <code style={{ fontFamily: "var(--font-mono)" }}>getSlackThread()</code> as a new
+              tool. What actually changes — and where do the redeploys land?
+            </p>
+          }
+          correctId="three-layers"
+          rightVerdict={
+            <>
+              Right. The agent code grows; the agent process redeploys; the
+              host frontend (or whatever surfaces the tool to the user) often
+              needs an update too. <em>Three layers</em>. And every other host
+              that wants the same tool — Cursor, an internal Slack bot — pays
+              the bill again.
+            </>
+          }
+          wrongVerdict={
+            <>
+              The honest answer is <em>three layers</em>: the tool file, the
+              agent registration + redeploy, and the host surface that exposes
+              it. And every other host that wants this tool re-plumbs the same
+              three layers. That's the bill MCP is here to stop charging.
+            </>
+          }
+          options={[
+            {
+              id: "register-only",
+              label: "Just register it on the agent — no redeploy needed.",
+            },
+            {
+              id: "tool-and-agent",
+              label: "Add the tool file, redeploy the agent process. Done.",
+            },
+            {
+              id: "three-layers",
+              label:
+                "Tool file, agent redeploy, plus the host surface that exposes it — three layers move.",
+            },
+            {
+              id: "everywhere",
+              label:
+                "Every consumer (Claude, Cursor, your bot) ships its own integration. They don't share code.",
+            },
+          ]}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default PreMcpQuiz;

--- a/content/courses-manifest.ts
+++ b/content/courses-manifest.ts
@@ -50,21 +50,21 @@ export const COURSES: CourseMeta[] = [
         slug: "the-room-before-the-protocol",
         title: "The room before the protocol",
         hook:
-          "before MCP, every AI integration was a one-off — and your terminal already hides the receipt.",: chapter 3 — JSON-RPC, the wire that carries it): chapter 4 — The handshake)
+          "before MCP, every AI integration was a one-off — and your terminal already hides the receipt.",
         readingMinutes: 8,
       },
       {
         slug: "host-client-server",
         title: "Three roles, one connection",
         hook:
-          "MCP isn't peer-to-peer. it's a host that spawns one client per server.",: chapter 3 — JSON-RPC, the wire that carries it): chapter 4 — The handshake)
+          "MCP isn't peer-to-peer. it's a host that spawns one client per server.",
         readingMinutes: 10,
       },
       {
         slug: "json-rpc-the-wire",
         title: "JSON-RPC, the wire that carries it",
         hook:
-          "every MCP message is JSON-RPC 2.0. four fields are the whole story.",: chapter 3 — JSON-RPC, the wire that carries it): chapter 4 — The handshake)
+          "every MCP message is JSON-RPC 2.0. four fields are the whole story.",
         readingMinutes: 12,
       },
       {
@@ -77,7 +77,7 @@ export const COURSES: CourseMeta[] = [
       {
         slug: "the-server-primitives",
         title: "Tools, resources, prompts",
-        hook: "three primitives, three controllers — model, application, user.",: chapter 4 — The handshake)
+        hook: "three primitives, three controllers — model, application, user.",
         readingMinutes: 14,
       },
       {
@@ -105,7 +105,7 @@ export const COURSES: CourseMeta[] = [
         slug: "how-mcp-gets-attacked",
         title: "How MCP gets attacked",
         hook:
-          "MCP is a protocol, not a perimeter. the spec says SHOULD; you ship the MUST.",: chapter 3 — JSON-RPC, the wire that carries it): chapter 4 — The handshake)
+          "MCP is a protocol, not a perimeter. the spec says SHOULD; you ship the MUST.",
         readingMinutes: 12,
       },
     ],


### PR DESCRIPTION
Resolves #70.

## Summary
Chapter 1 of the MCPs mini-course. Establishes the per-slug content-module pattern: each chapter renders into the dynamic chapter route via a static-imported Content module under `app/courses/mcps/_content/<slug>/`. A tiny registry (`chapter-content-map.ts`) keys `${courseSlug}/${chapterSlug}` to a server-component module; chapters without a module fall through to the existing placeholder body.

## Widgets shipped
- **`MxNExplorer`** (load-bearing) — two scrubbers (M = hosts 1–6, N = tools 1–10) drive a bipartite SVG; "with MCP" toggle collapses M·N arrows to M+N through a hub. Live arrow count + delta in the WidgetShell measurements slot. Reduced-motion snaps; mobile stacks.
- **`PreMcpQuiz`** — premise-quiz opener over a 2023-style LangChain snippet, four plausible misreads. Wrong-pick verdict creates demand for the chapter's reframe.
- **`AdapterTimeline`** — 4-step scripted stepper (direct REST → OpenAPI plugins → function-calling → LangChain tools) with `what moved` / `what stayed bespoke` columns per era; built on `<WidgetNav>`.
- **`IntegrationCountQuiz`** — comprehension check (1 vs 3, three hosts and a new SaaS).

## Manifest changes
- Course title `"Model Context Protocols"` → `"Model Context Protocol"` (singular, per the spec/Anthropic copy and brainstormer recommendation).
- Course `level` bumped from `intro` to `intermediate` (course spans intro→advanced).
- Replaced the placeholder 5-chapter list with the brainstormer's 9-chapter plan (slugs only — chapters 2–9 still render the placeholder until their own PRs land).

## Voice & a11y
Premise-quiz opener (voice §12.1), `<Term>` on first appearance of MCP / host / client / server / JSON-RPC, mechanism-first reframe (M·N → M+N before naming the elevator pitch), no `<hr>` / `<br>` / horizontal section dividers, single accent (terracotta), reduced-motion fallback verified, scrubbers as real `<input type="range">` with ARIA-valuenow, toggle as real `<button>` with `aria-pressed`.

## Validation
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — green; `/courses/mcps/the-room-before-the-protocol` listed under SSG
- `rg VerticalCutReveal app/courses/mcps/_content/` — zero matches
- `rg "<hr|<br" app/courses/mcps/_content/the-room-before-the-protocol/` — zero matches (only one comment mention)
- Local dev (port 3002): chapter HTTP 200, all four widgets present in the rendered HTML, course landing reflects new manifest

## Out of scope
- Architecture roles formal definition (chapter 2)
- JSON-RPC shape (chapter 3) — the `tools/list` glimpse here is visual only
- Runnable code (chapter 6 is the first runnable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)