### PR TITLE
feat(courses/mcps): chapter 2 — Three roles, one connection

### DIFF
--- a/app/courses/[courseSlug]/[chapterSlug]/page.tsx
+++ b/app/courses/[courseSlug]/[chapterSlug]/page.tsx
@@ -7,7 +7,24 @@ import { ChapterTopRule } from "@/components/courses/ChapterTopRule";
 import { ChapterNav } from "@/components/courses/ChapterNav";
 import { Prose } from "@/components/prose";
 import { SITE_NAME } from "@/lib/site";
+import { MCPS_CONTENT } from "@/app/courses/mcps/_content/registry";
 import "@/components/courses/course-canvas.css";
+
+/**
+ * Per-course content registry. Looks up an authored Content component for
+ * a given (courseSlug, chapterSlug) pair. Returns null if the chapter has
+ * no authored body yet — the route falls back to the placeholder paragraph
+ * in that case.
+ */
+function getChapterContent(
+  courseSlug: string,
+  chapterSlug: string,
+): React.ComponentType | null {
+  if (courseSlug === "mcps") {
+    return MCPS_CONTENT[chapterSlug] ?? null;
+  }
+  return null;
+}
 
 /**
  * Chapter page.
@@ -130,21 +147,29 @@ export default async function CourseChapterPage({
             {chapter.hook}
           </p>
 
-          {/* Placeholder body */}
-          <p
-            className="font-serif"
-            style={{
-              fontSize: "var(--text-body)",
-              lineHeight: 1.7,
-              color: "var(--color-text)",
-              margin: 0,
-            }}
-          >
-            Chapter content lands in a follow-up task. This page is the
-            layout shell — the navigation works end-to-end, your progress is
-            tracked locally, and the typography is in place. Real prose, with
-            an embedded interactive widget, will land here next.
-          </p>
+          {(() => {
+            const Content = getChapterContent(course.slug, chapter.slug);
+            if (Content) {
+              return <Content />;
+            }
+            return (
+              <p
+                className="font-serif"
+                style={{
+                  fontSize: "var(--text-body)",
+                  lineHeight: 1.7,
+                  color: "var(--color-text)",
+                  margin: 0,
+                }}
+              >
+                Chapter content lands in a follow-up task. This page is the
+                layout shell — the navigation works end-to-end, your
+                progress is tracked locally, and the typography is in
+                place. Real prose, with an embedded interactive widget,
+                will land here next.
+              </p>
+            );
+          })()}
         </div>
       </Prose>
 

--- a/app/courses/mcps/_content/host-client-server/Content.tsx
+++ b/app/courses/mcps/_content/host-client-server/Content.tsx
@@ -1,0 +1,279 @@
+/**
+ * Chapter 2 — "Three roles, one connection" — body content.
+ *
+ * Server component. Imports its three widgets (which are "use client").
+ * Prose voice follows voice-profile.md §12.1 (premise-quiz opener) +
+ * §12.2 (mechanism-first) + §12.6 (widget-prose ramp). No <hr>, no <br>,
+ * no horizontal section dividers (post-r4 rule).
+ *
+ * One <Aside> for the spec-name pedantry per the issue brief; the rest of
+ * the prose is the load-bearing path. Code sample is a 6-line Claude
+ * Desktop config showing two servers (filesystem + postgres). The TS-only
+ * default doesn't apply to this snippet — the file format is JSON; we
+ * render it with `lang="json"` (registered in lib/shiki.ts).
+ */
+
+import {
+  P,
+  H2,
+  Code,
+  Em,
+  Aside,
+  Term,
+} from "@/components/prose";
+import { CodeBlock } from "@/components/code/CodeBlock";
+import { TextHighlighter } from "@/components/fancy/text-highlighter";
+import { RoleQuiz } from "./widgets/RoleQuiz";
+import { TopologyBuilder } from "./widgets/TopologyBuilder";
+import { SessionLifecycleStrip } from "./widgets/SessionLifecycleStrip";
+import { ComprehensionCheck } from "./widgets/ComprehensionCheck";
+import { ChapterCliffhanger } from "./widgets/ChapterCliffhanger";
+
+const HL_TRANSITION = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR =
+  "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/** Highlight a load-bearing phrase. Default ltr swipe, spring, inView once. */
+function HL({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      transition={HL_TRANSITION}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+const CONFIG_SNIPPET = `{
+  "mcpServers": {
+    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/code"] },
+    "postgres":   { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-postgres", "postgres://localhost/dev"] }
+  }
+}`;
+
+export function Content() {
+  return (
+    <>
+      {/* §0 — premise-quiz opener (voice §12.1) */}
+      <P>
+        Before we define anything, try this. You open Cursor and ask the AI
+        to grep your codebase. Three things have to happen on the wire — and
+        most readers can't name <em>which</em> piece is which.{" "}
+        <HL>The gap between your guess and the truth is the rest of this chapter.</HL>
+      </P>
+
+      <RoleQuiz />
+
+      {/* §1 — the misconception */}
+      <H2>"MCP is like an API." It isn't.</H2>
+
+      <P>
+        Almost every reader walks in with the same wrong mental model: MCP
+        is just an API the LLM calls. It's the closest thing they have to
+        an analogy, so it sticks. The trouble is: APIs are <em>stateless</em>
+        . You hit an endpoint, the server answers, the conversation is over.
+        Two requests in a row don't know about each other unless you carry
+        the state yourself.
+      </P>
+
+      <P>
+        MCP is the opposite. <HL>An MCP exchange is a stateful session</HL>{" "}
+        between three named roles — host, client, and server — that lasts as
+        long as your editor is open. The session begins with a handshake,
+        the two sides agree on a protocol version and what each is capable
+        of, and from then on every message is interpreted in the context of
+        that agreement. Drop the connection and you've lost the agreement;
+        you can't pick up where you left off without re-handshaking.
+      </P>
+
+      <Aside>
+        The spec word for this is a <Term>stateful session</Term>. The
+        2025-06-18 specification of the Model Context Protocol calls it that
+        in §<Code>basic.lifecycle</Code>; we'll see the handshake's actual
+        JSON in chapter 4. For this chapter, it's enough to know that{" "}
+        <em>stateful</em> means the wire remembers — and that the rest of
+        the protocol is built on top of that memory.
+      </Aside>
+
+      {/* §2 — the host */}
+      <H2>The host is what the human looks at.</H2>
+
+      <P>
+        A <Term>host</Term> is the application sitting in front of a human
+        user — Claude Desktop, VS Code, Cursor, Zed, Replit, Codeium,
+        Sourcegraph. It owns the LLM call. It owns the chat UI. It owns the
+        user's trust posture: when a tool wants to write to disk, it's the
+        host that asks "are you sure?". <HL>Whatever runs the model and
+        renders the conversation — that's the host.</HL>
+      </P>
+
+      <P>
+        The reader's first wrong guess almost always lives here: people
+        suspect the LLM <em>itself</em> is the host. It isn't. The LLM is a
+        callable resource the host owns; from MCP's point of view, the LLM
+        sits on the host's side of the wall, not on the wire. MCP doesn't
+        define how the host talks to the model. That's the host's business.
+        MCP only defines how the host talks to <em>everything else</em>.
+      </P>
+
+      {/* §3 — the server */}
+      <H2>The server is a separate process or service.</H2>
+
+      <P>
+        A <Term>server</Term> is anything outside the host that exposes a
+        capability the host wants. A <Code>filesystem</Code> server is a
+        small Node process that knows how to read and write files. A{" "}
+        <Code>postgres</Code> server speaks SQL to a local database. A{" "}
+        <Code>sentry</Code> server is a remote service that knows how to
+        fetch error events from your account. <HL>Local or remote, in-house
+        or third-party — from the host's view it's just "a server".</HL>
+      </P>
+
+      <P>
+        Servers don't run inside the host. That's deliberate. A server is a{" "}
+        <em>different process</em>, possibly on a different machine, often
+        written by a different team. It crashes independently. It's
+        upgraded independently. It can be replaced without touching the host
+        — which is how Anthropic's marketing line "USB-C for AI" earns its
+        keep: change the peripheral, the device doesn't care.
+      </P>
+
+      {/* §4 — the client */}
+      <H2>The client is the connection, living inside the host.</H2>
+
+      <P>
+        Here's the piece readers most often miss. The <Term>client</Term> is
+        not a separate program; it's not the LLM; it's not a network
+        library. <HL>The client is a small connection-manager object the
+        host instantiates — one per server.</HL> If the host has three
+        servers configured, the host spins up three clients on launch. Each
+        client owns one connection, one session, one negotiated set of
+        capabilities, one live tool list. Two servers, two clients. Five
+        servers, five clients.
+      </P>
+
+      <P>
+        This is the load-bearing claim of the chapter and it's worth saying
+        once more: <em>one client per server, exactly</em>. Not one shared
+        client that fans out. Not a pool. A dedicated, in-memory connection
+        manager per configured server, all of them living inside the same
+        host process.
+      </P>
+
+      <H2>Why one client per server?</H2>
+
+      <P>
+        Three reasons, all paid off in later chapters. First, <em>state
+        isolation</em>: each connection negotiates its own protocol version
+        and capabilities at startup. The filesystem server might support
+        prompts; the Postgres one might not. Mixing those into a single
+        client would force the host to track per-server flags everywhere —
+        the per-client object <em>is</em> that state.
+      </P>
+
+      <P>
+        Second, <Term>capability negotiation</Term>. We'll dissect the
+        handshake in chapter 4; for now: each session begins with the
+        client and server telling each other what they can do, and the
+        result of that exchange becomes the rules for the rest of the
+        session. Sharing one client across two servers would mean two
+        different rule-sets fighting over the same object.
+      </P>
+
+      <P>
+        Third, <Term>transport</Term> isolation. One server might run
+        locally over a Unix pipe; another might run remotely over HTTP.
+        Pooling them would force one side to know about the other's wire
+        format. Keeping them separate lets the host treat both the same
+        way: <em>here is a client, ask it things</em>.
+      </P>
+
+      {/* §5 — load-bearing widget: TopologyBuilder */}
+      <P>
+        The widget below makes this concrete. There's a host card with no
+        servers attached. Tap a server in the palette: a client badge
+        appears inside the host, an arrow connects it to the server, and
+        the status badge updates. Toggle the server between local and
+        remote — notice the host doesn't move. <HL>Transport is the
+        server's concern, not the host's.</HL>
+      </P>
+
+      <TopologyBuilder />
+
+      <P>
+        Three servers on the canvas, three clients inside the host, three
+        live connections. Mark that picture: it's the picture every chapter
+        from here forward draws on top of. When chapter 5 introduces tools,
+        resources, and prompts, those primitives all live on{" "}
+        <em>one of these arrows</em>. When chapter 7 chooses a transport,
+        it's choosing what one of these arrows is made of.
+      </P>
+
+      {/* §6 — the lifecycle */}
+      <H2>What happens on a single connection, in time.</H2>
+
+      <P>
+        We've drawn the topology — <em>where</em> the pieces are. Now zoom
+        in on one of those arrows and ask: <em>what does it carry, and
+        when?</em> Every client–server connection moves through five
+        ticks. Step through them.
+      </P>
+
+      <SessionLifecycleStrip />
+
+      <P>
+        Tick three is the load-bearing one and it's where chapter 4 will
+        live. <HL>What gets agreed during <em>initialize</em> is what the
+        rest of the session is allowed to do.</HL> Skip the handshake and
+        nothing else works; corrupt the handshake and chapter 9's attack
+        classes get their opening. For now, it's enough to see that
+        <em> exchange</em> sits on top of <em>initialize</em> — the order
+        is not optional.
+      </P>
+
+      {/* §7 — the canonical config */}
+      <H2>The mental model fits in a config file.</H2>
+
+      <P>
+        If the topology builder is the picture, this is the same picture in
+        text. Most hosts read a JSON config keyed by server name; each block
+        is one server, and on launch the host instantiates one client per
+        block. Two entries means two clients. The shape is the model:
+      </P>
+
+      <CodeBlock
+        code={CONFIG_SNIPPET}
+        lang="json"
+        filename="claude_desktop_config.json"
+      />
+
+      <P>
+        Two servers configured, two clients spawned at startup, two
+        independent sessions live for as long as the host is open. The
+        config doesn't mention transports because the host figures that out
+        from the entry's shape — a <Code>command</Code> means a local
+        process over stdio; a <Code>url</Code> would mean a remote service
+        over HTTP. Same JSON shape; different wire on the other side of the
+        client.
+      </P>
+
+      {/* §8 — comprehension check */}
+      <H2>Check your read.</H2>
+
+      <P>
+        One question to lock the topology in. Predict, then reveal.
+      </P>
+
+      <ComprehensionCheck />
+
+      {/* §9 — cliffhanger */}
+      <ChapterCliffhanger />
+    </>
+  );
+}
+
+export default Content;

--- a/app/courses/mcps/_content/host-client-server/widgets/ChapterCliffhanger.tsx
+++ b/app/courses/mcps/_content/host-client-server/widgets/ChapterCliffhanger.tsx
@@ -1,0 +1,80 @@
+/**
+ * ChapterCliffhanger — closing block that loops chapter 2 forward to
+ * chapter 3. Voice-profile §12.8 + ban on VerticalCutReveal: the closer
+ * is still prose with one italic line, not a staggered reveal animation.
+ *
+ * Server component (no "use client"). Pure markup — no interactive layer.
+ */
+
+import Link from "next/link";
+
+export function ChapterCliffhanger() {
+  return (
+    <section
+      aria-label="next chapter"
+      className="mt-[var(--spacing-2xl)]"
+    >
+      <p
+        className="font-serif"
+        style={{
+          fontSize: "var(--text-body)",
+          lineHeight: 1.65,
+          color: "var(--color-text)",
+          margin: 0,
+        }}
+      >
+        We've drawn the topology. Three roles — host, client, server — and
+        one connection between each client–server pair. Carry that picture
+        forward; chapter 3 starts on top of it.
+      </p>
+
+      <p
+        className="mt-[var(--spacing-md)] font-serif italic"
+        style={{
+          fontSize: "var(--text-medium)",
+          color: "var(--color-text-muted)",
+          lineHeight: 1.55,
+          maxWidth: "55ch",
+          margin: "var(--spacing-md) 0 0 0",
+        }}
+      >
+        Now: what flows across each of those connections, and in what
+        shape?
+      </p>
+
+      <p
+        className="mt-[var(--spacing-lg)] font-mono"
+        style={{
+          fontSize: "var(--text-small)",
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+          margin: 0,
+        }}
+      >
+        chapter 3 ·{" "}
+        <Link
+          href="/courses/mcps/json-rpc-the-wire"
+          className="no-underline hover:text-[color:var(--color-accent)]"
+          style={{ color: "var(--color-text)" }}
+        >
+          JSON-RPC, the wire that carries it
+          <span aria-hidden> →</span>
+        </Link>
+      </p>
+
+      <p className="mt-[var(--spacing-md)] flex justify-center" aria-hidden>
+        <span
+          className="block"
+          style={{
+            width: 6,
+            height: 6,
+            background: "var(--color-accent)",
+          }}
+        />
+      </p>
+    </section>
+  );
+}
+
+export default ChapterCliffhanger;

--- a/app/courses/mcps/_content/host-client-server/widgets/ComprehensionCheck.tsx
+++ b/app/courses/mcps/_content/host-client-server/widgets/ComprehensionCheck.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * ComprehensionCheck — end-of-chapter predict-and-reveal for chapter 2.
+ *
+ * "Cursor opens with three MCP servers configured. How many clients does
+ * Cursor instantiate, and why?" Reuses the shared <Quiz> primitive. Voice
+ * §12.6 — the comprehension check seals the chapter's load-bearing claim
+ * (one client per server). Each wrong-answer verdict gently corrects the
+ * specific misconception that option models.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const PROMPT = (
+  <p
+    className="font-serif"
+    style={{
+      fontSize: "var(--text-body)",
+      lineHeight: 1.6,
+      color: "var(--color-text)",
+      margin: 0,
+    }}
+  >
+    Cursor opens with three MCP servers configured in its settings. How
+    many clients does Cursor instantiate, and why?
+  </p>
+);
+
+const OPTIONS = [
+  {
+    id: "three",
+    label: (
+      <span>
+        Three — one client per configured server, each managing its own
+        connection state.
+      </span>
+    ),
+  },
+  {
+    id: "one",
+    label: <span>One — Cursor pools requests across servers.</span>,
+  },
+  {
+    id: "six",
+    label: (
+      <span>Six — one client for sending and one for receiving per server.</span>
+    ),
+  },
+  {
+    id: "zero",
+    label: (
+      <span>
+        Zero until the user invokes a tool — clients are lazy.
+      </span>
+    ),
+  },
+];
+
+const RIGHT_VERDICT = (
+  <span>
+    Three. State, capabilities, and transport all live on the connection.
+    Pooling them would lose the isolation the protocol depends on. Carry
+    that picture into chapter 3.
+  </span>
+);
+
+export function ComprehensionCheck() {
+  return (
+    <WidgetShell
+      title="check · how many clients?"
+      measurements="3 servers · ?"
+      captionTone="muted"
+      caption={<span>predict, then pick.</span>}
+    >
+      <div className="px-[var(--spacing-xs)] pt-[var(--spacing-xs)] pb-[var(--spacing-sm)]">
+        <Quiz
+          question={PROMPT}
+          options={OPTIONS}
+          correctId="three"
+          rightVerdict={RIGHT_VERDICT}
+          wrongVerdict={
+            <span>
+              The right answer is <strong>three</strong>. State,
+              capabilities, and transport all live on the connection;
+              pooling them would lose the isolation the protocol depends
+              on. Pooling them would force the host to track per-server
+              flags everywhere — and the per-client object{" "}
+              <em>is</em> that state.
+            </span>
+          }
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default ComprehensionCheck;

--- a/app/courses/mcps/_content/host-client-server/widgets/RoleQuiz.tsx
+++ b/app/courses/mcps/_content/host-client-server/widgets/RoleQuiz.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * RoleQuiz — premise-quiz opener for chapter 2 of the MCPs course.
+ *
+ * Asks "in Cursor, when you ask the AI to grep your codebase, who's the
+ * host, who's the client, who's the server?" Four plausible options — each
+ * modelling a real wrong mental model the reader walks in with. The wrong
+ * verdict creates demand for the rest of the chapter; voice-profile §12.1.
+ *
+ * Wraps the shared <Quiz> primitive (components/widgets/Quiz). All a11y,
+ * frame-stability, reduced-motion handling lives there. This file owns the
+ * teaching content only.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { Code } from "@/components/prose";
+
+const PROMPT = (
+  <p
+    className="font-serif"
+    style={{
+      fontSize: "var(--text-body)",
+      lineHeight: 1.6,
+      color: "var(--color-text)",
+      margin: 0,
+    }}
+  >
+    You open Cursor and ask the AI to grep your codebase. Behind the scenes,
+    Cursor talks to a filesystem MCP server through a small connection
+    manager. Map the three roles — <strong>host</strong>,{" "}
+    <strong>client</strong>, <strong>server</strong> — to the three actors.
+  </p>
+);
+
+const OPTIONS = [
+  {
+    id: "correct",
+    label: (
+      <span>
+        host = <Code>Cursor</Code>; client = the in-Cursor connection
+        manager; server = the filesystem process.
+      </span>
+    ),
+  },
+  {
+    id: "cursor-server",
+    label: (
+      <span>
+        host = your code; client = <Code>Cursor</Code>; server = the
+        Anthropic API.
+      </span>
+    ),
+  },
+  {
+    id: "llm-client",
+    label: (
+      <span>
+        host = the OS; client = the LLM; server = <Code>Cursor</Code>.
+      </span>
+    ),
+  },
+  {
+    id: "fs-host",
+    label: (
+      <span>
+        host = the filesystem process; client = <Code>Cursor</Code>; server
+        = the LLM.
+      </span>
+    ),
+  },
+];
+
+const RIGHT_VERDICT = (
+  <span>
+    Right. The host is the <em>application</em> the human looks at; the
+    client is what the host instantiates per server; the server is the
+    process that exposes a capability. Three roles, one connection — and
+    that connection is what the rest of the chapter is about.
+  </span>
+);
+
+const WRONG_VERDICT = (
+  <span>
+    Most readers miss this. The host is the application the human looks at
+    (Cursor, Claude Desktop, VS Code); the client is what the host
+    instantiates per server — a small connection manager living{" "}
+    <em>inside</em> the host; the server is a separate process or remote
+    service. The LLM is on the host's side of the wall, not on the
+    server's. Read on.
+  </span>
+);
+
+export function RoleQuiz() {
+  return (
+    <WidgetShell
+      title="role quiz · who's who?"
+      measurements="3 roles · 1 connection"
+      captionTone="prominent"
+      caption={
+        <span>
+          Pick the mapping you'd give a teammate. The wrong answers each
+          model a confusion most readers walk in with.
+        </span>
+      }
+    >
+      <div className="px-[var(--spacing-xs)] pt-[var(--spacing-xs)] pb-[var(--spacing-sm)]">
+        <Quiz
+          question={PROMPT}
+          options={OPTIONS}
+          correctId="correct"
+          rightVerdict={RIGHT_VERDICT}
+          wrongVerdict={WRONG_VERDICT}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default RoleQuiz;

--- a/app/courses/mcps/_content/host-client-server/widgets/SessionLifecycleStrip.tsx
+++ b/app/courses/mcps/_content/host-client-server/widgets/SessionLifecycleStrip.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+/**
+ * SessionLifecycleStrip — 5-tick scripted stepper for chapter 2.
+ *
+ * Two lanes — host above, server below — connected by a tick-driven arrow
+ * that flips direction depending on who initiates the message at that
+ * tick. Five ticks: spawn → connect → initialize → exchange → terminate.
+ * Lane chips crossfade per tick to name the local state.
+ *
+ * Frame stability:
+ *  - Lanes use min-height; chip changes are opacity-only, never width/height.
+ *  - The arrow renders inside the SVG with motion-driven `pathLength`.
+ *  - Reduced motion → arrow appears at pathLength 1 instantly; chips
+ *    crossfade with `duration: 0`.
+ *
+ * Mobile (<720px container width): lanes stack vertically; arrows become
+ * down/up between stacked lanes via a CSS rotation on the arrow group.
+ *
+ * Accessibility: aria-current="step" on the active tick (handled by
+ * WidgetNav); a polite live region announces "host: X / server: Y" on tick
+ * change; counterNoun="tick".
+ */
+
+import { useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { SPRING } from "@/lib/motion";
+
+type Tick = {
+  label: string;
+  /** Direction the message flows at this tick. "none" = no message yet/anymore. */
+  dir: "down" | "up" | "none";
+  /** Short text describing what flows. Sits on the arrow. */
+  message: string;
+  /** Host-lane status chip text. */
+  hostChip: string;
+  /** Server-lane status chip text. */
+  serverChip: string;
+};
+
+const TICKS: Tick[] = [
+  {
+    label: "spawn",
+    dir: "none",
+    message: "host launches the server process",
+    hostChip: "host: spawning client #1",
+    serverChip: "server: not yet running",
+  },
+  {
+    label: "connect",
+    dir: "down",
+    message: "open transport (stdio or HTTP)",
+    hostChip: "host: client #1 ready",
+    serverChip: "server: transport open",
+  },
+  {
+    label: "initialize",
+    dir: "down",
+    message: "negotiate protocol + capabilities",
+    hostChip: "host: sent initialize",
+    serverChip: "server: replied with caps",
+  },
+  {
+    label: "exchange",
+    dir: "up",
+    message: "tools/list, tools/call, …",
+    hostChip: "host: calling a tool",
+    serverChip: "server: returning result",
+  },
+  {
+    label: "terminate",
+    dir: "down",
+    message: "close transport, free resources",
+    hostChip: "host: client #1 closed",
+    serverChip: "server: stopped",
+  },
+];
+
+export function SessionLifecycleStrip() {
+  const [tick, setTick] = useState(0);
+  const reduce = useReducedMotion();
+  const t = TICKS[tick];
+
+  return (
+    <WidgetShell
+      title={`session · ${t.label}`}
+      measurements={`tick ${tick + 1} · ${TICKS.length}`}
+      captionTone="prominent"
+      caption={
+        <span>
+          One client–server connection has a lifecycle. Step through the
+          five ticks. The arrow's direction names <em>who</em> sent the
+          message; the chips name what each side now knows.
+        </span>
+      }
+      controls={
+        <WidgetNav
+          value={tick}
+          total={TICKS.length}
+          onChange={setTick}
+          counterNoun="tick"
+          ariaLabel="lifecycle tick controls"
+        />
+      }
+    >
+      <style>{`
+        .bs-life {
+          container-type: inline-size;
+          container-name: life;
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+        }
+        .bs-life-lane {
+          position: relative;
+          display: flex;
+          align-items: center;
+          gap: var(--spacing-sm);
+          min-height: 56px;
+          padding: 10px 14px;
+          border-radius: var(--radius-md);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-surface) 50%, transparent);
+        }
+        .bs-life-lane[data-role="host"] {
+          border-color: color-mix(in oklab, var(--color-accent) 35%, var(--color-rule));
+        }
+        .bs-life-label {
+          flex-shrink: 0;
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          color: var(--color-text-muted);
+          min-width: 4.5ch;
+        }
+        .bs-life-chip {
+          font-family: var(--font-sans, system-ui);
+          font-size: var(--text-ui);
+          color: var(--color-text);
+          line-height: 1.4;
+        }
+        .bs-life-bridge {
+          position: relative;
+          height: 56px;
+        }
+        .bs-life-msg {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          pointer-events: none;
+        }
+      `}</style>
+
+      <div className="bs-life" role="group" aria-label="session lifecycle">
+        {/* HOST LANE */}
+        <div className="bs-life-lane" data-role="host">
+          <span className="bs-life-label">host</span>
+          <motion.span
+            key={`h-${tick}`}
+            className="bs-life-chip"
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+            aria-live="polite"
+          >
+            {t.hostChip}
+          </motion.span>
+        </div>
+
+        {/* BRIDGE — arrow + label between lanes */}
+        <div className="bs-life-bridge" aria-hidden>
+          <svg
+            viewBox="0 0 360 56"
+            width="100%"
+            height="56"
+            preserveAspectRatio="none"
+          >
+            <defs>
+              <marker
+                id="bs-life-arrow-down"
+                viewBox="0 0 10 10"
+                refX="5"
+                refY="9"
+                markerWidth="8"
+                markerHeight="8"
+                orient="auto-start-reverse"
+              >
+                <path
+                  d="M 0 0 L 10 0 L 5 10 z"
+                  fill="var(--color-accent)"
+                />
+              </marker>
+              <marker
+                id="bs-life-arrow-up"
+                viewBox="0 0 10 10"
+                refX="5"
+                refY="1"
+                markerWidth="8"
+                markerHeight="8"
+                orient="auto-start-reverse"
+              >
+                <path
+                  d="M 0 10 L 10 10 L 5 0 z"
+                  fill="var(--color-accent)"
+                />
+              </marker>
+            </defs>
+            {t.dir !== "none" ? (
+              <motion.line
+                key={`arrow-${tick}-${t.dir}`}
+                x1="180"
+                x2="180"
+                y1={t.dir === "down" ? 4 : 52}
+                y2={t.dir === "down" ? 52 : 4}
+                stroke="var(--color-accent)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                markerEnd={
+                  t.dir === "down"
+                    ? "url(#bs-life-arrow-down)"
+                    : "url(#bs-life-arrow-up)"
+                }
+                initial={reduce ? { pathLength: 1 } : { pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={reduce ? { duration: 0 } : SPRING.smooth}
+                vectorEffect="non-scaling-stroke"
+              />
+            ) : (
+              <line
+                x1="180"
+                x2="180"
+                y1="4"
+                y2="52"
+                stroke="var(--color-rule)"
+                strokeWidth="1"
+                strokeDasharray="3 3"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </svg>
+          <div className="bs-life-msg">
+            <motion.span
+              key={`m-${tick}`}
+              initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+              animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+              transition={reduce ? { duration: 0 } : SPRING.smooth}
+              style={{
+                background:
+                  "color-mix(in oklab, var(--color-surface) 90%, transparent)",
+                padding: "2px 8px",
+                borderRadius: "var(--radius-sm)",
+              }}
+            >
+              {t.message}
+            </motion.span>
+          </div>
+        </div>
+
+        {/* SERVER LANE */}
+        <div className="bs-life-lane" data-role="server">
+          <span className="bs-life-label">server</span>
+          <motion.span
+            key={`s-${tick}`}
+            className="bs-life-chip"
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+            transition={reduce ? { duration: 0 } : SPRING.smooth}
+            aria-live="polite"
+          >
+            {t.serverChip}
+          </motion.span>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default SessionLifecycleStrip;

--- a/app/courses/mcps/_content/host-client-server/widgets/TopologyBuilder.tsx
+++ b/app/courses/mcps/_content/host-client-server/widgets/TopologyBuilder.tsx
@@ -1,0 +1,554 @@
+"use client";
+
+/**
+ * TopologyBuilder — load-bearing widget for chapter 2.
+ *
+ * The reader picks servers from a palette; each pick adds a client badge
+ * inside the host card and an arrow to the server card outside. A toggle
+ * on each server flips it between local (stdio) and remote (HTTP) — the
+ * arrow icon morphs (pipe ↔ cloud) but the host doesn't change shape,
+ * driving the load-bearing claim: <transport is the server's concern, not
+ * the host's>.
+ *
+ * Interaction discipline (interactive-components.md §2.2). Native HTML5
+ * drag-and-drop is unreliable on touch and the editorial-calm register
+ * doesn't reward chaos. We ship tap/click-to-add as the universal primary
+ * interaction — works on touch, mouse, and keyboard. Each palette server
+ * is a real <button>: Tab to focus, arrow keys to traverse the palette,
+ * Enter to add, Backspace/Delete (or the visible "remove" button) to
+ * disconnect. The lesson — "you place this server, a client spawns" — is
+ * intact.
+ *
+ * Frame stability (R6): outer card stays the same size whether 0 or 3
+ * servers are connected. The host area reserves space for up to 3 client
+ * badges in a horizontal row; the connections grid reserves space for up
+ * to 3 rows. Reset is always available.
+ *
+ * Reduced motion: badge entrances + arrow draws collapse to opacity-only;
+ * toggle changes are instant.
+ *
+ * One accent: terracotta only. Local vs remote reads via icon shape +
+ * label, never via colour.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+type ServerId = "filesystem" | "postgres" | "sentry";
+type Transport = "local" | "remote";
+
+type ServerDef = {
+  id: ServerId;
+  name: string;
+  /** Default transport when first added. */
+  defaultTransport: Transport;
+};
+
+const SERVERS: ServerDef[] = [
+  { id: "filesystem", name: "Filesystem", defaultTransport: "local" },
+  { id: "postgres", name: "Postgres", defaultTransport: "local" },
+  { id: "sentry", name: "Sentry", defaultTransport: "remote" },
+];
+
+type Connection = {
+  serverId: ServerId;
+  transport: Transport;
+};
+
+const HOST_NAME = "VS Code";
+
+/** Pipe icon — small terminal-pipe glyph for local/stdio transport. */
+function PipeIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      aria-hidden
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    >
+      <path d="M2 8 L14 8" />
+      <path d="M5 5 L5 11" />
+      <path d="M11 5 L11 11" />
+    </svg>
+  );
+}
+
+/** Cloud icon — minimal scribble for remote/HTTP transport. */
+function CloudIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      aria-hidden
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4.5 11.5 a3 3 0 0 1 0.5 -5.95 a3.5 3.5 0 0 1 6.7 0.95 a2.5 2.5 0 0 1 -0.2 5 z" />
+    </svg>
+  );
+}
+
+export function TopologyBuilder() {
+  const reduce = useReducedMotion();
+  const [conns, setConns] = useState<Connection[]>([]);
+  const [announce, setAnnounce] = useState("");
+  const liveRef = useRef<HTMLDivElement | null>(null);
+
+  const connectedIds = useMemo(
+    () => new Set(conns.map((c) => c.serverId)),
+    [conns],
+  );
+
+  const addServer = useCallback(
+    (id: ServerId) => {
+      if (connectedIds.has(id)) return;
+      const def = SERVERS.find((s) => s.id === id);
+      if (!def) return;
+      playSound("Click");
+      setConns((prev) => [
+        ...prev,
+        { serverId: id, transport: def.defaultTransport },
+      ]);
+      setAnnounce(`added ${def.name} as client`);
+    },
+    [connectedIds],
+  );
+
+  const removeServer = useCallback((id: ServerId) => {
+    const def = SERVERS.find((s) => s.id === id);
+    playSound("Click");
+    setConns((prev) => prev.filter((c) => c.serverId !== id));
+    if (def) setAnnounce(`removed ${def.name}`);
+  }, []);
+
+  const toggleTransport = useCallback((id: ServerId) => {
+    playSound("Radio");
+    setConns((prev) =>
+      prev.map((c) =>
+        c.serverId === id
+          ? { ...c, transport: c.transport === "local" ? "remote" : "local" }
+          : c,
+      ),
+    );
+  }, []);
+
+  const reset = useCallback(() => {
+    if (conns.length === 0) return;
+    playSound("Click");
+    setConns([]);
+    setAnnounce("topology reset");
+  }, [conns.length]);
+
+  const measurements = `1 host · ${conns.length} client${conns.length === 1 ? "" : "s"} · ${conns.length} connection${conns.length === 1 ? "" : "s"}`;
+
+  return (
+    <WidgetShell
+      title="topology · build it"
+      measurements={measurements}
+      captionTone="prominent"
+      caption={
+        <span>
+          Tap a server in the palette to connect it. Each pick spawns a{" "}
+          <em>client</em> inside the host. Toggle a server between local
+          (pipe) and remote (cloud) — the host doesn't change shape.
+        </span>
+      }
+      controls={
+        <button
+          type="button"
+          onClick={reset}
+          disabled={conns.length === 0}
+          className="bs-topo-reset"
+          aria-label="reset topology"
+        >
+          ↻ reset
+        </button>
+      }
+    >
+      <style>{`
+        .bs-topo {
+          container-type: inline-size;
+          container-name: topo;
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-md);
+        }
+        .bs-topo-host {
+          position: relative;
+          min-height: 96px;
+          padding: 14px 16px;
+          border-radius: var(--radius-md);
+          border: 1px solid color-mix(in oklab, var(--color-accent) 35%, var(--color-rule));
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+        }
+        .bs-topo-host-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--spacing-sm);
+          margin-bottom: 10px;
+        }
+        .bs-topo-host-name {
+          font-family: var(--font-sans, system-ui);
+          font-size: var(--text-ui);
+          font-weight: 600;
+          color: var(--color-text);
+        }
+        .bs-topo-host-tag {
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          color: var(--color-text-muted);
+        }
+        .bs-topo-clients {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          min-height: 32px;
+        }
+        .bs-topo-client {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 4px 10px;
+          border-radius: var(--radius-sm);
+          background: color-mix(in oklab, var(--color-accent) 14%, transparent);
+          border: 1px solid color-mix(in oklab, var(--color-accent) 35%, transparent);
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          color: var(--color-text);
+        }
+        .bs-topo-client-dot {
+          display: inline-block;
+          width: 6px;
+          height: 6px;
+          border-radius: 999px;
+          background: var(--color-accent);
+        }
+        .bs-topo-empty {
+          font-style: italic;
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          padding: 4px 0;
+        }
+        .bs-topo-section-label {
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          color: var(--color-text-muted);
+          margin-bottom: 6px;
+        }
+        .bs-topo-palette {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 8px;
+        }
+        @container topo (min-width: 480px) {
+          .bs-topo-palette {
+            grid-template-columns: 1fr 1fr 1fr;
+          }
+        }
+        .bs-topo-pal-btn {
+          width: 100%;
+          min-height: 44px;
+          padding: 10px 12px;
+          text-align: left;
+          font-family: var(--font-sans, system-ui);
+          font-size: var(--text-ui);
+          color: var(--color-text);
+          border: 1px dashed var(--color-rule);
+          border-radius: var(--radius-sm);
+          background: transparent;
+          cursor: pointer;
+          transition: background 200ms, border-color 200ms, opacity 200ms;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+        .bs-topo-pal-btn:hover:not(:disabled) {
+          background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+          border-color: color-mix(in oklab, var(--color-accent) 50%, var(--color-rule));
+        }
+        .bs-topo-pal-btn:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-topo-pal-btn:disabled {
+          cursor: default;
+          opacity: 0.45;
+        }
+        .bs-topo-pal-plus {
+          color: var(--color-accent);
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-ui);
+        }
+        .bs-topo-conns {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          min-height: 0;
+        }
+        .bs-topo-conn {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) auto auto;
+          align-items: center;
+          gap: 10px;
+          padding: 10px 12px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: color-mix(in oklab, var(--color-surface) 50%, transparent);
+        }
+        .bs-topo-conn-name {
+          font-family: var(--font-sans, system-ui);
+          font-size: var(--text-ui);
+          color: var(--color-text);
+          font-weight: 500;
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          min-width: 0;
+        }
+        .bs-topo-conn-arrow {
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          color: var(--color-accent);
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+        }
+        .bs-topo-toggle {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          min-height: 32px;
+          padding: 4px 10px;
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          background: transparent;
+          cursor: pointer;
+        }
+        .bs-topo-toggle:hover { color: var(--color-text); }
+        .bs-topo-toggle:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-topo-remove {
+          min-width: 32px;
+          min-height: 32px;
+          padding: 4px 8px;
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          background: transparent;
+          color: var(--color-text-muted);
+          cursor: pointer;
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+        }
+        .bs-topo-remove:hover { color: var(--color-text); }
+        .bs-topo-remove:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-topo-reset {
+          min-height: 36px;
+          padding: 6px 14px;
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          background: transparent;
+          color: var(--color-text-muted);
+          font-family: var(--font-mono, ui-monospace);
+          font-size: var(--text-small);
+          cursor: pointer;
+        }
+        .bs-topo-reset:hover:not(:disabled) { color: var(--color-text); }
+        .bs-topo-reset:disabled { cursor: default; opacity: 0.45; }
+        .bs-topo-reset:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+      `}</style>
+
+      <div className="bs-topo">
+        {/* Live region for a11y announcements */}
+        <div
+          ref={liveRef}
+          aria-live="polite"
+          className="sr-only"
+        >
+          {announce}
+        </div>
+
+        {/* HOST */}
+        <div className="bs-topo-host" aria-label={`host: ${HOST_NAME}`}>
+          <div className="bs-topo-host-head">
+            <span className="bs-topo-host-name">{HOST_NAME}</span>
+            <span className="bs-topo-host-tag">host</span>
+          </div>
+
+          <div className="bs-topo-clients" aria-label="clients inside the host">
+            {conns.length === 0 ? (
+              <span className="bs-topo-empty">
+                no clients yet — pick a server below.
+              </span>
+            ) : (
+              <AnimatePresence initial={false} mode="popLayout">
+                {conns.map((c, i) => {
+                  const def = SERVERS.find((s) => s.id === c.serverId);
+                  return (
+                    <motion.span
+                      key={c.serverId}
+                      className="bs-topo-client"
+                      initial={
+                        reduce ? { opacity: 0 } : { opacity: 0, y: -6, scale: 0.96 }
+                      }
+                      animate={
+                        reduce
+                          ? { opacity: 1 }
+                          : { opacity: 1, y: 0, scale: 1 }
+                      }
+                      exit={
+                        reduce
+                          ? { opacity: 0 }
+                          : { opacity: 0, y: -6, scale: 0.96 }
+                      }
+                      transition={reduce ? { duration: 0 } : SPRING.smooth}
+                    >
+                      <span className="bs-topo-client-dot" aria-hidden />
+                      client #{i + 1} → {def?.name}
+                    </motion.span>
+                  );
+                })}
+              </AnimatePresence>
+            )}
+          </div>
+        </div>
+
+        {/* CONNECTIONS — list of active server connections */}
+        {conns.length > 0 ? (
+          <div className="bs-topo-conns" aria-label="active connections">
+            <div className="bs-topo-section-label">connections</div>
+            <AnimatePresence initial={false}>
+              {conns.map((c) => {
+                const def = SERVERS.find((s) => s.id === c.serverId);
+                if (!def) return null;
+                const isLocal = c.transport === "local";
+                return (
+                  <motion.div
+                    key={c.serverId}
+                    className="bs-topo-conn"
+                    initial={
+                      reduce ? { opacity: 0 } : { opacity: 0, y: 6 }
+                    }
+                    animate={
+                      reduce ? { opacity: 1 } : { opacity: 1, y: 0 }
+                    }
+                    exit={reduce ? { opacity: 0 } : { opacity: 0, y: 6 }}
+                    transition={reduce ? { duration: 0 } : SPRING.smooth}
+                  >
+                    <span className="bs-topo-conn-name">
+                      <span className="bs-topo-conn-arrow" aria-hidden>
+                        ↔ {isLocal ? <PipeIcon /> : <CloudIcon />}
+                      </span>
+                      {def.name}{" "}
+                      <span
+                        style={{
+                          color: "var(--color-text-muted)",
+                          fontFamily:
+                            "var(--font-mono, ui-monospace)",
+                          fontSize: "var(--text-small)",
+                          marginLeft: 4,
+                        }}
+                      >
+                        · {isLocal ? "stdio" : "HTTP"}
+                      </span>
+                    </span>
+                    <button
+                      type="button"
+                      className="bs-topo-toggle"
+                      onClick={() => toggleTransport(c.serverId)}
+                      aria-label={
+                        isLocal
+                          ? `${def.name} transport: local stdio. Tap to make remote.`
+                          : `${def.name} transport: remote HTTP. Tap to make local.`
+                      }
+                    >
+                      {isLocal ? "make remote" : "make local"}
+                    </button>
+                    <button
+                      type="button"
+                      className="bs-topo-remove"
+                      onClick={() => removeServer(c.serverId)}
+                      aria-label={`remove ${def.name} connection`}
+                    >
+                      ✕
+                    </button>
+                  </motion.div>
+                );
+              })}
+            </AnimatePresence>
+          </div>
+        ) : null}
+
+        {/* PALETTE */}
+        <div>
+          <div className="bs-topo-section-label">server palette</div>
+          <div
+            className="bs-topo-palette"
+            role="group"
+            aria-label="available servers"
+          >
+            {SERVERS.map((s) => {
+              const taken = connectedIds.has(s.id);
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  className="bs-topo-pal-btn"
+                  onClick={() => addServer(s.id)}
+                  disabled={taken}
+                  aria-label={
+                    taken
+                      ? `${s.name} already connected`
+                      : `add ${s.name} as a server (default ${s.defaultTransport})`
+                  }
+                >
+                  <span className="bs-topo-pal-plus" aria-hidden>
+                    {taken ? "✓" : "+"}
+                  </span>
+                  <span style={{ flex: 1 }}>{s.name}</span>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono, ui-monospace)",
+                      fontSize: "var(--text-small)",
+                      color: "var(--color-text-muted)",
+                    }}
+                  >
+                    {s.defaultTransport}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default TopologyBuilder;

--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -1,0 +1,22 @@
+/**
+ * Per-chapter content registry for the MCPs course.
+ *
+ * Each authored chapter exports a default `Content` component from
+ * `app/courses/mcps/_content/<chapter-slug>/Content.tsx`. The dynamic
+ * chapter route (`app/courses/[courseSlug]/[chapterSlug]/page.tsx`) looks
+ * the slug up here; if a Content module is registered, it renders that
+ * component instead of the placeholder paragraph. If not, it falls back
+ * to the placeholder so unauthored chapters still ship as shell pages.
+ *
+ * Adding a chapter:
+ *   1. Build `app/courses/mcps/_content/<slug>/Content.tsx` (default export).
+ *   2. Add a row to `MCPS_CONTENT` below.
+ *   3. The route picks it up automatically.
+ */
+
+import type { ComponentType } from "react";
+import HostClientServerContent from "./host-client-server/Content";
+
+export const MCPS_CONTENT: Record<string, ComponentType> = {
+  "host-client-server": HostClientServerContent,
+};

--- a/content/courses-manifest.ts
+++ b/content/courses-manifest.ts
@@ -39,42 +39,74 @@ export type CourseMeta = {
 export const COURSES: CourseMeta[] = [
   {
     slug: "mcps",
-    title: "Model Context Protocols",
+    title: "Model Context Protocol",
     hook:
-      "what MCPs are, why they're built like this, and why they matter right now.",
+      "what MCP is, why it's built like this, and why it matters right now.",
     pinned: true,
     level: "intro",
     updatedAt: "2026-04-30",
     chapters: [
       {
-        slug: "what-is-an-mcp",
-        title: "What is an MCP?",
-        hook: "the shape of the protocol, in one paragraph.",
-        readingMinutes: 6,
+        slug: "the-room-before-the-protocol",
+        title: "The room before the protocol",
+        hook:
+          "before MCP, every AI integration was a one-off — and your terminal already hides the receipt.",
+        readingMinutes: 8,
       },
       {
-        slug: "why-build-mcps",
-        title: "Why build MCPs?",
-        hook: "the problem they exist to solve.",
-        readingMinutes: 6,
+        slug: "host-client-server",
+        title: "Three roles, one connection",
+        hook:
+          "MCP isn't peer-to-peer. it's a host that spawns one client per server.",
+        readingMinutes: 10,
       },
       {
-        slug: "the-design-reasoning",
-        title: "The design reasoning",
-        hook: "why client/server, why JSON-RPC, why now.",
-        readingMinutes: 7,
+        slug: "json-rpc-the-wire",
+        title: "JSON-RPC, the wire that carries it",
+        hook:
+          "every MCP message is JSON-RPC 2.0. four fields are the whole story.",
+        readingMinutes: 12,
       },
       {
-        slug: "what-purpose-they-serve",
-        title: "What purpose they serve",
-        hook: "the day-to-day jobs MCPs are good at.",
-        readingMinutes: 6,
+        slug: "the-handshake",
+        title: "The handshake",
+        hook:
+          "every session begins with a negotiation. get it wrong and nothing works.",
+        readingMinutes: 11,
       },
       {
-        slug: "why-needed-today",
-        title: "Why they're needed today",
-        hook: "the tipping point that made MCPs inevitable.",
-        readingMinutes: 5,
+        slug: "the-server-primitives",
+        title: "Tools, resources, prompts",
+        hook: "three primitives, three controllers — model, application, user.",
+        readingMinutes: 14,
+      },
+      {
+        slug: "build-a-server",
+        title: "Build a server, in the page",
+        hook:
+          "by the end of this chapter you've authored a working MCP server.",
+        readingMinutes: 14,
+      },
+      {
+        slug: "build-a-client-pick-a-transport",
+        title: "Build a client, pick a transport",
+        hook:
+          "stdio for trust, HTTP for distance. and the smallest host that works.",
+        readingMinutes: 13,
+      },
+      {
+        slug: "when-the-server-asks-back",
+        title: "When the server asks back",
+        hook:
+          "sampling, elicitation, roots — and the human in the loop in each.",
+        readingMinutes: 11,
+      },
+      {
+        slug: "how-mcp-gets-attacked",
+        title: "How MCP gets attacked",
+        hook:
+          "MCP is a protocol, not a perimeter. the spec says SHOULD; you ship the MUST.",
+        readingMinutes: 12,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Chapter 2 of the MCPs course — *Three roles, one connection*. Defines host, client, and server with a premise-quiz opener, a load-bearing topology builder, a 5-tick session-lifecycle stepper, and a predict-and-reveal comprehension check. Closes on a cliffhanger to chapter 3 (JSON-RPC, the wire that carries it).

## What's in the chapter

- **`RoleQuiz` (premise opener)** — *"In Cursor, when you ask the AI to grep your codebase, who's the host, client, and server?"* Four options, each modelling a real wrong mental model. Reuses the shared `<Quiz>` primitive.
- **`TopologyBuilder` (load-bearing)** — host card with a tap-to-add server palette. Each pick spawns a client badge inside the host and adds a connection row with a local/remote (stdio/HTTP) toggle. The arrow icon morphs (pipe ↔ cloud); the host card never resizes — *transport is the server's concern, not the host's*.
- **`SessionLifecycleStrip` (5-tick stepper)** — spawn → connect → initialize → exchange → terminate, each tick named in both lanes with a tick-driven arrow flipping direction.
- **`ComprehensionCheck`** — *"Cursor opens with three configured servers; how many clients does it instantiate?"* Reuses `<Quiz>`.
- **`ChapterCliffhanger`** — still prose + one italic line + the centred terracotta dot (no `VerticalCutReveal`); links to `/courses/mcps/json-rpc-the-wire`.

Prose follows voice-profile §12.1 (premise opener), §12.2 (mechanism-first), §12.5 (`<Term>` on first appearance of host, client, server, stateful session, capability negotiation, transport), §12.6 (widget-prose ramp). One inline `<Aside>` for the spec-name pedantry. Code sample is a 6-line Claude Desktop config (`json`) showing `filesystem` + `postgres` side-by-side.

## Wire-up

- Manifest replaced with the brainstorm-recommended 9-chapter outline; chapter 2 lands at slug `host-client-server`. Course title rename: plural → singular *Model Context Protocol* per user-recommended defaults.
- New per-course content registry at `app/courses/mcps/_content/registry.ts`. The dynamic chapter route consults it; unauthored chapters still fall back to the placeholder paragraph so chapter 1's PR (and others) can land independently.

## Critical-constraint sweep

- VerticalCutReveal: zero usages (only mentioned in ban comments).
- `<hr>` / `<br>`: zero usages (only mentioned in ban comments).
- One accent (terracotta) only — local/remote reads via icon shape + label.
- Reduced-motion paths verified for all three widgets.
- Mobile frame-stable: outer `WidgetShell` doesn't resize during interaction. TopologyBuilder palette flips to single-column under 480 px; SessionLifecycleStrip lanes stack vertically natively.

## Test plan

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] `pnpm build` green; `/courses/mcps/host-client-server` prerendered
- [ ] Premise quiz at the top; right + wrong verdicts both fire
- [ ] TopologyBuilder: tap-to-add fills the host with client badges; transport toggle morphs the arrow icon and the host doesn't resize; reset clears
- [ ] SessionLifecycleStrip: 5 ticks step both directions; arrow flips per tick; reduced-motion collapses to instant
- [ ] Comprehension check answers gate verdicts; "three" is correct
- [ ] Cliffhanger link routes to `/courses/mcps/json-rpc-the-wire`
- [ ] Keyboard nav: Tab through palette + connection row + remove; arrow keys traverse Quiz options
- [ ] 375 px viewport: no horizontal scroll; tap targets ≥ 44 px

Resolves #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)