### PR TITLE
feat(courses/mcps): chapter 6 — Build a server, in the page

### DIFF
--- a/app/courses/mcps/_content/build-a-server/Content.tsx
+++ b/app/courses/mcps/_content/build-a-server/Content.tsx
@@ -1,0 +1,351 @@
+/**
+ * Chapter 6 — Build a server, in the page.
+ *
+ * Server component. Composes the chapter prose around three widgets:
+ *   1. ServerEditorQuiz — premise-quiz opener (voice §12.1).
+ *   2. ServerEditor     — LOAD-BEARING. Tabbed registration form (tools |
+ *                         resources | prompts) with a "try it" panel that
+ *                         synthesizes JSON-RPC responses from the reader's
+ *                         declarations. Parsed-stub approach (no eval).
+ *   3. (LiveCallStrip is composed inside ServerEditor; not rendered here.)
+ *
+ * Voice §12 patterns honoured:
+ *   - <Term> on first appearance of every spec word.
+ *   - Mechanism-first reframe — registration as the mechanism; handler
+ *     bodies as a downstream concern.
+ *   - Just-in-time vocabulary, no glossary chapter.
+ *   - Closer is still prose; loops back to the opener (descriptions matter).
+ *   - VerticalCutReveal banned (per playbook).
+ *
+ * No <hr>, no <br>. Section breaks ride on <H2> + spacing rhythm.
+ *
+ * The chapter uses the parsed-stub approach (NOT sandboxed eval) per the
+ * brainstormer's "Needs decision" call-out, decided in favour of safety
+ * and ship-in-one-turn pragmatism. The reader still touches every part of
+ * the registration surface — name, description, schema, URI template,
+ * prompt arguments — and watches the JSON-RPC shape land live.
+ */
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { Callout, H2, H3, P, Term } from "@/components/prose";
+import { CodeBlock } from "@/components/code/CodeBlock";
+
+const ServerEditorQuiz = dynamic(() =>
+  import("./widgets/ServerEditorQuiz").then((m) => m.ServerEditorQuiz),
+);
+const ServerEditor = dynamic(() =>
+  import("./widgets/ServerEditor").then((m) => m.ServerEditor),
+);
+
+export function Content() {
+  return (
+    <>
+      <P>
+        You have the wire from chapter 3, the handshake from chapter 4, and
+        the three primitives — tools, resources, prompts — from chapter 5.
+        What you don&apos;t have, yet, is a server. The four-message
+        exchange that&apos;s been flying through the diagrams was always
+        between two real processes; one of them is what this chapter
+        builds. The build is small enough to fit in one page, and you
+        won&apos;t leave this tab to do it.
+      </P>
+
+      <P>
+        Before we open the editor, a quick check on what the host actually
+        sees when your server replies. Most readers arrive thinking the
+        tool name does the heavy lifting. The spec disagrees — and so will
+        your model.
+      </P>
+
+      <ServerEditorQuiz />
+
+      <H2>The frame, in one paragraph</H2>
+
+      <P>
+        An MCP server is a process that registers a small set of named
+        primitives and answers JSON-RPC requests about them. The official{" "}
+        <Term>SDK</Term> — <code style={{ fontFamily: "var(--font-mono)" }}>@modelcontextprotocol/sdk</code>{" "}
+        in TypeScript — does the JSON-RPC plumbing for you: you call{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>registerTool</code>,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>registerResource</code>,
+        and <code style={{ fontFamily: "var(--font-mono)" }}>registerPrompt</code>;
+        the SDK turns those calls into the responses for{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>prompts/list</code>{" "}
+        and their corresponding read / call / get methods. No socket code,
+        no JSON parsing — you describe what the server has, and the SDK
+        carries it onto the wire.
+      </P>
+
+      <CodeBlock
+        lang="typescript"
+        filename="currency-server.ts (the shape, not the prose)"
+        code={`import { McpServer } from "@modelcontextprotocol/sdk/server/mcp";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio";
+import { z } from "zod";
+
+const server = new McpServer({ name: "currency-server", version: "0.1.0" });
+
+server.registerTool(
+  "convert",
+  {
+    description: "Convert an amount from one currency to another.",
+    inputSchema: { from: z.string(), to: z.string(), amount: z.number() },
+  },
+  async ({ from, to, amount }) => {
+    const rate = await rates.get(from, to);
+    return { content: [{ type: "text", text: String(rate * amount) }] };
+  },
+);
+
+server.registerResource("rates", "rates://{date}", {
+  mimeType: "application/json",
+  description: "FX rates for an ISO date.",
+}, async ({ date }) => ({ contents: [{ uri: \`rates://\${date}\`, mimeType: "application/json", text: JSON.stringify(await rates.snapshot(date)) }] }));
+
+server.registerPrompt("recommend-currency-mix", {
+  description: "Suggest a multi-currency holding split.",
+  arguments: [{ name: "country", required: true }, { name: "horizon" }],
+}, async ({ country, horizon }) => ({
+  messages: [{ role: "user", content: { type: "text", text: \`Recommend a mix for \${country} over \${horizon ?? "12m"}.\` } }],
+}));
+
+await server.connect(new StdioServerTransport());`}
+      />
+
+      <P>
+        That listing is the end-state — the file you&apos;d write outside
+        this page. We&apos;ll build it with our hands in a second. The
+        widget below isn&apos;t this exact file in a sandbox, but a{" "}
+        <em>parsed-stub equivalent</em> — you fill in registrations through
+        a small form, and the page synthesizes the JSON-RPC responses the
+        SDK <em>would</em> emit from those declarations. The lesson is
+        registration: what the model sees, what the host validates against,
+        what the URI template addresses. Handler bodies are a downstream
+        concern — you can write them in a real editor after the chapter,
+        and the file above is your starting point.
+      </P>
+
+      <Callout tone="note">
+        We&apos;re not running JavaScript in your browser. The editor below
+        synthesizes responses from the registration metadata — the same
+        metadata the SDK uses to satisfy{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>,
+        and <code style={{ fontFamily: "var(--font-mono)" }}>prompts/list</code>.
+        This is the part of the SDK the model actually <em>reads</em>.
+      </Callout>
+
+      <H2>A server in your hands</H2>
+
+      <P>
+        Open it up. The editor starts with the worked example loaded — a{" "}
+        <Term>currency-server</Term> exposing one tool (
+        <code style={{ fontFamily: "var(--font-mono)" }}>convert</code>),
+        one resource (
+        <code style={{ fontFamily: "var(--font-mono)" }}>rates://&#123;date&#125;</code>),
+        and one prompt (
+        <code style={{ fontFamily: "var(--font-mono)" }}>recommend-currency-mix</code>).
+        Edit any of the three, then fire a request from the &quot;try
+        it&quot; panel. The response is what a real host would receive over
+        stdio.
+      </P>
+
+      <ServerEditor />
+
+      <P>
+        Three things land while you&apos;re poking at it. First — calling{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>{" "}
+        returns the description text verbatim. That&apos;s the model&apos;s
+        only signal for when to call your tool; if you blank it out and
+        re-run the call, the entry shows up but reads as a black box.
+        Second — calling <code style={{ fontFamily: "var(--font-mono)" }}>tools/call</code>{" "}
+        without a required argument doesn&apos;t reach a handler. The host
+        validates the arguments against the schema first; the synthesizer
+        echoes the validation error the SDK would have thrown. Third — a{" "}
+        <Term>URI template</Term> like{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>rates://&#123;date&#125;</code>{" "}
+        isn&apos;t a list endpoint. There&apos;s no{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>rates://list</code>{" "}
+        — discovery is{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>,
+        access is <code style={{ fontFamily: "var(--font-mono)" }}>resources/read</code>{" "}
+        with a substituted URI, and the spec keeps those two surfaces
+        cleanly apart.
+      </P>
+
+      <H3>One tool, end to end</H3>
+
+      <P>
+        Pick the <strong>tools</strong> tab. The{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>convert</code> tool
+        carries a name, a description, and an input schema with three
+        required fields. Switch the &quot;try it&quot; method to{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>{" "}
+        and send. Note what the model gets back — a{" "}
+        <Term>JSON Schema</Term> describing each input, plus your
+        description. The schema isn&apos;t Zod on the wire; the SDK
+        translates Zod into JSON Schema so any client can validate against
+        it without a runtime dependency on Zod itself. Now switch to{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/call</code>,
+        pick <code style={{ fontFamily: "var(--font-mono)" }}>convert</code>,
+        and fill in the three fields. The synthesized response is a{" "}
+        <Term>content array</Term> — the SDK&apos;s canonical reply shape
+        for tool calls — with a single text item describing what your
+        handler would have returned.
+      </P>
+
+      <H3>One resource</H3>
+
+      <P>
+        Switch to the <strong>resources</strong> tab. The reader will see{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>rates://&#123;date&#125;</code>{" "}
+        — a URI template, not a concrete URI. The placeholder in braces
+        becomes a parameter the host substitutes when it asks to read.
+        Send a <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>{" "}
+        and you&apos;ll see the template, the MIME type, and the
+        description. Now switch to{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>resources/read</code>{" "}
+        and replace the placeholder with{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>2026-04-30</code>.
+        The synthesizer matches your URI back against the template and
+        synthesizes a response the application would feed to the model.
+        Try a URI that doesn&apos;t match — the response carries an error,
+        not a list. Resources are <em>content-addressable</em>, not
+        enumerable.
+      </P>
+
+      <H3>One prompt</H3>
+
+      <P>
+        The <strong>prompts</strong> tab carries{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>recommend-currency-mix</code>{" "}
+        — the user-controlled surface from chapter 5&apos;s controller
+        table. A prompt has a name, a description, an argument list, and a
+        body template with{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>&#123;arg&#125;</code>{" "}
+        substitutions. Switch to{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>prompts/get</code>,
+        pick the prompt, fill in{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>country=JP</code>{" "}
+        and <code style={{ fontFamily: "var(--font-mono)" }}>horizon=6m</code>,
+        and send. The response is a{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>messages</code>{" "}
+        array — pre-formed conversation turns the user invokes via a slash
+        command in their host.
+      </P>
+
+      <H2>The discipline behind the shapes</H2>
+
+      <P>
+        Three rules survive when you peel away the form and look at the
+        bytes on the wire. <strong>Descriptions matter</strong>: they&apos;re
+        the only thing the <Term>model</Term> reads to decide which tool to
+        call. An empty description registers cleanly and is invisible in
+        practice; a misleading one hijacks the model&apos;s decisions
+        (chapter 9 will cash this in as an attack surface).{" "}
+        <strong>Schemas matter</strong>: the <Term>host</Term> validates
+        arguments against the input schema before the handler runs.
+        Validation errors are the spec&apos;s — not yours; you don&apos;t
+        write them.{" "}
+        <strong>URI templates matter</strong>: a resource isn&apos;t a
+        named record but a content-addressable shape. Hosts list templates
+        with <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>{" "}
+        and read concrete URIs with{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>resources/read</code>{" "}
+        — discovery is one method, access is another, and the spec is
+        explicit about the separation.
+      </P>
+
+      <Callout tone="note">
+        In real life, you connect the server to a transport with{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>await server.connect(new StdioServerTransport())</code>.
+        Stdio is the right choice when the host spawns the server as a
+        subprocess on the same machine. Chapter 7 picks up here — when the
+        server lives somewhere else, stdio gives way to streamable HTTP.
+      </Callout>
+
+      <H2>Comprehension check</H2>
+
+      <P>
+        You register a resource at{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>notes://&#123;id&#125;</code>{" "}
+        and the user asks the host to call{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>notes/list</code>.
+        What happens?
+      </P>
+
+      <details
+        className="font-serif"
+        style={{
+          marginTop: "1em",
+          marginBottom: "1em",
+          background: "var(--color-surface)",
+          padding: "var(--spacing-md)",
+          borderRadius: "var(--radius-md)",
+          fontSize: "var(--text-body)",
+          lineHeight: 1.6,
+          border: "1px solid var(--color-rule)",
+        }}
+      >
+        <summary
+          style={{
+            cursor: "pointer",
+            color: "var(--color-text-muted)",
+            fontFamily: "var(--font-sans)",
+            fontSize: "var(--text-small)",
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          }}
+        >
+          reveal answer
+        </summary>
+        <P>
+          Nothing — there is no{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>notes/list</code>{" "}
+          method in the spec. Discovery on the resource axis is{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>resources/list</code>,
+          which returns your template; access is{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>resources/read</code>{" "}
+          with a concrete URI like{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>notes://abc</code>.
+          The two surfaces are deliberately separate: one for &quot;what do
+          you have?&quot;, the other for &quot;give me this specific
+          thing.&quot; A host that conflates them gets{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>-32601 method not found</code>{" "}
+          — and the spec is right to refuse.
+        </P>
+      </details>
+
+      <H2>The server is standing. Now what?</H2>
+
+      <P>
+        You registered three things, fired six requests, and watched the
+        JSON-RPC shapes land. The descriptions on your tools are what the
+        model reads; the schemas are what the host enforces; the URI
+        templates address content the application can fetch on the
+        model&apos;s behalf. Nothing in there is mysterious — the SDK
+        handles the wire, you handle the registrations, and the four-
+        message handshake from chapter 4 carries the menu across.
+      </P>
+
+      <P>
+        Which leaves the question we&apos;ve been deferring since chapter
+        3. The server is standing. Who&apos;s <em>calling</em> it? The
+        host spawned a process and got bytes back over a pipe. We need a
+        client — and we need to pick a transport while we&apos;re at it.{" "}
+        <Link
+          href="/courses/mcps/build-a-client-pick-a-transport"
+          className="font-sans"
+          style={{ color: "var(--color-accent)" }}
+        >
+          That&apos;s chapter 7.
+        </Link>
+      </P>
+    </>
+  );
+}
+
+export default Content;

--- a/app/courses/mcps/_content/build-a-server/widgets/LiveCallStrip.tsx
+++ b/app/courses/mcps/_content/build-a-server/widgets/LiveCallStrip.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * LiveCallStrip — a small horizontal log of the most recent JSON-RPC
+ * exchanges the reader has triggered in the ServerEditor. Each entry
+ * collapses to a one-line summary (method + outcome) and expands to
+ * show the request and response bodies.
+ *
+ * Why it exists: the editor itself shows the *current* request/response;
+ * the strip preserves the trail so the reader can compare a successful
+ * call to a failed one without losing either. Uses the same JSON
+ * presentation as Ch 3's `JsonRpcSandbox` — small <pre> blocks in the
+ * surface tone — to keep visual continuity across the course.
+ *
+ * Reduced-motion: collapse/expand snaps. Mobile: each entry stacks its
+ * request and response vertically rather than side-by-side.
+ */
+
+import { useState } from "react";
+import type { JsonRpcResponse } from "./server-stub";
+
+export type CallLogEntry = {
+  /** Stable id per call so React keys are stable. */
+  id: string;
+  method: string;
+  request: unknown;
+  response: JsonRpcResponse;
+};
+
+export function LiveCallStrip({ entries }: { entries: CallLogEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <div
+        className="font-mono"
+        style={{
+          fontSize: "var(--text-small)",
+          color: "var(--color-text-muted)",
+          padding: "var(--spacing-sm) var(--spacing-md)",
+          background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
+          borderRadius: "var(--radius-sm)",
+          border: "1px dashed var(--color-rule)",
+          textAlign: "center",
+        }}
+        aria-live="polite"
+      >
+        no calls yet — issue one from the &quot;try it&quot; panel above
+      </div>
+    );
+  }
+  return (
+    <ol
+      className="flex flex-col gap-[var(--spacing-xs)]"
+      style={{ listStyle: "none", padding: 0, margin: 0 }}
+      aria-label="recent JSON-RPC exchanges"
+    >
+      {entries.map((e) => (
+        <CallLogRow key={e.id} entry={e} />
+      ))}
+    </ol>
+  );
+}
+
+function CallLogRow({ entry }: { entry: CallLogEntry }) {
+  const [open, setOpen] = useState(false);
+  const isErr = "error" in entry.response;
+  return (
+    <li
+      style={{
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-rule)",
+        borderRadius: "var(--radius-sm)",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="w-full text-left flex items-center justify-between gap-[var(--spacing-sm)]"
+        style={{
+          padding: "var(--spacing-xs) var(--spacing-sm)",
+          background: "transparent",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--color-text)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--text-small)",
+        }}
+      >
+        <span style={{ display: "flex", gap: "var(--spacing-sm)", alignItems: "center" }}>
+          <span
+            aria-hidden
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: isErr ? "var(--color-text-muted)" : "var(--color-accent)",
+              display: "inline-block",
+            }}
+          />
+          <span>{entry.method}</span>
+          <span style={{ color: "var(--color-text-muted)" }}>
+            · {isErr ? "error" : "ok"}
+          </span>
+        </span>
+        <span
+          aria-hidden
+          style={{ color: "var(--color-text-muted)", fontSize: "var(--text-small)" }}
+        >
+          {open ? "−" : "+"}
+        </span>
+      </button>
+      {open ? (
+        <div
+          className="bs-callstrip-body"
+          style={{
+            display: "grid",
+            gap: "var(--spacing-sm)",
+            padding: "var(--spacing-sm)",
+            borderTop: "1px solid var(--color-rule)",
+            background: "color-mix(in oklab, var(--color-surface) 60%, transparent)",
+          }}
+        >
+          <CallPre label="request" value={entry.request} />
+          <CallPre label="response" value={entry.response} />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function CallPre({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div>
+      <div
+        className="font-sans"
+        style={{
+          fontSize: "var(--text-small)",
+          letterSpacing: "0.04em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+          marginBottom: "calc(var(--spacing-xs) / 2)",
+        }}
+      >
+        {label}
+      </div>
+      <pre
+        className="font-mono"
+        style={{
+          margin: 0,
+          padding: "var(--spacing-xs) var(--spacing-sm)",
+          background: "var(--color-bg)",
+          border: "1px solid var(--color-rule)",
+          borderRadius: "var(--radius-sm)",
+          fontSize: "var(--text-small)",
+          lineHeight: 1.5,
+          overflowX: "auto",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          color: "var(--color-text)",
+        }}
+      >
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export default LiveCallStrip;

--- a/app/courses/mcps/_content/build-a-server/widgets/ServerEditor.tsx
+++ b/app/courses/mcps/_content/build-a-server/widgets/ServerEditor.tsx
@@ -1,0 +1,1165 @@
+"use client";
+
+/**
+ * ServerEditor — chapter 6's load-bearing widget.
+ *
+ * Decision recorded (issue #75 ServerEditor ambition): PARSED-STUB.
+ *   The reader does not write JS. They edit a small set of registration
+ *   forms — name, description, JSON-Schema-shaped fields, URI templates,
+ *   prompt arguments — and the widget synthesizes the JSON-RPC responses
+ *   the SDK *would* return from those declarations. No `eval`, no
+ *   `Function`-from-string, no Web Worker. The lesson is registration —
+ *   what the model sees, what the host validates against, what the URI
+ *   template addresses — not handler-implementation.
+ *
+ * UX:
+ *   - Three tabs: Tools, Resources, Prompts.
+ *   - Each tab lists the reader's current registrations + an "add" form.
+ *   - Below the tabs sits a "try it" panel that lets the reader fire one
+ *     of `tools/list`, `tools/call`, `resources/list`, `resources/read`,
+ *     `prompts/list`, `prompts/get` against the registry; the synthesized
+ *     response renders in the right pane.
+ *   - A "reset demo" button restores the chapter's currency-server example.
+ *
+ * Accessibility:
+ *   - Tabs are real <button role="tab">; tab panels carry aria-labelledby.
+ *   - All inputs carry visible labels and matching <label htmlFor>.
+ *   - Response region is aria-live="polite".
+ *
+ * Reduced motion: snap; tab content swaps without crossfade. The frame is
+ * the same height regardless of state (R6 — no relayout on tab switch).
+ *
+ * Mobile (≤ 560 px container): tabs stay a row of buttons; the registry
+ * list and "try it" panel stack vertically. Hit zones are ≥ 36 px tall.
+ *
+ * Single accent: the active tab + the "send" button + the call-strip's
+ * "ok" pill are terracotta. Errors / info read via muted text + a dashed
+ * border, never red.
+ */
+
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { playSound } from "@/lib/audio";
+import {
+  DEFAULT_REGISTRY,
+  extractPlaceholders,
+  fieldsToJsonSchema,
+  synth,
+  type JsonRpcResponse,
+  type PromptDecl,
+  type Registry,
+  type ResourceDecl,
+  type SchemaField,
+  type ToolDecl,
+} from "./server-stub";
+import { LiveCallStrip, type CallLogEntry } from "./LiveCallStrip";
+import "./server-editor.css";
+
+type TabKey = "tools" | "resources" | "prompts";
+
+type Method =
+  | "tools/list"
+  | "tools/call"
+  | "resources/list"
+  | "resources/read"
+  | "prompts/list"
+  | "prompts/get";
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: "tools", label: "tools" },
+  { key: "resources", label: "resources" },
+  { key: "prompts", label: "prompts" },
+];
+
+let CALL_ID_SEED = 1;
+const nextCallId = () => `call-${CALL_ID_SEED++}`;
+
+export function ServerEditor() {
+  const [registry, setRegistry] = useState<Registry>(() => clone(DEFAULT_REGISTRY));
+  const [tab, setTab] = useState<TabKey>("tools");
+  const [log, setLog] = useState<CallLogEntry[]>([]);
+
+  // try-it panel state — picks differ per method
+  const [method, setMethod] = useState<Method>("tools/list");
+  const [callToolName, setCallToolName] = useState<string>("");
+  const [callArgs, setCallArgs] = useState<Record<string, string>>({});
+  const [readUri, setReadUri] = useState<string>("");
+  const [promptName, setPromptName] = useState<string>("");
+  const [promptArgs, setPromptArgs] = useState<Record<string, string>>({});
+
+  // Sync sensible defaults when registry changes — pre-select first item
+  // for `tools/call`, `resources/read`, `prompts/get` if current selection
+  // becomes invalid.
+  const ensureDefaultsForMethod = useCallback(
+    (m: Method, reg: Registry) => {
+      if (m === "tools/call") {
+        const first = reg.tools[0];
+        if (!first) {
+          setCallToolName("");
+          setCallArgs({});
+          return;
+        }
+        if (!reg.tools.find((t) => t.name === callToolName)) {
+          setCallToolName(first.name);
+          const seed: Record<string, string> = {};
+          first.inputSchema.forEach((f) => (seed[f.name] = ""));
+          setCallArgs(seed);
+        }
+      }
+      if (m === "resources/read") {
+        const first = reg.resources[0];
+        if (!first) {
+          setReadUri("");
+          return;
+        }
+        const placeholders = extractPlaceholders(first.uriTemplate);
+        const sample = placeholders.reduce(
+          (acc, ph) => acc.replace(`{${ph}}`, "example"),
+          first.uriTemplate,
+        );
+        setReadUri(sample);
+      }
+      if (m === "prompts/get") {
+        const first = reg.prompts[0];
+        if (!first) {
+          setPromptName("");
+          setPromptArgs({});
+          return;
+        }
+        if (!reg.prompts.find((p) => p.name === promptName)) {
+          setPromptName(first.name);
+          const seed: Record<string, string> = {};
+          first.arguments.forEach((a) => (seed[a.name] = ""));
+          setPromptArgs(seed);
+        }
+      }
+    },
+    [callToolName, promptName],
+  );
+
+  const onMethodChange = (m: Method) => {
+    setMethod(m);
+    ensureDefaultsForMethod(m, registry);
+  };
+
+  const reset = () => {
+    const fresh = clone(DEFAULT_REGISTRY);
+    setRegistry(fresh);
+    setLog([]);
+    setMethod("tools/list");
+    setCallToolName("");
+    setCallArgs({});
+    setReadUri("");
+    setPromptName("");
+    setPromptArgs({});
+  };
+
+  const fire = () => {
+    const id = log.length + 1;
+    let request: { jsonrpc: "2.0"; id: number; method: Method; params?: Record<string, unknown> };
+    let params: Record<string, unknown> = {};
+    if (method === "tools/call") {
+      params = { name: callToolName, arguments: typedArgs(callArgs, registry, callToolName) };
+      request = { jsonrpc: "2.0", id, method, params };
+    } else if (method === "resources/read") {
+      params = { uri: readUri };
+      request = { jsonrpc: "2.0", id, method, params };
+    } else if (method === "prompts/get") {
+      params = { name: promptName, arguments: promptArgs };
+      request = { jsonrpc: "2.0", id, method, params };
+    } else {
+      request = { jsonrpc: "2.0", id, method };
+    }
+    const outcome = synth(id, method, params, registry);
+    const response: JsonRpcResponse = outcome.payload;
+    setLog((prev) => {
+      const entry: CallLogEntry = {
+        id: nextCallId(),
+        method,
+        request,
+        response,
+      };
+      const next = [entry, ...prev];
+      return next.slice(0, 5);
+    });
+    playSound("Click");
+  };
+
+  return (
+    <WidgetShell
+      title="ServerEditor — your MCP server, in the page"
+      caption={
+        <>
+          Add, edit, or remove registrations on the left; fire a JSON-RPC
+          request on the right. The widget synthesizes the response from
+          your declarations — no code runs, but the shape is exactly what
+          the SDK would return.
+        </>
+      }
+    >
+      <div className="bs-server-editor flex flex-col gap-[var(--spacing-md)]">
+        {/* Tab strip */}
+        <div
+          role="tablist"
+          aria-label="primitive type"
+          className="flex gap-[var(--spacing-xs)] flex-wrap"
+        >
+          {TABS.map((t) => {
+            const active = t.key === tab;
+            return (
+              <button
+                key={t.key}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-controls={`tab-panel-${t.key}`}
+                id={`tab-${t.key}`}
+                onClick={() => setTab(t.key)}
+                className="font-mono"
+                style={{
+                  padding: "calc(var(--spacing-xs) + 2px) var(--spacing-sm)",
+                  fontSize: "var(--text-small)",
+                  background: active
+                    ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+                    : "transparent",
+                  color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+                  border: `1px solid ${active ? "var(--color-accent)" : "var(--color-rule)"}`,
+                  borderRadius: "var(--radius-sm)",
+                  cursor: "pointer",
+                  minHeight: 36,
+                }}
+              >
+                {t.label}
+                <span
+                  aria-hidden
+                  style={{ marginLeft: 6, color: "var(--color-text-muted)" }}
+                >
+                  · {countFor(t.key, registry)}
+                </span>
+              </button>
+            );
+          })}
+          <span style={{ flex: 1 }} aria-hidden />
+          <button
+            type="button"
+            onClick={reset}
+            className="font-sans"
+            style={{
+              padding: "calc(var(--spacing-xs) + 2px) var(--spacing-sm)",
+              fontSize: "var(--text-small)",
+              background: "transparent",
+              color: "var(--color-text-muted)",
+              border: "1px solid var(--color-rule)",
+              borderRadius: "var(--radius-sm)",
+              cursor: "pointer",
+              minHeight: 36,
+            }}
+          >
+            reset demo
+          </button>
+        </div>
+
+        {/* Tab panel */}
+        <div
+          role="tabpanel"
+          id={`tab-panel-${tab}`}
+          aria-labelledby={`tab-${tab}`}
+        >
+          {tab === "tools" && (
+            <ToolsPanel
+              tools={registry.tools}
+              onChange={(tools) => setRegistry((r) => ({ ...r, tools }))}
+            />
+          )}
+          {tab === "resources" && (
+            <ResourcesPanel
+              resources={registry.resources}
+              onChange={(resources) =>
+                setRegistry((r) => ({ ...r, resources }))
+              }
+            />
+          )}
+          {tab === "prompts" && (
+            <PromptsPanel
+              prompts={registry.prompts}
+              onChange={(prompts) => setRegistry((r) => ({ ...r, prompts }))}
+            />
+          )}
+        </div>
+
+        {/* Try-it panel */}
+        <div
+          className="bs-tryit"
+          style={{
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-rule)",
+            borderRadius: "var(--radius-md)",
+            padding: "var(--spacing-md)",
+          }}
+        >
+          <div
+            className="font-sans"
+            style={{
+              fontSize: "var(--text-small)",
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+              marginBottom: "var(--spacing-sm)",
+            }}
+          >
+            try it · synthesised JSON-RPC
+          </div>
+
+          <div
+            className="bs-tryit-grid"
+            style={{
+              display: "grid",
+              gap: "var(--spacing-md)",
+              gridTemplateColumns: "1fr",
+            }}
+          >
+            <TryItControls
+              method={method}
+              onMethodChange={onMethodChange}
+              registry={registry}
+              callToolName={callToolName}
+              setCallToolName={(name) => {
+                setCallToolName(name);
+                const t = registry.tools.find((tt) => tt.name === name);
+                const seed: Record<string, string> = {};
+                t?.inputSchema.forEach((f) => (seed[f.name] = ""));
+                setCallArgs(seed);
+              }}
+              callArgs={callArgs}
+              setCallArgs={setCallArgs}
+              readUri={readUri}
+              setReadUri={setReadUri}
+              promptName={promptName}
+              setPromptName={(name) => {
+                setPromptName(name);
+                const p = registry.prompts.find((pp) => pp.name === name);
+                const seed: Record<string, string> = {};
+                p?.arguments.forEach((a) => (seed[a.name] = ""));
+                setPromptArgs(seed);
+              }}
+              promptArgs={promptArgs}
+              setPromptArgs={setPromptArgs}
+              onFire={fire}
+            />
+          </div>
+
+          <div style={{ marginTop: "var(--spacing-md)" }}>
+            <div
+              className="font-sans"
+              style={{
+                fontSize: "var(--text-small)",
+                letterSpacing: "0.04em",
+                textTransform: "uppercase",
+                color: "var(--color-text-muted)",
+                marginBottom: "var(--spacing-xs)",
+              }}
+            >
+              recent calls (last 5)
+            </div>
+            <LiveCallStrip entries={log} />
+          </div>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+/* ───────── tools panel ───────── */
+
+function ToolsPanel({
+  tools,
+  onChange,
+}: {
+  tools: ToolDecl[];
+  onChange: (tools: ToolDecl[]) => void;
+}) {
+  const addTool = () => {
+    const id = `tool-${Date.now()}`;
+    onChange([
+      ...tools,
+      {
+        id,
+        name: "newTool",
+        description: "",
+        inputSchema: [{ name: "input", type: "string", required: true }],
+      },
+    ]);
+  };
+  return (
+    <div className="flex flex-col gap-[var(--spacing-sm)]">
+      {tools.length === 0 ? (
+        <EmptyHint>no tools registered. add one below.</EmptyHint>
+      ) : (
+        tools.map((t) => (
+          <ToolCard
+            key={t.id}
+            tool={t}
+            onChange={(next) =>
+              onChange(tools.map((x) => (x.id === t.id ? next : x)))
+            }
+            onRemove={() => onChange(tools.filter((x) => x.id !== t.id))}
+          />
+        ))
+      )}
+      <AddButton onClick={addTool} label="add tool" />
+    </div>
+  );
+}
+
+function ToolCard({
+  tool,
+  onChange,
+  onRemove,
+}: {
+  tool: ToolDecl;
+  onChange: (next: ToolDecl) => void;
+  onRemove: () => void;
+}) {
+  const nameId = useId();
+  const descId = useId();
+  return (
+    <Card>
+      <Row>
+        <Field label="name" htmlFor={nameId}>
+          <input
+            id={nameId}
+            value={tool.name}
+            onChange={(e) => onChange({ ...tool, name: e.target.value })}
+            className="bs-input"
+          />
+        </Field>
+        <RemoveButton onClick={onRemove} />
+      </Row>
+      <Field label="description" htmlFor={descId}>
+        <textarea
+          id={descId}
+          value={tool.description}
+          onChange={(e) => onChange({ ...tool, description: e.target.value })}
+          rows={2}
+          className="bs-input"
+          placeholder="one-line gloss the model reads to decide WHEN to call this tool"
+        />
+      </Field>
+      <FieldsEditor
+        fields={tool.inputSchema}
+        onChange={(inputSchema) => onChange({ ...tool, inputSchema })}
+      />
+    </Card>
+  );
+}
+
+function FieldsEditor({
+  fields,
+  onChange,
+}: {
+  fields: SchemaField[];
+  onChange: (next: SchemaField[]) => void;
+}) {
+  const update = (i: number, patch: Partial<SchemaField>) =>
+    onChange(fields.map((f, idx) => (idx === i ? { ...f, ...patch } : f)));
+  const add = () =>
+    onChange([
+      ...fields,
+      { name: `field${fields.length + 1}`, type: "string", required: false },
+    ]);
+  const remove = (i: number) =>
+    onChange(fields.filter((_, idx) => idx !== i));
+
+  return (
+    <div>
+      <div
+        className="font-sans"
+        style={{
+          fontSize: "var(--text-small)",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--spacing-xs)",
+        }}
+      >
+        input schema
+      </div>
+      <div className="flex flex-col gap-[var(--spacing-xs)]">
+        {fields.map((f, i) => (
+          <div
+            key={i}
+            className="flex flex-wrap items-center gap-[var(--spacing-xs)]"
+          >
+            <input
+              aria-label={`field ${i + 1} name`}
+              value={f.name}
+              onChange={(e) => update(i, { name: e.target.value })}
+              className="bs-input"
+              style={{ flex: "1 1 8ch", minWidth: "8ch" }}
+            />
+            <select
+              aria-label={`field ${i + 1} type`}
+              value={f.type}
+              onChange={(e) =>
+                update(i, { type: e.target.value as SchemaField["type"] })
+              }
+              className="bs-input"
+              style={{ flex: "0 1 auto" }}
+            >
+              <option value="string">string</option>
+              <option value="number">number</option>
+              <option value="boolean">boolean</option>
+            </select>
+            <label
+              className="font-mono"
+              style={{
+                fontSize: "var(--text-small)",
+                color: "var(--color-text-muted)",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                minHeight: 36,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={f.required}
+                onChange={(e) => update(i, { required: e.target.checked })}
+              />
+              required
+            </label>
+            <RemoveButton onClick={() => remove(i)} small />
+          </div>
+        ))}
+        <AddButton onClick={add} label="add field" small />
+      </div>
+    </div>
+  );
+}
+
+/* ───────── resources panel ───────── */
+
+function ResourcesPanel({
+  resources,
+  onChange,
+}: {
+  resources: ResourceDecl[];
+  onChange: (resources: ResourceDecl[]) => void;
+}) {
+  const add = () =>
+    onChange([
+      ...resources,
+      {
+        id: `res-${Date.now()}`,
+        uriTemplate: "scheme://{id}",
+        name: "newResource",
+        description: "",
+        mimeType: "application/json",
+      },
+    ]);
+  return (
+    <div className="flex flex-col gap-[var(--spacing-sm)]">
+      {resources.length === 0 ? (
+        <EmptyHint>no resources registered.</EmptyHint>
+      ) : (
+        resources.map((r) => (
+          <ResourceCard
+            key={r.id}
+            resource={r}
+            onChange={(next) =>
+              onChange(resources.map((x) => (x.id === r.id ? next : x)))
+            }
+            onRemove={() => onChange(resources.filter((x) => x.id !== r.id))}
+          />
+        ))
+      )}
+      <AddButton onClick={add} label="add resource" />
+    </div>
+  );
+}
+
+function ResourceCard({
+  resource,
+  onChange,
+  onRemove,
+}: {
+  resource: ResourceDecl;
+  onChange: (next: ResourceDecl) => void;
+  onRemove: () => void;
+}) {
+  const tplId = useId();
+  const nameId = useId();
+  const descId = useId();
+  const mimeId = useId();
+  return (
+    <Card>
+      <Row>
+        <Field label="URI template" htmlFor={tplId}>
+          <input
+            id={tplId}
+            value={resource.uriTemplate}
+            onChange={(e) =>
+              onChange({ ...resource, uriTemplate: e.target.value })
+            }
+            className="bs-input"
+            placeholder="scheme://{var}"
+          />
+        </Field>
+        <RemoveButton onClick={onRemove} />
+      </Row>
+      <Row>
+        <Field label="name" htmlFor={nameId}>
+          <input
+            id={nameId}
+            value={resource.name}
+            onChange={(e) => onChange({ ...resource, name: e.target.value })}
+            className="bs-input"
+          />
+        </Field>
+        <Field label="MIME" htmlFor={mimeId}>
+          <input
+            id={mimeId}
+            value={resource.mimeType}
+            onChange={(e) =>
+              onChange({ ...resource, mimeType: e.target.value })
+            }
+            className="bs-input"
+          />
+        </Field>
+      </Row>
+      <Field label="description" htmlFor={descId}>
+        <textarea
+          id={descId}
+          value={resource.description}
+          onChange={(e) =>
+            onChange({ ...resource, description: e.target.value })
+          }
+          rows={2}
+          className="bs-input"
+        />
+      </Field>
+    </Card>
+  );
+}
+
+/* ───────── prompts panel ───────── */
+
+function PromptsPanel({
+  prompts,
+  onChange,
+}: {
+  prompts: PromptDecl[];
+  onChange: (prompts: PromptDecl[]) => void;
+}) {
+  const add = () =>
+    onChange([
+      ...prompts,
+      {
+        id: `prompt-${Date.now()}`,
+        name: "newPrompt",
+        description: "",
+        arguments: [{ name: "topic", required: true }],
+        template: "Tell me about {topic}.",
+      },
+    ]);
+  return (
+    <div className="flex flex-col gap-[var(--spacing-sm)]">
+      {prompts.length === 0 ? (
+        <EmptyHint>no prompts registered.</EmptyHint>
+      ) : (
+        prompts.map((p) => (
+          <PromptCard
+            key={p.id}
+            prompt={p}
+            onChange={(next) =>
+              onChange(prompts.map((x) => (x.id === p.id ? next : x)))
+            }
+            onRemove={() => onChange(prompts.filter((x) => x.id !== p.id))}
+          />
+        ))
+      )}
+      <AddButton onClick={add} label="add prompt" />
+    </div>
+  );
+}
+
+function PromptCard({
+  prompt,
+  onChange,
+  onRemove,
+}: {
+  prompt: PromptDecl;
+  onChange: (next: PromptDecl) => void;
+  onRemove: () => void;
+}) {
+  const nameId = useId();
+  const descId = useId();
+  const tplId = useId();
+  return (
+    <Card>
+      <Row>
+        <Field label="name" htmlFor={nameId}>
+          <input
+            id={nameId}
+            value={prompt.name}
+            onChange={(e) => onChange({ ...prompt, name: e.target.value })}
+            className="bs-input"
+          />
+        </Field>
+        <RemoveButton onClick={onRemove} />
+      </Row>
+      <Field label="description" htmlFor={descId}>
+        <textarea
+          id={descId}
+          value={prompt.description}
+          onChange={(e) => onChange({ ...prompt, description: e.target.value })}
+          rows={2}
+          className="bs-input"
+        />
+      </Field>
+      <PromptArgsEditor
+        args={prompt.arguments}
+        onChange={(args) => onChange({ ...prompt, arguments: args })}
+      />
+      <Field label="template" htmlFor={tplId}>
+        <textarea
+          id={tplId}
+          value={prompt.template}
+          onChange={(e) => onChange({ ...prompt, template: e.target.value })}
+          rows={3}
+          className="bs-input"
+          placeholder="prompt body — use {arg} for substitution"
+        />
+      </Field>
+    </Card>
+  );
+}
+
+function PromptArgsEditor({
+  args,
+  onChange,
+}: {
+  args: PromptDecl["arguments"];
+  onChange: (next: PromptDecl["arguments"]) => void;
+}) {
+  const update = (i: number, patch: Partial<PromptDecl["arguments"][number]>) =>
+    onChange(args.map((a, idx) => (idx === i ? { ...a, ...patch } : a)));
+  const add = () =>
+    onChange([...args, { name: `arg${args.length + 1}`, required: false }]);
+  const remove = (i: number) => onChange(args.filter((_, idx) => idx !== i));
+  return (
+    <div>
+      <div
+        className="font-sans"
+        style={{
+          fontSize: "var(--text-small)",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--spacing-xs)",
+        }}
+      >
+        arguments
+      </div>
+      <div className="flex flex-col gap-[var(--spacing-xs)]">
+        {args.map((a, i) => (
+          <div
+            key={i}
+            className="flex flex-wrap items-center gap-[var(--spacing-xs)]"
+          >
+            <input
+              aria-label={`prompt arg ${i + 1} name`}
+              value={a.name}
+              onChange={(e) => update(i, { name: e.target.value })}
+              className="bs-input"
+              style={{ flex: "1 1 8ch", minWidth: "8ch" }}
+            />
+            <label
+              className="font-mono"
+              style={{
+                fontSize: "var(--text-small)",
+                color: "var(--color-text-muted)",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                minHeight: 36,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={a.required}
+                onChange={(e) => update(i, { required: e.target.checked })}
+              />
+              required
+            </label>
+            <RemoveButton onClick={() => remove(i)} small />
+          </div>
+        ))}
+        <AddButton onClick={add} label="add argument" small />
+      </div>
+    </div>
+  );
+}
+
+/* ───────── try-it controls ───────── */
+
+function TryItControls(props: {
+  method: Method;
+  onMethodChange: (m: Method) => void;
+  registry: Registry;
+  callToolName: string;
+  setCallToolName: (name: string) => void;
+  callArgs: Record<string, string>;
+  setCallArgs: (next: Record<string, string>) => void;
+  readUri: string;
+  setReadUri: (uri: string) => void;
+  promptName: string;
+  setPromptName: (name: string) => void;
+  promptArgs: Record<string, string>;
+  setPromptArgs: (next: Record<string, string>) => void;
+  onFire: () => void;
+}) {
+  const {
+    method,
+    onMethodChange,
+    registry,
+    callToolName,
+    setCallToolName,
+    callArgs,
+    setCallArgs,
+    readUri,
+    setReadUri,
+    promptName,
+    setPromptName,
+    promptArgs,
+    setPromptArgs,
+    onFire,
+  } = props;
+
+  const methodId = useId();
+  const tool = registry.tools.find((t) => t.name === callToolName);
+  const prompt = registry.prompts.find((p) => p.name === promptName);
+
+  return (
+    <div className="flex flex-col gap-[var(--spacing-sm)]">
+      <Field label="method" htmlFor={methodId}>
+        <select
+          id={methodId}
+          value={method}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+            onMethodChange(e.target.value as Method)
+          }
+          className="bs-input"
+        >
+          <option value="tools/list">tools/list</option>
+          <option value="tools/call">tools/call</option>
+          <option value="resources/list">resources/list</option>
+          <option value="resources/read">resources/read</option>
+          <option value="prompts/list">prompts/list</option>
+          <option value="prompts/get">prompts/get</option>
+        </select>
+      </Field>
+
+      {method === "tools/call" && (
+        <>
+          <Field label="tool name">
+            <select
+              value={callToolName}
+              onChange={(e) => setCallToolName(e.target.value)}
+              className="bs-input"
+            >
+              <option value="">— pick a tool —</option>
+              {registry.tools.map((t) => (
+                <option key={t.id} value={t.name}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          {tool && tool.inputSchema.length > 0 ? (
+            <div className="flex flex-col gap-[var(--spacing-xs)]">
+              <div
+                className="font-sans"
+                style={{
+                  fontSize: "var(--text-small)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                arguments
+              </div>
+              {tool.inputSchema.map((f) => (
+                <Field
+                  key={f.name}
+                  label={`${f.name}${f.required ? " *" : ""}  (${f.type})`}
+                >
+                  <input
+                    value={callArgs[f.name] ?? ""}
+                    onChange={(e) =>
+                      setCallArgs({ ...callArgs, [f.name]: e.target.value })
+                    }
+                    className="bs-input"
+                  />
+                </Field>
+              ))}
+            </div>
+          ) : null}
+        </>
+      )}
+
+      {method === "resources/read" && (
+        <Field label="URI">
+          <input
+            value={readUri}
+            onChange={(e) => setReadUri(e.target.value)}
+            className="bs-input"
+            placeholder="rates://2026-04-30"
+          />
+        </Field>
+      )}
+
+      {method === "prompts/get" && (
+        <>
+          <Field label="prompt name">
+            <select
+              value={promptName}
+              onChange={(e) => setPromptName(e.target.value)}
+              className="bs-input"
+            >
+              <option value="">— pick a prompt —</option>
+              {registry.prompts.map((p) => (
+                <option key={p.id} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          {prompt && prompt.arguments.length > 0 ? (
+            <div className="flex flex-col gap-[var(--spacing-xs)]">
+              <div
+                className="font-sans"
+                style={{
+                  fontSize: "var(--text-small)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                arguments
+              </div>
+              {prompt.arguments.map((a) => (
+                <Field key={a.name} label={`${a.name}${a.required ? " *" : ""}`}>
+                  <input
+                    value={promptArgs[a.name] ?? ""}
+                    onChange={(e) =>
+                      setPromptArgs({ ...promptArgs, [a.name]: e.target.value })
+                    }
+                    className="bs-input"
+                  />
+                </Field>
+              ))}
+            </div>
+          ) : null}
+        </>
+      )}
+
+      <button
+        type="button"
+        onClick={onFire}
+        className="font-sans font-semibold"
+        style={{
+          alignSelf: "flex-start",
+          padding: "calc(var(--spacing-xs) + 4px) var(--spacing-md)",
+          background: "var(--color-accent)",
+          color: "var(--color-bg)",
+          border: "none",
+          borderRadius: "var(--radius-sm)",
+          cursor: "pointer",
+          fontSize: "var(--text-small)",
+          minHeight: 36,
+        }}
+      >
+        send →
+      </button>
+    </div>
+  );
+}
+
+/* ───────── tiny visual primitives ───────── */
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex flex-col gap-[var(--spacing-sm)]"
+      style={{
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-rule)",
+        borderRadius: "var(--radius-md)",
+        padding: "var(--spacing-sm) var(--spacing-md)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex flex-wrap items-end gap-[var(--spacing-sm)]"
+      style={{ width: "100%" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="font-sans"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        flex: "1 1 12ch",
+        minWidth: "12ch",
+        fontSize: "var(--text-small)",
+        color: "var(--color-text-muted)",
+      }}
+    >
+      {label}
+      {children}
+    </label>
+  );
+}
+
+function AddButton({
+  onClick,
+  label,
+  small,
+}: {
+  onClick: () => void;
+  label: string;
+  small?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="font-mono"
+      style={{
+        alignSelf: "flex-start",
+        padding: small
+          ? "4px var(--spacing-sm)"
+          : "var(--spacing-xs) var(--spacing-sm)",
+        background: "transparent",
+        border: "1px dashed var(--color-rule)",
+        borderRadius: "var(--radius-sm)",
+        color: "var(--color-text-muted)",
+        cursor: "pointer",
+        fontSize: "var(--text-small)",
+        minHeight: small ? 28 : 36,
+      }}
+    >
+      + {label}
+    </button>
+  );
+}
+
+function RemoveButton({
+  onClick,
+  small,
+}: {
+  onClick: () => void;
+  small?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="remove"
+      className="font-mono"
+      style={{
+        padding: small ? "2px 8px" : "4px 10px",
+        background: "transparent",
+        border: "1px solid var(--color-rule)",
+        borderRadius: "var(--radius-sm)",
+        color: "var(--color-text-muted)",
+        cursor: "pointer",
+        fontSize: "var(--text-small)",
+        minHeight: small ? 28 : 32,
+      }}
+    >
+      remove
+    </button>
+  );
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="font-serif"
+      style={{
+        padding: "var(--spacing-sm) var(--spacing-md)",
+        background: "color-mix(in oklab, var(--color-surface) 50%, transparent)",
+        border: "1px dashed var(--color-rule)",
+        borderRadius: "var(--radius-sm)",
+        color: "var(--color-text-muted)",
+        fontSize: "var(--text-small)",
+        textAlign: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/* ───────── helpers ───────── */
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+function countFor(key: TabKey, reg: Registry): number {
+  if (key === "tools") return reg.tools.length;
+  if (key === "resources") return reg.resources.length;
+  return reg.prompts.length;
+}
+
+/**
+ * Coerce form-string args to the schema's declared types so the
+ * synthesized `arguments` payload looks like real SDK input.
+ */
+function typedArgs(
+  raw: Record<string, string>,
+  reg: Registry,
+  toolName: string,
+): Record<string, unknown> {
+  const tool = reg.tools.find((t) => t.name === toolName);
+  if (!tool) return raw;
+  const out: Record<string, unknown> = {};
+  for (const f of tool.inputSchema) {
+    const v = raw[f.name];
+    if (v === undefined || v === "") continue;
+    if (f.type === "number") {
+      const n = Number(v);
+      out[f.name] = Number.isFinite(n) ? n : v;
+    } else if (f.type === "boolean") {
+      out[f.name] = v === "true";
+    } else {
+      out[f.name] = v;
+    }
+  }
+  return out;
+}
+
+export default ServerEditor;

--- a/app/courses/mcps/_content/build-a-server/widgets/ServerEditorQuiz.tsx
+++ b/app/courses/mcps/_content/build-a-server/widgets/ServerEditorQuiz.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * ServerEditorQuiz — premise-quiz opener for chapter 6 (voice §12.1).
+ *
+ * The reader's instinct after chapters 1–5: "registering a tool is just
+ * giving it a name; the model figures out the rest." The chapter's
+ * correction: descriptions are the model's *only* signal for whether to
+ * call a tool. A tool with no description registers cleanly but is
+ * effectively invisible to the model — and ch 9 will cash this in as
+ * an attack surface.
+ *
+ * Reuses the shipped <Quiz> primitive: radiogroup a11y, frame-stable
+ * verdict slot, single-accent terracotta.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+export function ServerEditorQuiz() {
+  return (
+    <WidgetShell
+      title="What does the model see when a tool ships with no description?"
+      caption={
+        <>
+          Predict before you read on. Most readers think the tool name does
+          most of the work. The spec — and your model — disagree.
+        </>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        <Quiz
+          question={
+            <p
+              className="font-serif"
+              style={{
+                fontSize: "var(--text-body)",
+                lineHeight: 1.55,
+                margin: 0,
+              }}
+            >
+              You register a tool called{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>foo</code>{" "}
+              with an input schema but no description. The host sends{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>.
+              What does the model receive — and how likely is it to call{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>foo</code>?
+            </p>
+          }
+          correctId="empty-but-valid"
+          rightVerdict={
+            <>
+              Right. The registration is technically valid — the spec only
+              requires a name and an input schema — but with an empty
+              description the model has nothing to read. It can see{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>foo</code>{" "}
+              exists; it has no idea <em>when</em> to use it. The
+              description is the model&apos;s only signal.
+            </>
+          }
+          wrongVerdict={
+            <>
+              The description is what the model reads to decide{" "}
+              <em>when</em> to call a tool. An empty one is technically
+              valid but pedagogically dead — and ch 9 will show how an
+              attacker-controlled description can hijack the model&apos;s
+              decisions.
+            </>
+          }
+          options={[
+            {
+              id: "error",
+              label:
+                "An error — every tool must carry a description, the SDK refuses to register it.",
+            },
+            {
+              id: "empty-but-valid",
+              label:
+                "A valid tool entry with an empty description and the schema. The model sees it but has no signal for when to call it.",
+            },
+            {
+              id: "name-only",
+              label:
+                "Just the name. The SDK omits tools without descriptions from tools/list responses.",
+            },
+            {
+              id: "source",
+              label:
+                "The handler's source code, so the model can decide for itself.",
+            },
+          ]}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default ServerEditorQuiz;

--- a/app/courses/mcps/_content/build-a-server/widgets/server-editor.css
+++ b/app/courses/mcps/_content/build-a-server/widgets/server-editor.css
@@ -1,0 +1,64 @@
+/**
+ * ServerEditor — input + responsive grid styles.
+ *
+ * Kept beside the component so the widget file stays focused on the React
+ * + state logic. Values match the rest of the bytesize course canvas:
+ * fonts via --font-mono / --font-sans, surfaces via --color-surface,
+ * focus rings via --color-accent.
+ */
+
+.bs-input {
+  width: 100%;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: var(--text-small);
+  line-height: 1.4;
+  min-height: 32px;
+  box-sizing: border-box;
+}
+
+.bs-input:focus,
+.bs-input:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent);
+}
+
+textarea.bs-input {
+  resize: vertical;
+  min-height: 44px;
+}
+
+select.bs-input {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 24px;
+  background-image: linear-gradient(
+      45deg,
+      transparent 50%,
+      var(--color-text-muted) 50%
+    ),
+    linear-gradient(135deg, var(--color-text-muted) 50%, transparent 50%);
+  background-position:
+    right 10px top 14px,
+    right 6px top 14px;
+  background-size:
+    4px 4px,
+    4px 4px;
+  background-repeat: no-repeat;
+}
+
+/* Scope to widget so we don't leak to the rest of the page. */
+.bs-server-editor button {
+  font-family: inherit;
+}
+
+@media (min-width: 720px) {
+  .bs-tryit-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/courses/mcps/_content/build-a-server/widgets/server-stub.ts
+++ b/app/courses/mcps/_content/build-a-server/widgets/server-stub.ts
@@ -1,0 +1,380 @@
+/**
+ * Parsed-stub MCP server used by `ServerEditor` (Ch 6).
+ *
+ * Decision recorded (issue #75, ServerEditor ambition):
+ *   We chose the **parsed-stub** approach, NOT a sandboxed `Function`
+ *   evaluator. The reader doesn't write JS; they fill out a small
+ *   registration form (name, description, JSON-Schema-shaped fields, a
+ *   URI template, prompt arguments) and the widget synthesises the
+ *   JSON-RPC response from those declarations. Why:
+ *     - Safety. No `eval`, no Function-from-string, no Worker boundary.
+ *     - Simpler. Ships in one turn; the lesson is *registration*, not
+ *       handler-implementation.
+ *     - Pedagogically truer to the spec — the SDK's `registerTool`
+ *       takes a description + input schema + (optional) handler;
+ *       what the *model* sees is the description and the schema, not
+ *       the handler body. Editing a form mirrors that.
+ *
+ * Spec version we model: 2025-06-18.
+ *
+ * The dispatcher here is a slimmer cousin of
+ * `app/courses/mcps/_content/json-rpc-the-wire/widgets/server-stub.ts`
+ * (Ch 3). Different surface — Ch 3's stub has fixed canned responses;
+ * this one closes over the reader's *current* registrations passed in.
+ */
+
+export type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+export type JsonRpcOk = {
+  jsonrpc: "2.0";
+  id: number | string;
+  result: unknown;
+};
+
+export type JsonRpcErr = {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  error: { code: number; message: string; data?: unknown };
+};
+
+export type JsonRpcResponse = JsonRpcOk | JsonRpcErr;
+
+const PROTOCOL_VERSION = "2025-06-18";
+
+/**
+ * A field declaration in a tool's input schema. Keeps the form simple:
+ * a name, a JSON-Schema-style type, an optional description, and a
+ * `required` flag. No nested objects — the lesson is the SHAPE, not
+ * the schema-language's full power.
+ */
+export type SchemaField = {
+  name: string;
+  type: "string" | "number" | "boolean";
+  description?: string;
+  required: boolean;
+};
+
+export type ToolDecl = {
+  id: string;
+  name: string;
+  description: string;
+  /** Each field becomes one property in the synthesized JSON Schema. */
+  inputSchema: SchemaField[];
+};
+
+export type ResourceDecl = {
+  id: string;
+  /** A URI template like `notes://{id}` or `weather://{city}/today`. */
+  uriTemplate: string;
+  name: string;
+  description: string;
+  mimeType: string;
+};
+
+export type PromptArg = {
+  name: string;
+  description?: string;
+  required: boolean;
+};
+
+export type PromptDecl = {
+  id: string;
+  name: string;
+  description: string;
+  arguments: PromptArg[];
+  /** A small template body. `{name}` placeholders get substituted at get-time. */
+  template: string;
+};
+
+export type Registry = {
+  tools: ToolDecl[];
+  resources: ResourceDecl[];
+  prompts: PromptDecl[];
+};
+
+/** What the synthesizer hands back to the widget for rendering. */
+export type Outcome =
+  | { kind: "response"; payload: JsonRpcResponse }
+  | { kind: "error"; payload: JsonRpcErr };
+
+/** Build a JSON Schema object from a flat list of fields. */
+export function fieldsToJsonSchema(fields: SchemaField[]): {
+  type: "object";
+  properties: Record<string, { type: string; description?: string }>;
+  required: string[];
+} {
+  const properties: Record<string, { type: string; description?: string }> = {};
+  const required: string[] = [];
+  for (const f of fields) {
+    properties[f.name] = f.description
+      ? { type: f.type, description: f.description }
+      : { type: f.type };
+    if (f.required) required.push(f.name);
+  }
+  return { type: "object", properties, required };
+}
+
+/**
+ * Substitute `{var}` placeholders in a string from a params object.
+ * Anything left unsubstituted becomes the literal `{var}` so the reader
+ * sees what they forgot to pass.
+ */
+export function substitute(
+  template: string,
+  params: Record<string, string>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_match, key: string) =>
+    Object.prototype.hasOwnProperty.call(params, key) ? params[key] : `{${key}}`,
+  );
+}
+
+/**
+ * Extract `{name}` placeholders from a URI template.
+ */
+export function extractPlaceholders(template: string): string[] {
+  const out: string[] = [];
+  const re = /\{(\w+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(template)) !== null) {
+    if (!out.includes(m[1])) out.push(m[1]);
+  }
+  return out;
+}
+
+/**
+ * Synthesize a JSON-RPC response against the reader's current registry.
+ * The widget passes a method + params + the registry; we never run user
+ * code, we just describe what the SDK *would* return.
+ */
+export function synth(
+  id: number | string,
+  method: string,
+  params: Record<string, unknown>,
+  reg: Registry,
+): Outcome {
+  switch (method) {
+    case "tools/list":
+      return ok(id, {
+        tools: reg.tools.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: fieldsToJsonSchema(t.inputSchema),
+        })),
+      });
+
+    case "tools/call": {
+      const toolName = (params.name as string | undefined) ?? "";
+      if (!toolName) return invalidParams(id, 'missing required field "name"');
+      const tool = reg.tools.find((t) => t.name === toolName);
+      if (!tool) {
+        return ok(id, {
+          content: [
+            { type: "text", text: `tool "${toolName}" is not registered` },
+          ],
+          isError: true,
+        });
+      }
+      const args = (params.arguments as Record<string, unknown> | undefined) ?? {};
+      // Validate required fields are present — the lesson is that schemas
+      // matter; a host validates against them before the handler runs.
+      const missing = tool.inputSchema
+        .filter((f) => f.required && !(f.name in args))
+        .map((f) => f.name);
+      if (missing.length > 0) {
+        return ok(id, {
+          content: [
+            {
+              type: "text",
+              text: `validation error · missing required argument(s): ${missing.join(", ")}`,
+            },
+          ],
+          isError: true,
+        });
+      }
+      // Echo the call as the synthesized response — the SDK would have
+      // routed this to the handler; we render the shape the model receives.
+      return ok(id, {
+        content: [
+          {
+            type: "text",
+            text: `(synth) ${tool.name} called with ${JSON.stringify(args)} — handler would return its result here.`,
+          },
+        ],
+        isError: false,
+      });
+    }
+
+    case "resources/list":
+      return ok(id, {
+        resources: reg.resources.map((r) => ({
+          uri: r.uriTemplate,
+          name: r.name,
+          description: r.description,
+          mimeType: r.mimeType,
+        })),
+      });
+
+    case "resources/read": {
+      const uri = (params.uri as string | undefined) ?? "";
+      if (!uri) return invalidParams(id, 'missing required field "uri"');
+      // Match the reader's URI against templates: same scheme, same shape.
+      const resource = reg.resources.find((r) => matches(r.uriTemplate, uri));
+      if (!resource) {
+        return ok(id, {
+          contents: [],
+          isError: true,
+          content: [
+            { type: "text", text: `no registered resource matches "${uri}"` },
+          ],
+        });
+      }
+      return ok(id, {
+        contents: [
+          {
+            uri,
+            mimeType: resource.mimeType,
+            text: `(synth) handler would read ${uri} and return ${resource.mimeType} content.`,
+          },
+        ],
+      });
+    }
+
+    case "prompts/list":
+      return ok(id, {
+        prompts: reg.prompts.map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments,
+        })),
+      });
+
+    case "prompts/get": {
+      const promptName = (params.name as string | undefined) ?? "";
+      if (!promptName)
+        return invalidParams(id, 'missing required field "name"');
+      const prompt = reg.prompts.find((p) => p.name === promptName);
+      if (!prompt) return methodNotFound(id, `prompts/get · "${promptName}"`);
+      const args = (params.arguments as Record<string, string> | undefined) ?? {};
+      const missing = prompt.arguments
+        .filter((a) => a.required && !(a.name in args))
+        .map((a) => a.name);
+      if (missing.length > 0) {
+        return ok(id, {
+          messages: [],
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `validation error · missing required argument(s): ${missing.join(", ")}`,
+            },
+          ],
+        });
+      }
+      const rendered = substitute(prompt.template, args);
+      return ok(id, {
+        description: prompt.description,
+        messages: [
+          {
+            role: "user",
+            content: { type: "text", text: rendered },
+          },
+        ],
+      });
+    }
+
+    default:
+      return methodNotFound(id, method);
+  }
+}
+
+/**
+ * URI matcher that respects placeholder syntax. `notes://{id}` matches
+ * `notes://abc` (capturing `id=abc`) but not `weather://abc`. Returns
+ * true on a structural match — the widget doesn't need the captures to
+ * synthesize a response.
+ */
+function matches(template: string, uri: string): boolean {
+  const escaped = template.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Now restore the placeholder syntax (we escaped its braces above).
+  const pattern = escaped.replace(/\\\{\w+\\\}/g, "[^/]+");
+  return new RegExp(`^${pattern}$`).test(uri);
+}
+
+function ok(id: number | string, result: unknown): Outcome {
+  return { kind: "response", payload: { jsonrpc: "2.0", id, result } };
+}
+
+function invalidParams(id: number | string, detail: string): Outcome {
+  return {
+    kind: "error",
+    payload: {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32602, message: "Invalid params", data: detail },
+    },
+  };
+}
+
+function methodNotFound(id: number | string, method: string): Outcome {
+  return {
+    kind: "error",
+    payload: {
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32601,
+        message: "Method not found",
+        data: `unknown method "${method}"`,
+      },
+    },
+  };
+}
+
+/**
+ * The default demo registry — the chapter's worked example. Mirrors the
+ * brainstormer's `currency-server` proposal in shape. The reader can
+ * edit / add / remove from any of the three lists.
+ */
+export const DEFAULT_REGISTRY: Registry = {
+  tools: [
+    {
+      id: "convert",
+      name: "convert",
+      description:
+        "Convert an amount from one currency to another at the latest rate.",
+      inputSchema: [
+        { name: "from", type: "string", description: "ISO currency code", required: true },
+        { name: "to", type: "string", description: "ISO currency code", required: true },
+        { name: "amount", type: "number", description: "Amount in 'from' currency", required: true },
+      ],
+    },
+  ],
+  resources: [
+    {
+      id: "rates",
+      uriTemplate: "rates://{date}",
+      name: "Daily rates",
+      description: "FX rates for a given ISO date (YYYY-MM-DD).",
+      mimeType: "application/json",
+    },
+  ],
+  prompts: [
+    {
+      id: "recommend",
+      name: "recommend-currency-mix",
+      description:
+        "Suggest a multi-currency holding split for a target country.",
+      arguments: [
+        { name: "country", description: "ISO country code", required: true },
+        { name: "horizon", description: "Holding horizon, e.g. '6m'", required: false },
+      ],
+      template:
+        "Recommend a currency mix for someone holding cash for travel to {country} over a horizon of {horizon}. Justify briefly.",
+    },
+  ],
+};

--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -20,6 +20,7 @@ import TheRoomBeforeProtocolContent from "./the-room-before-the-protocol/Content
 import JsonRpcTheWireContent from "./json-rpc-the-wire/Content";
 import TheHandshakeContent from "./the-handshake/Content";
 import ToolsResourcesPromptsContent from "./tools-resources-prompts/Content";
+import BuildAServerContent from "./build-a-server/Content";
 
 export const MCPS_CONTENT: Record<string, ComponentType> = {
   "the-room-before-the-protocol": TheRoomBeforeProtocolContent,
@@ -27,4 +28,5 @@ export const MCPS_CONTENT: Record<string, ComponentType> = {
   "json-rpc-the-wire": JsonRpcTheWireContent,
   "the-handshake": TheHandshakeContent,
   "tools-resources-prompts": ToolsResourcesPromptsContent,
+  "build-a-server": BuildAServerContent,
 };


### PR DESCRIPTION
Resolves #75.

## Summary
- Chapter 6 of the MCP course: a one-page build of an MCP server. The reader fills in registration forms (tools | resources | prompts) and watches the page synthesize the JSON-RPC responses the SDK would emit from those declarations.
- Load-bearing widget: `ServerEditor` — three-tab registration form + a "try it" panel that fires `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`. Companion `LiveCallStrip` keeps the last 5 exchanges collapsible underneath.
- Premise-quiz opener: `ServerEditorQuiz` — *"a tool with no description: what does the model see?"* — sets up Ch 9's coming attack-surface beat without spoiling it.

## Decision recorded — ServerEditor ambition (parsed-stub vs sandboxed Function)
Per the brainstormer's open question on widget scope, this PR ships the **parsed-stub** approach.

- The reader does **not** write JS. There is no `eval`, no `new Function`, no Web Worker. They fill out a small registration form (name, description, JSON-Schema-shaped fields, URI template, prompt arguments).
- The widget synthesizes JSON-RPC responses directly from the registration metadata — the same metadata the SDK uses to satisfy `tools/list` and friends.
- Why this over the sandboxed evaluator:
  - **Safety.** No string-to-code path.
  - **Simpler.** Ships in one turn; the chapter doesn't grow a hidden interpreter.
  - **Pedagogically truer.** What the *model* reads is the description and the input schema, not the handler body. Editing a form mirrors that — and Ch 9 will cash in on it.
- Trade-off accepted: the reader doesn't experience changing a handler's *return logic*. That's a fair loss because the chapter's claim is "you have authored a working MCP server" — registration is the SDK's surface; handler bodies are downstream concerns the reader can write in a real editor afterwards (the chapter ships a copy-pasteable `currency-server.ts` end-state).

## Files
- `app/courses/mcps/_content/build-a-server/Content.tsx`
- `app/courses/mcps/_content/build-a-server/widgets/ServerEditor.tsx` (load-bearing)
- `app/courses/mcps/_content/build-a-server/widgets/ServerEditorQuiz.tsx`
- `app/courses/mcps/_content/build-a-server/widgets/LiveCallStrip.tsx`
- `app/courses/mcps/_content/build-a-server/widgets/server-stub.ts`
- `app/courses/mcps/_content/build-a-server/widgets/server-editor.css`
- `app/courses/mcps/_content/registry.ts` (registers the chapter)

## Constraints honoured
- VerticalCutReveal absent (banned everywhere).
- No `<hr>`, no `<br>`. Section breaks ride on `<H2>` + spacing.
- One accent only — terracotta on the active tab and "send →".
- Reduced-motion safe — no transform/opacity animation that would harm `prefers-reduced-motion`.
- Mobile-first — hit zones ≥ 36 px; tabs wrap; "try it" panel stacks beneath.
- Real `<button role="tab">` with `aria-controls` / `aria-selected`; every form field has an associated label; response region is `aria-live="polite"`.

## Test plan
- [x] `pnpm build` green (output above shows the route prerendered).
- [x] `tsc --noEmit` clean for new files (only pre-existing `@web-kits/audio` resolver errors persist).
- [x] Smoke test on `pnpm dev --port 3008` — `/courses/mcps/build-a-server` returns HTTP 200 with the expected content (`currency-server`, `tools/list`, `recommend-currency-mix`).
- [ ] Visual / a11y / Lighthouse pass on Vercel preview.
- [ ] Reviewer plays through one full registration → call cycle on each tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)