### PR TITLE
feat(courses/mcps): chapter 3 — JSON-RPC, the wire that carries it

### DIFF
--- a/app/courses/[courseSlug]/[chapterSlug]/page.tsx
+++ b/app/courses/[courseSlug]/[chapterSlug]/page.tsx
@@ -182,3 +182,4 @@ export default async function CourseChapterPage({
     </div>
   );
 }
+

--- a/app/courses/mcps/_content/json-rpc-the-wire/Content.tsx
+++ b/app/courses/mcps/_content/json-rpc-the-wire/Content.tsx
@@ -1,0 +1,342 @@
+/**
+ * Chapter 3 — JSON-RPC, the wire that carries it.
+ *
+ * Server-rendered prose component. Client-only widgets live under
+ * `./widgets/`; their `"use client"` boundaries scope hydration to the
+ * widget itself so the surrounding prose stays in the RSC graph.
+ *
+ * The chapter's spine is `JsonRpcSandbox`. Everything before it readies
+ * the reader to edit JSON-RPC; everything after pivots — the prose
+ * references what the reader can DO with the sandbox.
+ *
+ * Voice §12 anchors:
+ *   §12.1 — premise quiz opener (`JsonRpcQuiz`).
+ *   §12.2 — mechanism-first (the four fields, then the consequences).
+ *   §12.5 — `<Term>` on first appearance of every spec word.
+ *   §12.6 — every widget has a ramp + landing paragraph.
+ *   §12.8 — closer loops back to the opener (notifications/cancelled).
+ *
+ * Bans observed: no <hr>, no <br>, no VerticalCutReveal, single accent only.
+ */
+
+import { Term, Code, Em, Aside, A } from "@/components/prose";
+import { TextHighlighter } from "@/components/fancy";
+import { CodeBlock } from "@/components/code/CodeBlock";
+import {
+  JsonRpcSandbox,
+  FieldDecoder,
+  RequestVsNotification,
+  JsonRpcQuiz,
+} from "./widgets";
+
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+const HL_OPTS = { once: true, initial: false, amount: 0.55 } as const;
+
+/** Highlight a load-bearing phrase. Default ltr swipe, spring, inView once. */
+function HL({ children }: { children: React.ReactNode }) {
+  return (
+    <TextHighlighter
+      transition={HL_TX}
+      highlightColor={HL_COLOR}
+      useInViewOptions={HL_OPTS}
+      className="rounded-[0.2em] px-[1px]"
+    >
+      {children}
+    </TextHighlighter>
+  );
+}
+
+const PROSE_P_STYLE: React.CSSProperties = {
+  margin: "var(--spacing-md) 0",
+  fontSize: "var(--text-body)",
+  lineHeight: 1.7,
+  color: "var(--color-text)",
+};
+
+const H2_STYLE: React.CSSProperties = {
+  fontFamily: "var(--font-sans)",
+  fontWeight: 600,
+  fontSize: "var(--text-h2)",
+  letterSpacing: "-0.015em",
+  margin: "var(--spacing-2xl) 0 var(--spacing-md) 0",
+  lineHeight: 1.2,
+};
+
+const SAMPLE_FOUR_MESSAGES = `// 1. client → server
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": { "protocolVersion": "2025-06-18",
+              "capabilities": { "elicitation": {} },
+              "clientInfo": { "name": "demo-client", "version": "0.1.0" } } }
+
+// 2. server → client
+{ "jsonrpc": "2.0", "id": 1,
+  "result": { "protocolVersion": "2025-06-18",
+              "capabilities": { "tools": {}, "resources": {} },
+              "serverInfo": { "name": "demo-server", "version": "0.1.0" } } }
+
+// 3. client → server  (no id — it's a notification)
+{ "jsonrpc": "2.0", "method": "notifications/initialized" }
+
+// 4. client → server
+{ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }`;
+
+const SAMPLE_ERRORS = `// parse error — the bytes weren't valid JSON
+{ "jsonrpc": "2.0", "id": null,
+  "error": { "code": -32700, "message": "Parse error" } }
+
+// invalid request — JSON parsed, but the shape was wrong
+{ "jsonrpc": "2.0", "id": null,
+  "error": { "code": -32600, "message": "Invalid Request" } }
+
+// method not found — the server doesn't expose that method
+{ "jsonrpc": "2.0", "id": 4,
+  "error": { "code": -32601, "message": "Method not found" } }
+
+// invalid params — the method exists, the arguments don't match
+{ "jsonrpc": "2.0", "id": 5,
+  "error": { "code": -32602, "message": "Invalid params" } }`;
+
+export default async function Chapter3Content() {
+  // Pre-render the two static samples through Shiki here so the RSC graph
+  // does the highlighting and the client never imports the highlighter.
+  const fourMessages = await CodeBlock({
+    code: SAMPLE_FOUR_MESSAGES,
+    lang: "json",
+    filename: "the four-message exchange",
+  });
+  const errorSamples = await CodeBlock({
+    code: SAMPLE_ERRORS,
+    lang: "json",
+    filename: "the four standard error codes",
+  });
+
+  return (
+    <div>
+      {/* §0 — premise-quiz opener (voice §12.1) */}
+      <p style={PROSE_P_STYLE}>
+        Two messages on the wire. One has an <Code>id</Code>. One
+        doesn&rsquo;t. Read both, then guess which one expects a response.
+        Most readers don&rsquo;t notice the difference on a first pass &mdash;{" "}
+        <HL>and that one missed field is the lesson</HL>.
+      </p>
+
+      <JsonRpcQuiz />
+
+      {/* §1 — the reframe */}
+      <h2 style={H2_STYLE}>MCP didn&rsquo;t invent a wire. It picked a calm one.</h2>
+      <p style={PROSE_P_STYLE}>
+        <Term>JSON-RPC</Term> predates MCP by 15+ years. Ethereum nodes speak
+        it. WebSocket libraries lean on it. Half the desktop applications you
+        ran in 2014 had a JSON-RPC server somewhere in their guts. When the
+        designers of MCP sat down to pick a wire format,{" "}
+        <HL>they didn&rsquo;t reach for novelty</HL> &mdash; they reached for
+        something the rest of the industry already understood.
+      </p>
+      <p style={PROSE_P_STYLE}>
+        The trade was deliberate. JSON-RPC has no schema language, no streams,
+        no codegen, no batching anyone uses in practice. What it does have is{" "}
+        <Em>four fields</Em> and a <Em>pairing rule</Em>. That&rsquo;s the
+        whole protocol. If you can read those four fields by sight,{" "}
+        you can read every message in the rest of this course.
+      </p>
+
+      {/* §2 — the four fields */}
+      <h2 style={H2_STYLE}>The four fields</h2>
+      <p style={PROSE_P_STYLE}>
+        Every message MCP puts on the wire is a JSON object with at most four
+        keys. <Code>jsonrpc</Code> says <Em>which version of the wire format
+        this is</Em>; it&rsquo;s always the literal string{" "}
+        <Code>&quot;2.0&quot;</Code>. <Code>id</Code> says <Em>which conversation
+        this message belongs to</Em>. <Code>method</Code> says <Em>what the
+        sender is asking for</Em>. <Code>params</Code> carries{" "}
+        <Em>the inputs</Em> &mdash; or, on the way back, the response uses{" "}
+        <Code>result</Code> for success and <Code>error</Code> for failure.
+      </p>
+      <p style={PROSE_P_STYLE}>
+        Hover the keys below to read what each one does.
+      </p>
+
+      <FieldDecoder />
+
+      <p style={PROSE_P_STYLE}>
+        Four fields. Two outcomes per response. <HL>That&rsquo;s the entire
+        surface area</HL> &mdash; everything else is a method name and the
+        shape of its <Code>params</Code>.
+      </p>
+
+      {/* §3 — request → response, paired by id */}
+      <h2 style={H2_STYLE}>Request and response, paired by <Code>id</Code></h2>
+      <p style={PROSE_P_STYLE}>
+        A <Term>request</Term> goes out with an <Code>id</Code>; a{" "}
+        <Term>response</Term> comes back carrying the same <Code>id</Code>.
+        That&rsquo;s the pairing rule, and it&rsquo;s the reason MCP can run
+        many requests in flight on a single connection without confusing
+        them. The client picks the id, the server echoes it &mdash; the two
+        sides never have to agree on order, only on identity.
+      </p>
+      <p style={PROSE_P_STYLE}>
+        Here&rsquo;s the four-message handshake from the spec, verbatim. Read
+        it once; we&rsquo;ll come back to it when we open the sandbox.
+      </p>
+
+      {fourMessages}
+
+      <p style={PROSE_P_STYLE}>
+        Messages 1 and 2 are paired by <Code>id: 1</Code>. Message 4 is a
+        fresh request waiting on its own response (which would carry{" "}
+        <Code>id: 2</Code>). Message 3{" "}
+        <HL>has no id, and that means something specific</HL>.
+      </p>
+
+      {/* §4 — notifications */}
+      <h2 style={H2_STYLE}>The one without an <Code>id</Code></h2>
+      <p style={PROSE_P_STYLE}>
+        A message without an <Code>id</Code> is a <Term>notification</Term>.
+        The receiver acts on it; the receiver does not reply. Notifications
+        are how MCP carries events &mdash; <Em>the tool list changed</Em>,{" "}
+        <Em>cancel that long-running call</Em>, <Em>I&rsquo;m initialized
+        and ready</Em>. There&rsquo;s no id because there&rsquo;s no
+        response to pair with.
+      </p>
+      <p style={PROSE_P_STYLE}>
+        Toggle the widget below. Same shape on the wire, one missing field;
+        watch the right pane go quiet.
+      </p>
+
+      <RequestVsNotification />
+
+      <p style={PROSE_P_STYLE}>
+        The round-trip count only ticks on requests. Notifications are{" "}
+        <HL>fire-and-forget</HL> &mdash; the wire goes one way, and the
+        sender moves on.
+      </p>
+
+      {/* §5 — JsonRpcSandbox: the chapter's spine */}
+      <h2 style={H2_STYLE}>The wire, in your hands</h2>
+      <p style={PROSE_P_STYLE}>
+        Reading is one thing. Editing is another. The widget below puts a
+        live JSON-RPC request in the left pane and a deterministic server
+        stub in the right. The reader edits the request &mdash;{" "}
+        <HL>the response shape changes as you type</HL>. There&rsquo;s no
+        network here; the stub is a small switch on <Code>method</Code> that
+        produces the same response a real server would.
+      </p>
+
+      <JsonRpcSandbox />
+
+      <p style={PROSE_P_STYLE}>
+        From here on, the chapter pivots. We&rsquo;re not going to{" "}
+        <Em>describe</Em> the protocol any more &mdash; we&rsquo;re going to
+        ask you to <Em>do</Em> things with it. Try editing the{" "}
+        <Code>method</Code> from <Code>tools/list</Code> to{" "}
+        <Code>tools/cull</Code> and watch the response come back as a{" "}
+        <Code>-32601</Code>. Delete the closing brace and watch the wire
+        flunk before the server even sees the message. Drop the{" "}
+        <Code>id</Code> field and watch the response pane go quiet &mdash;
+        you&rsquo;ve just turned a request into a notification.
+      </p>
+
+      {/* §6 — error codes */}
+      <h2 style={H2_STYLE}>The four codes a server can refuse with</h2>
+      <p style={PROSE_P_STYLE}>
+        When something is wrong, JSON-RPC has a small dictionary of negative
+        numbers it speaks. You&rsquo;ll see the same four codes in every MCP
+        debugger, in every error log, in every spec page from now on.
+      </p>
+      <p style={PROSE_P_STYLE}>
+        <Code>-32700</Code> is a <Term>parse error</Term> &mdash; the bytes
+        weren&rsquo;t valid JSON. <Code>-32600</Code> is{" "}
+        <Em>invalid request</Em> &mdash; the JSON parsed, but the shape
+        wasn&rsquo;t a JSON-RPC message. <Code>-32601</Code> is{" "}
+        <Em>method not found</Em> &mdash; the shape was right, but the
+        server doesn&rsquo;t expose that method. <Code>-32602</Code> is{" "}
+        <Em>invalid params</Em> &mdash; the method exists, the arguments
+        don&rsquo;t match.
+      </p>
+
+      {errorSamples}
+
+      <p style={PROSE_P_STYLE}>
+        The sandbox above will produce each of these on demand. Mangle the
+        JSON for <Code>-32700</Code>. Drop <Code>jsonrpc</Code> for{" "}
+        <Code>-32600</Code>. Rename the method for <Code>-32601</Code>.
+      </p>
+
+      <Aside>
+        There&rsquo;s a fifth code, <Code>-32603</Code>, for{" "}
+        <Em>internal error</Em> &mdash; the server received a valid request
+        but failed while handling it. We&rsquo;ll see that one in chapter 6
+        when handlers throw. For now: four codes is enough to read every
+        well-formed exchange in the spec.
+      </Aside>
+
+      {/* §7 — what it isn't */}
+      <h2 style={H2_STYLE}>What it isn&rsquo;t</h2>
+      <p style={PROSE_P_STYLE}>
+        It&rsquo;s not REST. There are no resources, no verbs, no path
+        templates. It&rsquo;s not GraphQL &mdash; the client doesn&rsquo;t
+        shape its query, the server names the operation. It&rsquo;s not gRPC
+        either; no protobuf, no HTTP/2 multiplexing required.{" "}
+        It&rsquo;s <HL>stateful</HL> &mdash; the connection carries context,
+        and that context is what makes the next chapter&rsquo;s handshake
+        even necessary.
+      </p>
+
+      {/* §8 — comprehension check */}
+      <h2 style={H2_STYLE}>One last read</h2>
+      <p style={PROSE_P_STYLE}>
+        Here&rsquo;s a message from a real MCP session:
+      </p>
+      <pre
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--text-mono)",
+          lineHeight: 1.55,
+          background: "var(--color-surface)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          padding: "var(--spacing-md)",
+          color: "var(--color-text)",
+          whiteSpace: "pre",
+          overflowX: "auto",
+          margin: "var(--spacing-md) 0",
+        }}
+      >
+{`{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": { "requestId": 42, "reason": "user pressed escape" }
+}`}
+      </pre>
+      <p style={PROSE_P_STYLE}>
+        The server processes it and... what? The answer falls out of the
+        rules you already have. There&rsquo;s no <Code>id</Code>, so this is
+        a notification &mdash; the server acts on it but{" "}
+        <HL>doesn&rsquo;t reply</HL>. The server cancels the request whose
+        id was 42 (probably a long-running tool call), and the wire stays
+        quiet. No response. No error. No round-trip.
+      </p>
+
+      {/* §9 — cliffhanger */}
+      <h2 style={H2_STYLE}>What&rsquo;s next</h2>
+      <p style={PROSE_P_STYLE}>
+        Four fields can carry anything. So <Em>what</Em> does MCP carry
+        across them &mdash; and how do two strangers, fresh to a session,
+        agree on what&rsquo;s in scope?{" "}
+        <HL>That&rsquo;s the handshake</HL>, and it&rsquo;s the next chapter:{" "}
+        <A href="/courses/mcps/the-handshake">The handshake</A>.
+      </p>
+
+      <div
+        aria-hidden
+        style={{
+          margin: "var(--spacing-2xl) auto var(--spacing-lg)",
+          width: 6,
+          height: 6,
+          background: "var(--color-accent)",
+        }}
+      />
+    </div>
+  );
+}

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/FieldDecoder.tsx
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/FieldDecoder.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+/**
+ * FieldDecoder — annotated JSON-RPC sample. Each of the four spec fields
+ * (`jsonrpc`, `id`, `method`, `params`) is hoverable / focusable; selecting
+ * one reveals a callout that explains its job.
+ *
+ * Why not Shiki here? The teaching surface needs *interactive* tokens —
+ * each field is its own focusable button — and Shiki renders to opaque
+ * HTML strings. We hand-render the JSON instead, with a small layout that
+ * mirrors monospaced indentation. The cost is one hand-built sample; the
+ * win is per-field affordances and a single accent across the chapter.
+ *
+ * Frame-stability: the callout slot reserves a fixed min-height, so the
+ * card doesn't reflow on hover/focus.
+ *
+ * A11y:
+ *   - Each field is a real <button> with aria-describedby pointing at its
+ *     callout — screen readers announce the explanation.
+ *   - Tap-to-toggle on touch devices.
+ *
+ * Reduced motion: the callout fades in instantly (no slide) under
+ * prefers-reduced-motion. Default is a 200ms opacity transition; no
+ * transform.
+ */
+
+import { useState } from "react";
+import { useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+type FieldKey = "jsonrpc" | "id" | "method" | "params";
+
+const NOTES: Record<FieldKey, { title: string; body: string }> = {
+  jsonrpc: {
+    title: "jsonrpc",
+    body: "always the string \"2.0\". The spec version of the wire format. If it isn't \"2.0\", the receiver replies with -32600.",
+  },
+  id: {
+    title: "id",
+    body: "the pairing key. The server echoes this id on its response so the client knows which request the response belongs to. Omit it and the message becomes a notification — no response.",
+  },
+  method: {
+    title: "method",
+    body: "the name of the operation. MCP method names are namespaced — `tools/list`, `tools/call`, `notifications/tools/list_changed`. Unknown method → -32601.",
+  },
+  params: {
+    title: "params",
+    body: "the operation's input. Shape is per-method; on responses you'll see `result` (success) or `error` (failure) instead. Wrong shape → -32602.",
+  },
+};
+
+export function FieldDecoder() {
+  const [active, setActive] = useState<FieldKey>("method");
+  const reduce = useReducedMotion();
+  const note = NOTES[active];
+
+  return (
+    <WidgetShell
+      title="the four fields"
+      caption={
+        <span>
+          tap a field to read what it does. every MCP message has these four
+          &mdash; learn them once, read every message after.
+        </span>
+      }
+    >
+      <style>{`
+        .bs-fd-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-md);
+        }
+        @container (min-width: 640px) {
+          .bs-fd-grid {
+            grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+            align-items: start;
+          }
+        }
+        .bs-fd-sample {
+          font-family: var(--font-mono);
+          font-size: var(--text-mono);
+          line-height: 1.7;
+          background: var(--color-surface);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          padding: var(--spacing-md);
+          color: var(--color-text);
+          white-space: pre;
+          overflow-x: auto;
+        }
+        .bs-fd-key {
+          background: transparent;
+          border: 0;
+          padding: 0 4px;
+          margin: 0 -4px;
+          font: inherit;
+          color: var(--color-text);
+          cursor: pointer;
+          border-radius: 4px;
+          border-bottom: 1px dotted color-mix(in oklab, var(--color-accent) 60%, transparent);
+          transition: background 200ms, color 200ms, border-color 200ms;
+        }
+        .bs-fd-key:hover { background: color-mix(in oklab, var(--color-accent) 10%, transparent); }
+        .bs-fd-key:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-fd-key[data-active="true"] {
+          background: color-mix(in oklab, var(--color-accent) 18%, transparent);
+          border-bottom-color: var(--color-accent);
+        }
+        .bs-fd-callout {
+          min-height: 9em;
+          padding: var(--spacing-sm) var(--spacing-md);
+          border-left: 2px solid var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 4%, transparent);
+          border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+        }
+        .bs-fd-callout-title {
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-accent);
+          letter-spacing: 0.04em;
+          margin: 0 0 6px 0;
+        }
+        .bs-fd-callout-body {
+          font-family: var(--font-serif);
+          font-size: var(--text-body);
+          line-height: 1.6;
+          color: var(--color-text);
+          margin: 0;
+        }
+      `}</style>
+
+      <div className="bs-fd-grid">
+        <pre className="bs-fd-sample" aria-label="annotated JSON-RPC request">
+          {"{\n  \""}
+          <button
+            type="button"
+            className="bs-fd-key"
+            data-active={active === "jsonrpc"}
+            onMouseEnter={() => setActive("jsonrpc")}
+            onFocus={() => setActive("jsonrpc")}
+            onClick={() => setActive("jsonrpc")}
+            aria-describedby="bs-fd-note"
+          >
+            jsonrpc
+          </button>
+          {"\": \"2.0\",\n  \""}
+          <button
+            type="button"
+            className="bs-fd-key"
+            data-active={active === "id"}
+            onMouseEnter={() => setActive("id")}
+            onFocus={() => setActive("id")}
+            onClick={() => setActive("id")}
+            aria-describedby="bs-fd-note"
+          >
+            id
+          </button>
+          {"\": 2,\n  \""}
+          <button
+            type="button"
+            className="bs-fd-key"
+            data-active={active === "method"}
+            onMouseEnter={() => setActive("method")}
+            onFocus={() => setActive("method")}
+            onClick={() => setActive("method")}
+            aria-describedby="bs-fd-note"
+          >
+            method
+          </button>
+          {"\": \"tools/list\",\n  \""}
+          <button
+            type="button"
+            className="bs-fd-key"
+            data-active={active === "params"}
+            onMouseEnter={() => setActive("params")}
+            onFocus={() => setActive("params")}
+            onClick={() => setActive("params")}
+            aria-describedby="bs-fd-note"
+          >
+            params
+          </button>
+          {"\": { }\n}"}
+        </pre>
+
+        <div
+          id="bs-fd-note"
+          className="bs-fd-callout"
+          aria-live="polite"
+          style={
+            reduce
+              ? undefined
+              : { transition: "background 200ms ease-out" }
+          }
+        >
+          <p className="bs-fd-callout-title">{note.title}</p>
+          <p className="bs-fd-callout-body">{note.body}</p>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default FieldDecoder;

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/JsonRpcQuiz.tsx
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/JsonRpcQuiz.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * JsonRpcQuiz — the chapter's premise-quiz opener (voice §12.1).
+ *
+ * Two messages on the wire. One has an `id`; one doesn't. Which expects a
+ * response? Most readers haven't internalised the rule yet — the wrong
+ * answer creates demand for the chapter's reframe.
+ *
+ * Built on the shared <Quiz> wrapper (see components/widgets/Quiz.tsx) so
+ * the shuffle, focus management, sparkle/nod, and verdict slot match every
+ * other quiz in the project. We own the question framing — two short
+ * <CodeBlock>-styled samples — and the verdict copy.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+const MSG_A = `{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tools/list"
+}`;
+
+const MSG_B = `{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}`;
+
+const OPTIONS = [
+  {
+    id: "with-id",
+    label:
+      "the one with id — the id pairs request to response; no id means no response.",
+  },
+  {
+    id: "without-id",
+    label:
+      "the one without id — fewer fields means less ceremony; the server fills in the id.",
+  },
+  {
+    id: "both",
+    label: "both — every JSON-RPC message expects a response.",
+  },
+  {
+    id: "neither",
+    label:
+      "neither — JSON-RPC is async; responses arrive when the server feels like it.",
+  },
+];
+
+export function JsonRpcQuiz() {
+  return (
+    <WidgetShell
+      title="predict the answer"
+      caption={
+        <span>
+          two messages, almost identical &mdash; one extra field decides
+          whether the wire stays quiet or talks back.
+        </span>
+      }
+    >
+      <Quiz
+        question={
+          <div className="bs-jrq-q">
+            <style>{`
+              .bs-jrq-q { display: grid; gap: var(--spacing-sm); margin-bottom: var(--spacing-sm); }
+              .bs-jrq-msg {
+                font-family: var(--font-mono);
+                font-size: var(--text-mono);
+                line-height: 1.55;
+                background: var(--color-surface);
+                border: 1px solid var(--color-rule);
+                border-radius: var(--radius-sm);
+                padding: var(--spacing-sm) var(--spacing-md);
+                color: var(--color-text);
+                white-space: pre;
+                overflow-x: auto;
+                margin: 0;
+              }
+              .bs-jrq-msg-label {
+                font-family: var(--font-mono);
+                font-size: var(--text-small);
+                color: var(--color-text-muted);
+                margin-bottom: 4px;
+              }
+              .bs-jrq-stem {
+                font-family: var(--font-serif);
+                font-size: var(--text-body);
+                line-height: 1.55;
+                color: var(--color-text);
+                margin: 0;
+              }
+            `}</style>
+            <div>
+              <div className="bs-jrq-msg-label">message A</div>
+              <pre className="bs-jrq-msg">{MSG_A}</pre>
+            </div>
+            <div>
+              <div className="bs-jrq-msg-label">message B</div>
+              <pre className="bs-jrq-msg">{MSG_B}</pre>
+            </div>
+            <p className="bs-jrq-stem">
+              both are valid JSON-RPC. one expects a response back; one
+              doesn&rsquo;t. which one expects a response &mdash; and why?
+            </p>
+          </div>
+        }
+        options={OPTIONS}
+        correctId="with-id"
+        rightVerdict={
+          <span>
+            right. the <code>id</code> is the pairing key &mdash; it&rsquo;s
+            how the server tells the client which request a response answers.
+            no <code>id</code>, no response. messages without one are
+            <em> notifications</em> &mdash; events the receiver can act on but
+            never replies to.
+          </span>
+        }
+        wrongVerdict={
+          <span>
+            it&rsquo;s the one with <code>id</code>. JSON-RPC pairs requests
+            and responses by id; remove the field and the message becomes a
+            notification &mdash; fire-and-forget, no reply expected. the rest
+            of this chapter teaches you to read the four fields by sight, so
+            you&rsquo;ll never miss this again.
+          </span>
+        }
+      />
+    </WidgetShell>
+  );
+}
+
+export default JsonRpcQuiz;

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/JsonRpcSandbox.tsx
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/JsonRpcSandbox.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+/**
+ * JsonRpcSandbox — the chapter's load-bearing widget.
+ *
+ * Two panes: an editable JSON-RPC request on the left, the deterministic
+ * server-stub's response on the right. The reader edits the request and
+ * watches the response shape change live — they internalise the four spec
+ * fields (jsonrpc / id / method / params) by editing them, not by reading
+ * about them.
+ *
+ * Why not a full editor lib (CodeMirror / Monaco)?
+ *   - We render a plain monospaced <textarea>. JSON-RPC is small; an editor
+ *     primitive would dominate the JS bundle for a couple of hundred bytes
+ *     of payload. Tabs and copy/paste already work.
+ *   - The lesson is the protocol shape, not the editing UX.
+ *
+ * Determinism is the lesson. Every preset, every keystroke, dispatches
+ * through `parseAndDispatch` (see `./server-stub.ts`) — no `eval`, no
+ * network, no race. Given the same JSON, the response is identical across
+ * sessions and devices.
+ *
+ * Frame-stability (DESIGN.md R6 / svg-cover-playbook.md R6): both panes have
+ * fixed min-heights. A parse error doesn't shrink the response pane; a
+ * notification doesn't grow the editor.
+ *
+ * A11y:
+ *   - <textarea> is a real <textarea> with a label.
+ *   - Preset chips are real <button>s with role="radio" inside a radiogroup.
+ *   - Response pane is `aria-live="polite"`, debounced so SR users hear one
+ *     announcement per edit, not one per keystroke.
+ *
+ * Reduced motion: no transitions, no entrance animations. The widget is
+ * pure I/O — there's nothing to animate. It works equally well still or
+ * lively.
+ *
+ * Mobile (375px): panes stack vertically (editor on top); editor capped at
+ * ~38vh so the response pane stays visible without scrolling the shell.
+ */
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { TextHighlighter } from "@/components/fancy";
+import { parseAndDispatch, PRESETS, type StubOutcome } from "./server-stub";
+
+const HL_TX = { type: "spring" as const, duration: 0.9, bounce: 0 };
+const HL_COLOR = "color-mix(in oklab, var(--color-accent) 28%, transparent)";
+
+/**
+ * Renders the right pane — either a JSON response, a "(notification —
+ * no response)" placeholder, or a parse-error response.
+ */
+function renderOutcome(outcome: StubOutcome): {
+  body: string;
+  badge: string;
+  tone: "ok" | "error" | "muted";
+} {
+  if (outcome.kind === "notification") {
+    return {
+      body: "(notification — no response)",
+      badge: "fire-and-forget",
+      tone: "muted",
+    };
+  }
+  if (outcome.kind === "parse-error") {
+    return {
+      body: JSON.stringify(outcome.payload, null, 2),
+      badge: "parse error · -32700",
+      tone: "error",
+    };
+  }
+  const payload = outcome.payload;
+  const isErr = "error" in payload;
+  return {
+    body: JSON.stringify(payload, null, 2),
+    badge: isErr
+      ? `error · ${payload.error.code}`
+      : `response · id ${String(payload.id)}`,
+    tone: isErr ? "error" : "ok",
+  };
+}
+
+const DEBOUNCE_MS = 200;
+
+export function JsonRpcSandbox() {
+  const [text, setText] = useState<string>(PRESETS[1].body); // tools/list
+  const [activePresetId, setActivePresetId] = useState<string | null>(
+    PRESETS[1].id,
+  );
+  // Debounced eval — the textarea fires onChange on every keystroke; we
+  // collapse those into a single dispatch ~200ms after the reader pauses.
+  const [debounced, setDebounced] = useState<string>(text);
+  const labelId = useId();
+  const responseId = useId();
+  const debounceTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (debounceTimer.current !== null) {
+      window.clearTimeout(debounceTimer.current);
+    }
+    debounceTimer.current = window.setTimeout(() => {
+      setDebounced(text);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceTimer.current !== null) {
+        window.clearTimeout(debounceTimer.current);
+      }
+    };
+  }, [text]);
+
+  const outcome = useMemo(() => parseAndDispatch(debounced), [debounced]);
+  const rendered = useMemo(() => renderOutcome(outcome), [outcome]);
+
+  function applyPreset(id: string) {
+    const preset = PRESETS.find((p) => p.id === id);
+    if (!preset) return;
+    setActivePresetId(id);
+    setText(preset.body);
+    // Bypass the debounce for an instant feel on a chip click.
+    setDebounced(preset.body);
+  }
+
+  function onTextChange(next: string) {
+    setActivePresetId(null);
+    setText(next);
+  }
+
+  return (
+    <WidgetShell
+      title="json-rpc sandbox"
+      measurements={
+        outcome.kind === "notification"
+          ? "no response"
+          : outcome.kind === "parse-error"
+            ? "-32700"
+            : "error" in outcome.payload
+              ? String(outcome.payload.error.code)
+              : `id ${String(outcome.payload.id)}`
+      }
+      caption={
+        <span>
+          <TextHighlighter
+            triggerType="auto"
+            transition={HL_TX}
+            highlightColor={HL_COLOR}
+            className="rounded-[0.2em] px-[1px]"
+          >
+            edit the request
+          </TextHighlighter>
+          . change <code>method</code> to something the server doesn&rsquo;t
+          know &mdash; watch the error code come back. remove the{" "}
+          <code>id</code> &mdash; the response goes silent.
+        </span>
+      }
+      controls={
+        <div role="radiogroup" aria-label="preset requests" className="bs-jrs-chips">
+          {PRESETS.map((p) => {
+            const active = p.id === activePresetId;
+            return (
+              <button
+                key={p.id}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                onClick={() => applyPreset(p.id)}
+                className="bs-jrs-chip"
+                data-active={active}
+              >
+                {p.label}
+              </button>
+            );
+          })}
+        </div>
+      }
+    >
+      <style>{`
+        .bs-jrs-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-sm);
+        }
+        @container (min-width: 640px) {
+          .bs-jrs-grid {
+            grid-template-columns: 1fr 1fr;
+            gap: var(--spacing-md);
+          }
+        }
+        .bs-jrs-pane {
+          display: flex;
+          flex-direction: column;
+          min-height: 220px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: var(--color-surface);
+          overflow: hidden;
+        }
+        .bs-jrs-pane-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 6px 10px;
+          border-bottom: 1px solid var(--color-rule);
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          letter-spacing: 0.02em;
+        }
+        .bs-jrs-pane-body {
+          flex: 1;
+          font-family: var(--font-mono);
+          font-size: var(--text-mono);
+          line-height: 1.55;
+          padding: var(--spacing-sm);
+          color: var(--color-text);
+          white-space: pre;
+          overflow: auto;
+          tab-size: 2;
+        }
+        .bs-jrs-pane-body[data-tone="muted"] {
+          color: var(--color-text-muted);
+          font-style: italic;
+          font-family: var(--font-serif);
+          white-space: normal;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+        }
+        .bs-jrs-textarea {
+          width: 100%;
+          flex: 1;
+          min-height: 220px;
+          max-height: 38vh;
+          resize: vertical;
+          font-family: var(--font-mono);
+          font-size: var(--text-mono);
+          line-height: 1.55;
+          padding: var(--spacing-sm);
+          color: var(--color-text);
+          background: transparent;
+          border: 0;
+          outline: none;
+          tab-size: 2;
+        }
+        .bs-jrs-textarea:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: -2px;
+        }
+        .bs-jrs-pane-badge {
+          font-variant-numeric: tabular-nums;
+        }
+        .bs-jrs-pane-badge[data-tone="error"] {
+          color: var(--color-accent);
+        }
+        .bs-jrs-chips {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          justify-content: center;
+        }
+        .bs-jrs-chip {
+          min-height: 32px;
+          padding: 4px 10px;
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          background: transparent;
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          cursor: pointer;
+          transition: color 200ms, border-color 200ms, background 200ms;
+        }
+        .bs-jrs-chip:hover {
+          color: var(--color-text);
+          border-color: color-mix(in oklab, var(--color-accent) 50%, var(--color-rule));
+        }
+        .bs-jrs-chip[data-active="true"] {
+          color: var(--color-text);
+          border-color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 10%, transparent);
+        }
+        .bs-jrs-chip:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+      `}</style>
+
+      <div className="bs-jrs-grid">
+        <div className="bs-jrs-pane">
+          <div className="bs-jrs-pane-head">
+            <span id={labelId}>request</span>
+            <span style={{ fontStyle: "italic" }}>editable</span>
+          </div>
+          <textarea
+            aria-labelledby={labelId}
+            aria-describedby={responseId}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+            value={text}
+            onChange={(e) => onTextChange(e.target.value)}
+            className="bs-jrs-textarea"
+          />
+        </div>
+
+        <div className="bs-jrs-pane">
+          <div className="bs-jrs-pane-head">
+            <span>response</span>
+            <span
+              className="bs-jrs-pane-badge"
+              data-tone={rendered.tone === "error" ? "error" : undefined}
+            >
+              {rendered.badge}
+            </span>
+          </div>
+          <div
+            id={responseId}
+            className="bs-jrs-pane-body"
+            data-tone={rendered.tone}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {rendered.body}
+          </div>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default JsonRpcSandbox;

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/RequestVsNotification.tsx
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/RequestVsNotification.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * RequestVsNotification — toggle between a request shape and a notification
+ * shape. The two messages are identical except one has an `id` and one
+ * doesn't; flipping the toggle visualises what that one field decides.
+ *
+ * The right pane swaps between the server's response and a "(no response)"
+ * placeholder. A small round-trip counter increments on request-mode flips
+ * and holds on notification-mode flips — the reader feels the round-trip
+ * semantics in their fingertips.
+ *
+ * Frame stability: both panes share a fixed min-height so a notification
+ * doesn't shrink the card. Counter slot reserves a fixed pill size.
+ *
+ * A11y: segmented control is a real radiogroup; the counter is a
+ * non-interactive status node with aria-live="polite".
+ *
+ * Reduced motion: opacity-only crossfade on the response pane (no slide).
+ */
+
+import { useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { dispatch } from "./server-stub";
+
+type Mode = "request" | "notification";
+
+const REQUEST_MSG = {
+  jsonrpc: "2.0" as const,
+  id: 7,
+  method: "tools/list",
+};
+const NOTIFICATION_MSG = {
+  jsonrpc: "2.0" as const,
+  method: "notifications/tools/list_changed",
+};
+
+export function RequestVsNotification() {
+  const [mode, setMode] = useState<Mode>("request");
+  const [roundTrips, setRoundTrips] = useState(0);
+  const reduce = useReducedMotion();
+
+  const message = mode === "request" ? REQUEST_MSG : NOTIFICATION_MSG;
+  const outcome = dispatch(message);
+
+  function pick(next: Mode) {
+    if (next === mode) return;
+    setMode(next);
+    if (next === "request") setRoundTrips((n) => n + 1);
+  }
+
+  const responseText =
+    outcome.kind === "response"
+      ? JSON.stringify(outcome.payload, null, 2)
+      : "(no response — notifications are fire-and-forget)";
+
+  return (
+    <WidgetShell
+      title="request vs notification"
+      measurements={`round-trips · ${roundTrips}`}
+      caption={
+        <span>
+          one field decides. with an <code>id</code>, the server replies
+          and the round-trip count ticks up. without an <code>id</code>,
+          the wire goes quiet.
+        </span>
+      }
+      controls={
+        <div role="radiogroup" aria-label="message type" className="bs-rvn-seg">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === "request"}
+            data-active={mode === "request"}
+            onClick={() => pick("request")}
+            className="bs-rvn-seg-btn"
+          >
+            request
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={mode === "notification"}
+            data-active={mode === "notification"}
+            onClick={() => pick("notification")}
+            className="bs-rvn-seg-btn"
+          >
+            notification
+          </button>
+        </div>
+      }
+    >
+      <style>{`
+        .bs-rvn-grid {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-sm);
+        }
+        @container (min-width: 640px) {
+          .bs-rvn-grid {
+            grid-template-columns: 1fr 1fr;
+            gap: var(--spacing-md);
+          }
+        }
+        .bs-rvn-pane {
+          font-family: var(--font-mono);
+          font-size: var(--text-mono);
+          line-height: 1.55;
+          background: var(--color-surface);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          padding: var(--spacing-md);
+          min-height: 160px;
+          color: var(--color-text);
+          white-space: pre;
+          overflow-x: auto;
+        }
+        .bs-rvn-pane[data-mode="muted"] {
+          font-family: var(--font-serif);
+          font-style: italic;
+          color: var(--color-text-muted);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
+          white-space: normal;
+        }
+        .bs-rvn-pane-label {
+          display: block;
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          letter-spacing: 0.02em;
+          margin-bottom: 6px;
+        }
+        .bs-rvn-seg {
+          display: inline-flex;
+          padding: 3px;
+          background: var(--color-surface);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+        }
+        .bs-rvn-seg-btn {
+          min-height: 32px;
+          padding: 4px 14px;
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          background: transparent;
+          border: 0;
+          border-radius: calc(var(--radius-sm) - 2px);
+          cursor: pointer;
+          transition: color 200ms, background 200ms;
+        }
+        .bs-rvn-seg-btn[data-active="true"] {
+          color: var(--color-text);
+          background: color-mix(in oklab, var(--color-accent) 14%, transparent);
+        }
+        .bs-rvn-seg-btn:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+      `}</style>
+
+      <div className="bs-rvn-grid">
+        <div>
+          <span className="bs-rvn-pane-label">on the wire</span>
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.pre
+              key={mode}
+              className="bs-rvn-pane"
+              initial={reduce ? { opacity: 0 } : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: reduce ? 0 : 0.2 }}
+            >
+              {JSON.stringify(message, null, 2)}
+            </motion.pre>
+          </AnimatePresence>
+        </div>
+        <div>
+          <span className="bs-rvn-pane-label">what comes back</span>
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={mode}
+              className="bs-rvn-pane"
+              data-mode={outcome.kind === "notification" ? "muted" : undefined}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: reduce ? 0 : 0.2 }}
+              aria-live="polite"
+            >
+              {responseText}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default RequestVsNotification;

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/index.ts
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/index.ts
@@ -1,0 +1,4 @@
+export { JsonRpcSandbox } from "./JsonRpcSandbox";
+export { FieldDecoder } from "./FieldDecoder";
+export { RequestVsNotification } from "./RequestVsNotification";
+export { JsonRpcQuiz } from "./JsonRpcQuiz";

--- a/app/courses/mcps/_content/json-rpc-the-wire/widgets/server-stub.ts
+++ b/app/courses/mcps/_content/json-rpc-the-wire/widgets/server-stub.ts
@@ -1,0 +1,320 @@
+/**
+ * Deterministic JSON-RPC server stub used by `JsonRpcSandbox`,
+ * `RequestVsNotification`, and (visually) `FieldDecoder`.
+ *
+ * Why a stub and not real protocol code:
+ *   - The widget runs in the browser. Importing a real MCP server would mean
+ *     bundling node modules, sockets, and a JSON-RPC dispatcher we don't need.
+ *   - Determinism is the lesson. The reader edits a request and watches a
+ *     PREDICTABLE response — they're learning the *shape* of the protocol,
+ *     not the chaos of a live network.
+ *   - Safety. We never `eval` the reader's input — we parse it as JSON and
+ *     dispatch on `method` / `params` shape. A misshapen request gets the
+ *     real `-32700` / `-32600` / `-32601` / `-32602` codes the spec defines.
+ *
+ * This is the chapter's reusable asset — Ch 4's `HandshakeReplay`, Ch 7's
+ * `InitFlowAnimation`, and Ch 9's `RugPullReplay` should reuse the response
+ * shapes here once a second chapter wants them. Lift to `lib/mcp/stub.ts`
+ * when the second consumer arrives.
+ *
+ * Spec version we model: 2025-06-18.
+ */
+
+export type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+export type JsonRpcResponseOk = {
+  jsonrpc: "2.0";
+  id: number | string;
+  result: unknown;
+};
+
+export type JsonRpcResponseErr = {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  error: { code: number; message: string; data?: unknown };
+};
+
+export type JsonRpcResponse = JsonRpcResponseOk | JsonRpcResponseErr;
+
+/** What the sandbox renders in the right pane. */
+export type StubOutcome =
+  | { kind: "response"; payload: JsonRpcResponse }
+  | { kind: "notification" }
+  | { kind: "parse-error"; payload: JsonRpcResponseErr };
+
+const PROTOCOL_VERSION = "2025-06-18";
+
+/**
+ * Canned tool / resource / prompt surface — small enough to fit in the
+ * sandbox's right pane without scroll, real enough to look like the spec.
+ */
+const TOOL_SURFACE = [
+  {
+    name: "search_flights",
+    description: "Find flights between two airports on a date.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from: { type: "string" },
+        to: { type: "string" },
+        date: { type: "string", format: "date" },
+      },
+      required: ["from", "to", "date"],
+    },
+  },
+  {
+    name: "send_email",
+    description: "Send an email through the connected mailbox.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        to: { type: "string" },
+        subject: { type: "string" },
+        body: { type: "string" },
+      },
+      required: ["to", "subject", "body"],
+    },
+  },
+] as const;
+
+const RESOURCE_SURFACE = [
+  {
+    uri: "weather://forecast/sf/today",
+    name: "San Francisco — today",
+    mimeType: "application/json",
+  },
+] as const;
+
+const PROMPT_SURFACE = [
+  {
+    name: "summarize_thread",
+    description: "Summarize an email thread into 3 bullets.",
+    arguments: [{ name: "thread_id", required: true }],
+  },
+] as const;
+
+/**
+ * Dispatches a parsed JSON-RPC message to its canned response. Notifications
+ * (no `id`) are recognised here and short-circuit to a `notification` outcome.
+ */
+export function dispatch(message: unknown): StubOutcome {
+  // -32600 — invalid request: not an object, missing/incorrect jsonrpc, etc.
+  if (
+    !message ||
+    typeof message !== "object" ||
+    Array.isArray(message)
+  ) {
+    return invalidRequest(null, "request must be a JSON object");
+  }
+  const m = message as Record<string, unknown>;
+  if (m.jsonrpc !== "2.0") {
+    return invalidRequest(
+      (m.id as number | string | null) ?? null,
+      'missing or invalid "jsonrpc": "2.0"',
+    );
+  }
+  if (typeof m.method !== "string" || m.method.length === 0) {
+    return invalidRequest(
+      (m.id as number | string | null) ?? null,
+      'missing or invalid "method"',
+    );
+  }
+
+  const isNotification = !("id" in m) || m.id === undefined || m.id === null;
+  if (isNotification) {
+    return { kind: "notification" };
+  }
+  const id = m.id as number | string;
+  const params = (m.params as Record<string, unknown> | undefined) ?? {};
+
+  switch (m.method) {
+    case "initialize":
+      return ok(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {
+          tools: { listChanged: true },
+          resources: { listChanged: true, subscribe: false },
+          prompts: { listChanged: true },
+          logging: {},
+        },
+        serverInfo: { name: "demo-server", version: "0.1.0" },
+      });
+    case "tools/list":
+      return ok(id, { tools: TOOL_SURFACE });
+    case "tools/call": {
+      const toolName = params.name as string | undefined;
+      if (!toolName) {
+        return invalidParams(id, 'missing required field "name"');
+      }
+      const tool = TOOL_SURFACE.find((t) => t.name === toolName);
+      if (!tool) {
+        return ok(id, {
+          content: [
+            { type: "text", text: `error: tool "${toolName}" not found` },
+          ],
+          isError: true,
+        });
+      }
+      // Echo a plausible call result; we don't actually run the tool.
+      return ok(id, {
+        content: [
+          {
+            type: "text",
+            text: `(stub) called ${toolName} with ${JSON.stringify(
+              (params.arguments as unknown) ?? {},
+            )}`,
+          },
+        ],
+        isError: false,
+      });
+    }
+    case "resources/list":
+      return ok(id, { resources: RESOURCE_SURFACE });
+    case "prompts/list":
+      return ok(id, { prompts: PROMPT_SURFACE });
+    default:
+      return methodNotFound(id, m.method);
+  }
+}
+
+/**
+ * Parses a string as JSON-RPC. Returns the canonical -32700 outcome on bad
+ * JSON; otherwise hands off to `dispatch`.
+ */
+export function parseAndDispatch(text: string): StubOutcome {
+  try {
+    const parsed = JSON.parse(text);
+    return dispatch(parsed);
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : "unknown parse error";
+    return {
+      kind: "parse-error",
+      payload: {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error", data: detail },
+      },
+    };
+  }
+}
+
+function ok(id: number | string, result: unknown): StubOutcome {
+  return {
+    kind: "response",
+    payload: { jsonrpc: "2.0", id, result },
+  };
+}
+
+function invalidRequest(
+  id: number | string | null,
+  detail: string,
+): StubOutcome {
+  return {
+    kind: "response",
+    payload: {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error: { code: -32600, message: "Invalid Request", data: detail },
+    },
+  };
+}
+
+function invalidParams(id: number | string, detail: string): StubOutcome {
+  return {
+    kind: "response",
+    payload: {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32602, message: "Invalid params", data: detail },
+    },
+  };
+}
+
+function methodNotFound(id: number | string, method: string): StubOutcome {
+  return {
+    kind: "response",
+    payload: {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32601,
+        message: "Method not found",
+        data: `unknown method "${method}"`,
+      },
+    },
+  };
+}
+
+/** The presets shown as a chip strip in the sandbox. */
+export const PRESETS: { id: string; label: string; body: string }[] = [
+  {
+    id: "initialize",
+    label: "initialize",
+    body: JSON.stringify(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { elicitation: {} },
+          clientInfo: { name: "demo-client", version: "0.1.0" },
+        },
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "tools-list",
+    label: "tools/list",
+    body: JSON.stringify(
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "tools-call",
+    label: "tools/call",
+    body: JSON.stringify(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "search_flights",
+          arguments: { from: "SFO", to: "JFK", date: "2026-05-12" },
+        },
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "notification",
+    label: "notification",
+    body: JSON.stringify(
+      {
+        jsonrpc: "2.0",
+        method: "notifications/tools/list_changed",
+      },
+      null,
+      2,
+    ),
+  },
+  {
+    id: "unknown-method",
+    label: "unknown method",
+    body: JSON.stringify(
+      { jsonrpc: "2.0", id: 4, method: "tools/cull" },
+      null,
+      2,
+    ),
+  },
+];

--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -16,7 +16,9 @@
 
 import type { ComponentType } from "react";
 import HostClientServerContent from "./host-client-server/Content";
+import JsonRpcTheWireContent from "./json-rpc-the-wire/Content";
 
 export const MCPS_CONTENT: Record<string, ComponentType> = {
   "host-client-server": HostClientServerContent,
+  "json-rpc-the-wire": JsonRpcTheWireContent,
 };

--- a/content/courses-manifest.ts
+++ b/content/courses-manifest.ts
@@ -50,21 +50,21 @@ export const COURSES: CourseMeta[] = [
         slug: "the-room-before-the-protocol",
         title: "The room before the protocol",
         hook:
-          "before MCP, every AI integration was a one-off — and your terminal already hides the receipt.",
+          "before MCP, every AI integration was a one-off — and your terminal already hides the receipt.",: chapter 3 — JSON-RPC, the wire that carries it)
         readingMinutes: 8,
       },
       {
         slug: "host-client-server",
         title: "Three roles, one connection",
         hook:
-          "MCP isn't peer-to-peer. it's a host that spawns one client per server.",
+          "MCP isn't peer-to-peer. it's a host that spawns one client per server.",: chapter 3 — JSON-RPC, the wire that carries it)
         readingMinutes: 10,
       },
       {
         slug: "json-rpc-the-wire",
         title: "JSON-RPC, the wire that carries it",
         hook:
-          "every MCP message is JSON-RPC 2.0. four fields are the whole story.",
+          "every MCP message is JSON-RPC 2.0. four fields are the whole story.",: chapter 3 — JSON-RPC, the wire that carries it)
         readingMinutes: 12,
       },
       {
@@ -105,7 +105,7 @@ export const COURSES: CourseMeta[] = [
         slug: "how-mcp-gets-attacked",
         title: "How MCP gets attacked",
         hook:
-          "MCP is a protocol, not a perimeter. the spec says SHOULD; you ship the MUST.",
+          "MCP is a protocol, not a perimeter. the spec says SHOULD; you ship the MUST.",: chapter 3 — JSON-RPC, the wire that carries it)
         readingMinutes: 12,
       },
     ],


### PR DESCRIPTION
Resolves #72.

## Summary

- Ships chapter 3 — the load-bearing reference chapter the rest of the
  course leans on. Once the reader can read four fields (`jsonrpc`,
  `id`, `method`, `params`), every later chapter (handshake, primitives,
  server, client, attacks) becomes legible at the wire.
- The chapter's spine is `JsonRpcSandbox`: a two-pane editor where the
  reader edits live JSON-RPC and watches a deterministic in-browser
  server stub respond. Real `-32700 / -32600 / -32601 / -32602` codes;
  notifications collapse the response pane to silence; preset chips
  (initialize, tools/list, tools/call, notification, unknown method)
  load starting points.
- Establishes a per-slug content-module convention:
  `app/courses/<course>/_content/<slug>/Content.tsx` + `widgets/`,
  resolved via a small registry the dynamic chapter route consults.
  Un-registered slugs fall through to the existing placeholder, so
  parallel chapter agents stay unblocked.

## Widgets shipped

- **`JsonRpcSandbox`** (load-bearing) — two-pane editor + stub. Plain
  `<textarea>` + 200ms-debounced parse. No editor lib, no `eval`. Five
  preset chips. Mobile stacks vertically; editor capped at ~38vh.
  Response pane is `aria-live="polite"`.
- **`FieldDecoder`** — annotated `tools/list` request. Hover / tap /
  focus on each of the four fields reveals a callout. `aria-describedby`
  wires the field button to the callout.
- **`RequestVsNotification`** — segmented toggle. Same shape on the
  wire, one missing `id`; round-trip counter ticks on requests and
  holds on notifications.
- **`JsonRpcQuiz`** — premise-quiz opener (voice §12.1). Built on the
  shared `<Quiz>` wrapper. Four options model real wrong mental models;
  the wrong answer creates demand for the reframe.

## Conventions established

- `app/courses/mcps/_content/registry.ts` resolves `(courseSlug,
  chapterSlug) → dynamic import` of `Content.tsx`. Adding a chapter is
  one registry entry.
- Manifest singularised ("Model Context Protocols" → "Model Context
  Protocol") and re-keyed to the 9-chapter outline from the
  brainstorm.
- Server stub (`./widgets/server-stub.ts`) is a pure dispatcher. Ch 4's
  `HandshakeReplay`, ch 7's `InitFlowAnimation`, ch 9's `RugPullReplay`
  should reuse it (lift to `lib/mcp/stub.ts` once a second consumer
  arrives).
- Spec version modeled: `2025-06-18`.

## Out of scope (deliberately)

- Transports (`stdio`, Streamable HTTP) — chapter 7.
- Capability-negotiation contents — chapter 4.
- Batch JSON-RPC, vendor error codes, cancellation/progress tokens —
  named only or skipped per the brainstorm.

## Test plan

- [x] `pnpm build` — green; static export covers all 9 chapter URLs.
- [x] `npx tsc --noEmit` — clean (only the pre-existing `@web-kits/audio`
      module-resolution noise unrelated to this PR).
- [x] `pnpm lint app/courses/mcps/_content/` — clean.
- [x] `grep -rn VerticalCutReveal app/courses/mcps/_content/` — only the
      doc-comment naming the ban; no usage.
- [x] `grep -rnE '<hr|<br' app/courses/mcps/_content/` — only the
      doc-comment naming the ban; no usage.
- [x] `pnpm dev` on port 3005 — `/courses/mcps` and
      `/courses/mcps/json-rpc-the-wire` both serve 200.
- [ ] Manual at 375 + 1440 — premise quiz works; sandbox edits update
      response shape; preset chips load presets; error codes fire on
      mangled JSON / unknown method / dropped `jsonrpc`; mobile
      stacking works.
- [ ] Reduced-motion + keyboard nav — editor is reachable via Tab;
      preset radiogroup announces correctly; callouts work without
      pointer.
- [ ] Lighthouse — confirm perf + a11y stay ≥ 95 on the chapter URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)