### PR TITLE
feat(courses/mcps): chapter 8 — When the server asks back

### DIFF
--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -19,22 +19,18 @@ import HostClientServerContent from "./host-client-server/Content";
 import TheRoomBeforeProtocolContent from "./the-room-before-the-protocol/Content";
 import JsonRpcTheWireContent from "./json-rpc-the-wire/Content";
 import TheHandshakeContent from "./the-handshake/Content";
-<<<<<<< HEAD
 import ToolsResourcesPromptsContent from "./tools-resources-prompts/Content";
 import BuildAServerContent from "./build-a-server/Content";
-=======
 import BuildAClientPickATransportContent from "./build-a-client-pick-a-transport/Content";
->>>>>>> 17f3e5e (feat(courses/mcps): chapter 7 — Build a client, and pick a transport)
+import WhenTheServerAsksBackContent from "./when-the-server-asks-back/Content";
 
 export const MCPS_CONTENT: Record<string, ComponentType> = {
   "the-room-before-the-protocol": TheRoomBeforeProtocolContent,
   "host-client-server": HostClientServerContent,
   "json-rpc-the-wire": JsonRpcTheWireContent,
   "the-handshake": TheHandshakeContent,
-<<<<<<< HEAD
   "tools-resources-prompts": ToolsResourcesPromptsContent,
   "build-a-server": BuildAServerContent,
-=======
   "build-a-client-pick-a-transport": BuildAClientPickATransportContent,
->>>>>>> 17f3e5e (feat(courses/mcps): chapter 7 — Build a client, and pick a transport)
+  "when-the-server-asks-back": WhenTheServerAsksBackContent,
 };

--- a/app/courses/mcps/_content/when-the-server-asks-back/Content.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/Content.tsx
@@ -1,0 +1,363 @@
+/**
+ * Chapter 8 — When the server asks back: sampling, elicitation, roots.
+ *
+ * Server component. Composes the chapter prose around five widgets:
+ *   1. ReverseQuiz           — premise-quiz opener (voice §12.1).
+ *   2. ReverseFlowDiagram    — load-bearing three-tab diagram with HITL
+ *                              gates and embedded sub-widgets.
+ *   3. SamplingApproval      — standalone deep-dive on the gate UX.
+ *   4. ElicitationForm       — schema → form → response payload.
+ *   5. RootsManager          — declared-roots editor + envelope log.
+ *
+ * Voice §12 patterns honoured:
+ *   - <Term> on first appearance of every spec word.
+ *   - Mechanism-first reframe — "the protocol's other direction" is the
+ *     mechanism, not a feature taxonomy.
+ *   - Just-in-time vocabulary — no glossary chapter.
+ *   - Closer loops back to the opener (two HITL gates on sampling).
+ *   - VerticalCutReveal banned; closer is still prose.
+ *
+ * No <hr>, no <br>. Section breaks ride on <H2> + spacing rhythm.
+ *
+ * The "roots is coordination, not enforcement" sentence appears verbatim
+ * in §3 — chapter 9 inherits it as the load-bearing claim.
+ */
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { Callout, H2, P, Term } from "@/components/prose";
+import { CodeBlock } from "@/components/code/CodeBlock";
+
+const ReverseQuiz = dynamic(
+  () => import("./widgets/ReverseQuiz").then((m) => m.ReverseQuiz),
+);
+const ReverseFlowDiagram = dynamic(
+  () =>
+    import("./widgets/ReverseFlowDiagram").then((m) => m.ReverseFlowDiagram),
+);
+const SamplingApproval = dynamic(
+  () => import("./widgets/SamplingApproval").then((m) => m.SamplingApproval),
+);
+const ElicitationForm = dynamic(
+  () => import("./widgets/ElicitationForm").then((m) => m.ElicitationForm),
+);
+const RootsManager = dynamic(
+  () => import("./widgets/RootsManager").then((m) => m.RootsManager),
+);
+
+export function Content() {
+  return (
+    <>
+      <P>
+        Every message we&apos;ve followed in this course has gone the same
+        way — client opens the session, client lists tools, client calls
+        them. The server has been the one being asked. But MCP isn&apos;t
+        one-way. There are three messages that flow the other direction,
+        each with its own checkpoint, and one of them has{" "}
+        <em>two</em>. Before we explain anything, try the opener.
+      </P>
+
+      <ReverseQuiz />
+
+      <H2>The flip — three reverse messages</H2>
+
+      <P>
+        Until now the client has been driving. Sometimes the server needs
+        to. Three primitives reverse the direction:{" "}
+        <Term>sampling</Term> (server asks the host&apos;s LLM for a
+        completion), <Term>elicitation</Term> (server asks the user a
+        structured question), and <Term>roots</Term> (server asks the
+        client what directories it&apos;s allowed to operate inside). Each
+        is named in the client&apos;s capability declaration from chapter
+        4 — the server can only ask back for what the client opted into.
+      </P>
+
+      <P>
+        Two of the three involve the user directly; all three pass through
+        the host before anything reaches a model or a filesystem. The
+        host&apos;s job here is the{" "}
+        <Term>human-in-the-loop</Term> gate — the spec&apos;s claim that
+        the user is the one who decides, not the model and not the server.
+        The diagram below plays the three flows side by side; the gates
+        appear as terracotta diamonds.
+      </P>
+
+      <ReverseFlowDiagram />
+
+      <P>
+        Three tabs, three flows. The arrows are the wire; the diamonds are
+        the host. Now zoom on each one.
+      </P>
+
+      <H2>Sampling — the server wants your model</H2>
+
+      <P>
+        Most servers don&apos;t ship their own LLM. A flight-search server
+        wants to summarise; a Slack server wants to draft a reply; a SQL
+        server wants to explain a query plan. Building inference into every
+        server would mean every server pays for compute, every server
+        chooses a model, every server has to be updated when a new model
+        ships. The flip is cleaner: the server asks the host to use{" "}
+        <em>its</em> model. Same protocol, same session, no extra credentials.
+      </P>
+
+      <P>
+        The method is{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          sampling/createMessage
+        </code>
+        . The body carries messages, an optional{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>systemPrompt</code>,
+        a{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>maxTokens</code>{" "}
+        ceiling, and{" "}
+        <Term>modelPreferences</Term> — hints at speed/cost/quality the host
+        is free to honour or ignore.
+      </P>
+
+      <CodeBlock
+        lang="json"
+        filename="sampling/createMessage (request body)"
+        code={`{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      { "role": "user", "content": {
+        "type": "text",
+        "text": "Summarise these 47 flights in three lines."
+      } }
+    ],
+    "systemPrompt": "You are a concise travel assistant.",
+    "modelPreferences": {
+      "hints": [{ "name": "claude-3-5-sonnet" }],
+      "speedPriority": 0.4,
+      "costPriority": 0.3,
+      "intelligencePriority": 0.3
+    },
+    "maxTokens": 512
+  }
+}`}
+      />
+
+      <P>
+        Then the gate. The host pauses, shows the user the prompt, and
+        asks. Three buttons. Three different sessions downstream — the
+        request only reaches the model if the user lets it.
+      </P>
+
+      <SamplingApproval />
+
+      <P>
+        Sampling has{" "}
+        <em>two</em> human-in-the-loop gates, not one — that&apos;s the
+        opener&apos;s payload. The first gate fires before the prompt
+        reaches the LLM. The second fires before the completion goes back
+        to the server: the host can show the user what the model said and
+        ask whether it can be sent back. The user controls both ends. A
+        server that wanted to exfiltrate data through a sampling response
+        would still have to pass the second gate — which is the
+        spec&apos;s safety claim made architectural.
+      </P>
+
+      <H2>Elicitation — the server asks the user</H2>
+
+      <P>
+        The pattern: a server is mid-flow and needs a piece of information
+        only the user has. A booking server doesn&apos;t know your seat
+        preference. A timezone-aware server doesn&apos;t know your
+        timezone. Hard-coding a failure path (<em>error: missing
+        information</em>) would force the user to start over. Hard-coding a
+        guess would be worse. The protocol&apos;s answer is to{" "}
+        <em>ask</em>.
+      </P>
+
+      <P>
+        The method is{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          elicitation/create
+        </code>
+        . The server sends a JSON-Schema fragment — a small subset, just
+        enough for primitive types and enums — describing the form it
+        wants. The host renders the form. The user fills it. The values
+        come back as the elicitation response, with an{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>action</code>{" "}
+        field that&apos;s one of{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>accept</code>,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>decline</code>,
+        or{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>cancel</code>.
+      </P>
+
+      <ElicitationForm />
+
+      <P>
+        Elicitation has exactly one HITL gate, because the gate is the
+        answer. Sampling routes a model around the user; elicitation
+        routes the user&apos;s input around a model. The user{" "}
+        <em>is</em> the response.
+      </P>
+
+      <H2>Roots — the boundaries the client declares</H2>
+
+      <P>
+        The third flip is quieter. Roots are file:// URIs the client tells
+        the server about: <em>operate inside these directories.</em> A
+        filesystem server told its roots are{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          /Users/ada/projects/bytesize
+        </code>{" "}
+        and{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          /Users/ada/Documents/specs
+        </code>{" "}
+        knows not to read{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          ~/.ssh
+        </code>
+        . Two methods carry it:{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>roots/list</code>{" "}
+        is a request the server can make at any time; the client&apos;s{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          notifications/roots/list_changed
+        </code>{" "}
+        fires when the user moves the workspace.
+      </P>
+
+      <RootsManager />
+
+      <P>
+        The thing to feel about roots is what they aren&apos;t.{" "}
+        <strong>
+          Roots are coordination, not enforcement.
+        </strong>{" "}
+        The server <em>SHOULD</em> respect the list — that&apos;s the
+        spec&apos;s normative word. Nothing on the wire stops a malicious
+        server from reading whatever the host&apos;s process can read; the
+        roots message just makes the boundary legible. The enforcement has
+        to come from the host process itself: sandboxing, OS-level
+        permissions, capability tokens. Chapter 9 inherits this directly.
+      </P>
+
+      <H2>Why these three exist</H2>
+
+      <P>
+        Without sampling, every server needs its own model. Without
+        elicitation, every missing field is a hard error. Without roots,
+        every server has to guess what it&apos;s allowed to touch. Agentic
+        flows — the chains where one tool call leads to another, and the
+        model needs more information halfway through — collapse without
+        these. A single forward call can&apos;t carry an agent through a
+        booking with three branching questions; the server has to be able
+        to ask back.
+      </P>
+
+      <P>
+        And in all three cases, the trust boundary stays with the client.
+        The server can request; the client can deny. The host is the
+        bottleneck on purpose — a deny on the sampling gate is a deny full
+        stop, and a closed elicitation form is an{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>action: cancel</code>{" "}
+        on the wire. The asymmetry from chapter 5 (server primitives are
+        controlled by model / app / user) holds here in mirror: client
+        primitives add a fourth invariant — the human is in the loop on
+        every one that touches data.
+      </P>
+
+      <H2>Comprehension check</H2>
+
+      <P>
+        A server requests sampling. The host has no LLM available — maybe
+        the user is offline, maybe the host shipped without a model. What
+        does the client return? Predict before revealing.
+      </P>
+
+      <details
+        className="font-serif"
+        style={{
+          marginTop: "1em",
+          marginBottom: "1em",
+          background: "var(--color-surface)",
+          padding: "var(--spacing-md)",
+          borderRadius: "var(--radius-md)",
+          fontSize: "var(--text-body)",
+          lineHeight: 1.6,
+          border: "1px solid var(--color-rule)",
+        }}
+      >
+        <summary
+          style={{
+            cursor: "pointer",
+            color: "var(--color-text-muted)",
+            fontFamily: "var(--font-sans)",
+            fontSize: "var(--text-small)",
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          }}
+        >
+          reveal answer
+        </summary>
+        <P>
+          The client returns a JSON-RPC error response, paired by id, with
+          a code that signals the LLM is unavailable —{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>-32603</code>{" "}
+          (internal error) is the catch-all the spec falls back to, with a
+          message describing the cause. A well-built server catches the
+          error and either retries with a backoff, falls back to its own
+          best-effort heuristic, or returns its own error to the client
+          that opened the session. Sampling is a request; requests can
+          fail; failure has a code.
+        </P>
+      </details>
+
+      <Callout tone="note">
+        Capability check, while we&apos;re here: a server can only call{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          sampling/createMessage
+        </code>{" "}
+        if the client declared{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>sampling</code>{" "}
+        in its handshake capabilities. Same for{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>elicitation</code>{" "}
+        and{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>roots</code>. A
+        server that asks back for something the client never offered gets{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          -32601 method not found
+        </code>{" "}
+        — the same shape as chapter 4&apos;s{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>{" "}
+        on a server that didn&apos;t advertise tools.
+      </Callout>
+
+      <H2>The protocol&apos;s two directions, complete</H2>
+
+      <P>
+        Now you know both directions. Client → server got us through
+        chapters 3 through 7: the handshake, the primitives, the build-a-
+        server / build-a-client tour. Server → client gets us through
+        sampling, elicitation, and roots — the surface that lets agents do
+        anything beyond a single forward call. Two HITL gates on sampling,
+        one on elicitation, zero on roots (because roots is coordination,
+        not enforcement). Scroll back to the opener: the gate count
+        isn&apos;t a riddle anymore.
+      </P>
+
+      <P>
+        Every message we&apos;ve followed has been polite. The server
+        asked nicely, the client answered nicely, the host gated nicely.
+        The wild has teeth.{" "}
+        <Link
+          href="/courses/mcps/how-mcp-gets-attacked"
+          className="font-sans"
+          style={{ color: "var(--color-accent)" }}
+        >
+          That&apos;s chapter 9.
+        </Link>
+      </P>
+    </>
+  );
+}
+
+export default Content;

--- a/app/courses/mcps/_content/when-the-server-asks-back/widgets/ElicitationForm.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/widgets/ElicitationForm.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+/**
+ * ElicitationForm — render a small form from a JSON Schema fragment.
+ *
+ * Pedagogical role: an `elicitation/create` request carries a JSON-Schema
+ * subset; the host renders that schema as a form, the user fills it, and
+ * the form data goes back to the server as the response. The user IS the
+ * response — there's only one HITL gate, because the gate is the answer.
+ *
+ * Two roles in the chapter:
+ *   - Standalone (Content.tsx, around the elicitation beat) — the reader
+ *     sees a default schema, fills the form, watches the response payload
+ *     update live.
+ *   - Embedded inside ReverseFlowDiagram's "elicitation" tab (compact mode)
+ *     at the user-fills tick.
+ *
+ * The schema is intentionally small (two fields: name + email) and held
+ * static — `ElicitationSchemaBuilder` is out of scope for this build; the
+ * component teaches "schema → form → response payload" without dragging.
+ */
+
+import { useState, useId, useMemo } from "react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { playSound } from "@/lib/audio";
+
+type Field = {
+  key: string;
+  label: string;
+  type: "string" | "email" | "enum";
+  required: boolean;
+  options?: string[];
+  placeholder?: string;
+};
+
+const SCHEMA: Field[] = [
+  {
+    key: "name",
+    label: "your name",
+    type: "string",
+    required: true,
+    placeholder: "Ada Lovelace",
+  },
+  {
+    key: "email",
+    label: "email for the booking confirmation",
+    type: "email",
+    required: true,
+    placeholder: "ada@example.com",
+  },
+  {
+    key: "seatPreference",
+    label: "seat preference",
+    type: "enum",
+    required: false,
+    options: ["aisle", "window", "middle"],
+  },
+];
+
+const SCHEMA_JSON = `{
+  "method": "elicitation/create",
+  "params": {
+    "message": "We need a few details to confirm.",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" },
+        "seatPreference": {
+          "type": "string",
+          "enum": ["aisle", "window", "middle"]
+        }
+      },
+      "required": ["name", "email"]
+    }
+  }
+}`;
+
+type ElicitationFormProps = {
+  /** Compact = no WidgetShell, render only the form (used inside the flow
+   *  diagram). Default false. */
+  compact?: boolean;
+  /** Optional callback fired when the form is submitted. Lets the parent
+   *  diagram advance its tick once the user has answered. */
+  onSubmit?: (response: Record<string, string>) => void;
+};
+
+export function ElicitationForm({
+  compact = false,
+  onSubmit,
+}: ElicitationFormProps) {
+  const formId = useId();
+  const [values, setValues] = useState<Record<string, string>>({
+    name: "",
+    email: "",
+    seatPreference: "",
+  });
+  const [submitted, setSubmitted] = useState(false);
+
+  const setField = (k: string, v: string) =>
+    setValues((prev) => ({ ...prev, [k]: v }));
+
+  // The "live" response payload reflects whatever the user has typed so far.
+  const responsePayload = useMemo(() => {
+    const filtered: Record<string, string> = {};
+    for (const f of SCHEMA) {
+      if (values[f.key]) filtered[f.key] = values[f.key];
+    }
+    return JSON.stringify(
+      {
+        action: submitted ? "accept" : "draft",
+        content: filtered,
+      },
+      null,
+      2,
+    );
+  }, [values, submitted]);
+
+  const canSubmit =
+    SCHEMA.filter((f) => f.required).every((f) => values[f.key].trim().length > 0);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    playSound("Success");
+    setSubmitted(true);
+    onSubmit?.(values);
+  };
+
+  const handleReset = () => {
+    playSound("Progress-Tick");
+    setValues({ name: "", email: "", seatPreference: "" });
+    setSubmitted(false);
+  };
+
+  const form = (
+    <div className="bs-elic-grid">
+      <form
+        id={formId}
+        className="bs-elic-form"
+        onSubmit={handleSubmit}
+        aria-label="Elicitation form rendered from server schema"
+      >
+        <div className="bs-elic-eyebrow">
+          <span>filesystem-server is asking</span>
+          <span className="bs-elic-pill">elicitation/create</span>
+        </div>
+        <p className="bs-elic-message">
+          We need a few details to confirm.
+        </p>
+        {SCHEMA.map((f) => (
+          <div key={f.key} className="bs-elic-field">
+            <label htmlFor={`${formId}-${f.key}`} className="bs-elic-label">
+              {f.label}
+              {f.required ? (
+                <span className="bs-elic-required" aria-label="required">
+                  *
+                </span>
+              ) : (
+                <span className="bs-elic-optional"> (optional)</span>
+              )}
+            </label>
+            {f.type === "enum" ? (
+              <select
+                id={`${formId}-${f.key}`}
+                className="bs-elic-input"
+                value={values[f.key]}
+                onChange={(e) => setField(f.key, e.target.value)}
+                disabled={submitted}
+              >
+                <option value="">— pick one —</option>
+                {f.options?.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                id={`${formId}-${f.key}`}
+                type={f.type === "email" ? "email" : "text"}
+                className="bs-elic-input"
+                value={values[f.key]}
+                onChange={(e) => setField(f.key, e.target.value)}
+                placeholder={f.placeholder}
+                required={f.required}
+                disabled={submitted}
+              />
+            )}
+          </div>
+        ))}
+        <div className="bs-elic-actions">
+          {submitted ? (
+            <button
+              type="button"
+              className="bs-elic-btn bs-elic-btn--reset"
+              onClick={handleReset}
+            >
+              reset
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className="bs-elic-btn bs-elic-btn--primary"
+              disabled={!canSubmit}
+            >
+              send →
+            </button>
+          )}
+        </div>
+      </form>
+      <div className="bs-elic-side">
+        <div className="bs-elic-side-block">
+          <div className="bs-elic-side-head">schema (server → client)</div>
+          <pre className="bs-elic-json">{SCHEMA_JSON}</pre>
+        </div>
+        <div className="bs-elic-side-block">
+          <div className="bs-elic-side-head">
+            response (client → server){" "}
+            <span className="bs-elic-side-tag" data-state={submitted ? "sent" : "draft"}>
+              {submitted ? "sent" : "draft"}
+            </span>
+          </div>
+          <pre className="bs-elic-json">{responsePayload}</pre>
+        </div>
+      </div>
+    </div>
+  );
+
+  const styles = (
+    <style>{`
+      .bs-elic-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--spacing-md);
+      }
+      @container widget (min-width: 640px) {
+        .bs-elic-grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .bs-elic-form {
+        background: var(--color-surface);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+      }
+      .bs-elic-eyebrow {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-sm);
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        color: var(--color-text);
+      }
+      .bs-elic-pill {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+        white-space: nowrap;
+      }
+      .bs-elic-message {
+        font-family: var(--font-serif);
+        font-size: var(--text-body);
+        color: var(--color-text);
+        margin: 0;
+        line-height: 1.5;
+      }
+      .bs-elic-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .bs-elic-label {
+        font-family: var(--font-sans);
+        font-size: var(--text-small);
+        color: var(--color-text-muted);
+      }
+      .bs-elic-required {
+        color: var(--color-accent);
+        margin-left: 4px;
+      }
+      .bs-elic-optional {
+        color: var(--color-text-muted);
+        opacity: 0.7;
+      }
+      .bs-elic-input {
+        min-height: 44px;
+        padding: 8px 10px;
+        font-family: var(--font-mono);
+        font-size: var(--text-body);
+        background: var(--color-bg);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-sm);
+        color: var(--color-text);
+      }
+      .bs-elic-input:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 1px;
+        border-color: var(--color-accent);
+      }
+      .bs-elic-input:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+      .bs-elic-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--spacing-sm);
+      }
+      .bs-elic-btn {
+        min-height: 44px;
+        padding: 8px 16px;
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-rule);
+        background: transparent;
+        color: var(--color-text);
+        cursor: pointer;
+      }
+      .bs-elic-btn:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px;
+      }
+      .bs-elic-btn--primary {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+      }
+      .bs-elic-btn--primary:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .bs-elic-side {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+      }
+      .bs-elic-side-block {
+        background: var(--color-surface);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .bs-elic-side-head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px var(--spacing-sm);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--color-text-muted);
+        text-transform: lowercase;
+        letter-spacing: 0.02em;
+        border-bottom: 1px solid var(--color-rule);
+      }
+      .bs-elic-side-tag {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        padding: 1px 6px;
+        border-radius: 999px;
+        border: 1px solid var(--color-rule);
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .bs-elic-side-tag[data-state="sent"] {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+      }
+      .bs-elic-json {
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        line-height: 1.5;
+        color: var(--color-text);
+        margin: 0;
+        padding: var(--spacing-sm);
+        white-space: pre;
+        overflow-x: auto;
+        max-height: 280px;
+        overflow-y: auto;
+      }
+    `}</style>
+  );
+
+  if (compact) {
+    return (
+      <>
+        {styles}
+        {form}
+      </>
+    );
+  }
+
+  return (
+    <WidgetShell
+      title="Elicitation — schema in, form out, response payload back"
+      caption={
+        <>
+          The server sent a JSON-Schema fragment; the host renders it as a
+          form. Fill it (the user is the response) and watch the payload that
+          goes back compose, field by field.
+        </>
+      }
+    >
+      {styles}
+      {form}
+    </WidgetShell>
+  );
+}
+
+export default ElicitationForm;

--- a/app/courses/mcps/_content/when-the-server-asks-back/widgets/ReverseFlowDiagram.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/widgets/ReverseFlowDiagram.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+/**
+ * ReverseFlowDiagram — the load-bearing widget for chapter 8.
+ *
+ * Three tabs (sampling | elicitation | roots), each a 4-tick flow that
+ * interleaves three actors (server, client, user). The HITL checkpoints
+ * render with a terracotta diamond marker; on the relevant tick, the
+ * corresponding sub-widget mounts inline so the gate is not just diagrammed
+ * but operable.
+ *
+ * Tick scripts (per tab):
+ *   sampling:
+ *     1. server → client      sampling/createMessage      (request lands)
+ *     2. client → user        HITL gate (request review)  → SamplingApproval
+ *     3. user → client        approved; client samples its host LLM
+ *     4. client → server      response w/ completion       (HITL gate 2 implied)
+ *
+ *   elicitation:
+ *     1. server → client      elicitation/create + schema
+ *     2. client → user        host renders the form        → ElicitationForm
+ *     3. user → client        user submits values
+ *     4. client → server      response w/ form data
+ *
+ *   roots:
+ *     1. server → client      roots/list (or client → server `notifications/
+ *                             roots/list_changed`)
+ *     2. client                client reads its declared roots → RootsManager
+ *     3. client → server      response w/ roots list
+ *     4. server                server now operates inside those bounds
+ *                             (coordination, not enforcement)
+ *
+ * Controls: Step / Auto-play / Reset (via WidgetNav). Reduced motion safe.
+ * One accent only. Three lanes stack on narrow viewports.
+ */
+
+import { useCallback, useId, useMemo, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { SPRING } from "@/lib/motion";
+import { SamplingApproval } from "./SamplingApproval";
+import { ElicitationForm } from "./ElicitationForm";
+import { RootsManager } from "./RootsManager";
+
+type Lane = "server" | "client" | "user";
+type Scenario = "sampling" | "elicitation" | "roots";
+
+type Tick = {
+  /** Origin lane of the action (where the arrow / event begins). */
+  from: Lane;
+  /** Destination lane (or same as `from` for self-events). */
+  to: Lane;
+  /** Method / event label shown on the arrow. */
+  label: string;
+  /** Short caption for the prose-voice slot below the lanes. */
+  caption: string;
+  /** Whether this tick is a human-in-the-loop checkpoint. */
+  hitl?: boolean;
+  /** Optional embedded widget — mounts when the tick fires. */
+  embed?: "sampling-approval" | "elicitation-form" | "roots-manager";
+};
+
+const SCRIPTS: Record<Scenario, Tick[]> = {
+  sampling: [
+    {
+      from: "server",
+      to: "client",
+      label: "sampling/createMessage",
+      caption:
+        "1 · The server wants the host's LLM. It sends sampling/createMessage with the prompt, modelPreferences, and maxTokens.",
+    },
+    {
+      from: "client",
+      to: "user",
+      label: "request review",
+      caption:
+        "2 · HITL gate one. The host shows the user the prompt and asks: do you consent to this server sampling your LLM?",
+      hitl: true,
+      embed: "sampling-approval",
+    },
+    {
+      from: "user",
+      to: "client",
+      label: "approved · sample LLM",
+      caption:
+        "3 · The user approved. The client samples its host LLM with the prompt; the model returns a completion.",
+    },
+    {
+      from: "client",
+      to: "server",
+      label: "response · completion",
+      caption:
+        "4 · HITL gate two (implicit on this lane). Before the completion goes back to the server, the host could surface it to the user; once approved, the response sails.",
+      hitl: true,
+    },
+  ],
+  elicitation: [
+    {
+      from: "server",
+      to: "client",
+      label: "elicitation/create",
+      caption:
+        "1 · The server is missing a piece of information mid-flow. It sends elicitation/create with a JSON-Schema fragment for the form it wants.",
+    },
+    {
+      from: "client",
+      to: "user",
+      label: "render form from schema",
+      caption:
+        "2 · The host renders the schema as a form. The HITL gate is the form itself — the user filling it IS the response.",
+      hitl: true,
+      embed: "elicitation-form",
+    },
+    {
+      from: "user",
+      to: "client",
+      label: "submit values",
+      caption:
+        "3 · The user submits. The client packages the values into the elicitation response payload.",
+    },
+    {
+      from: "client",
+      to: "server",
+      label: "response · { action, content }",
+      caption:
+        "4 · The response goes back to the server. action is accept | decline | cancel; content carries the values when accepted.",
+    },
+  ],
+  roots: [
+    {
+      from: "server",
+      to: "client",
+      label: "roots/list",
+      caption:
+        "1 · The server asks the client what directories it's allowed to operate inside. The client could also push notifications/roots/list_changed any time the user moves the workspace.",
+    },
+    {
+      from: "client",
+      to: "client",
+      label: "read declared roots",
+      caption:
+        "2 · The client reads its current roots. No HITL gate here — the user already declared the boundary at workspace setup; this is just coordination on the wire.",
+      embed: "roots-manager",
+    },
+    {
+      from: "client",
+      to: "server",
+      label: "response · [ roots ]",
+      caption:
+        "3 · The client returns the roots list as file:// URIs. The server now knows the bounds it should respect.",
+    },
+    {
+      from: "server",
+      to: "server",
+      label: "operate inside bounds",
+      caption:
+        "4 · The server operates inside the declared bounds. Coordination, not enforcement — nothing on the wire stops a misbehaving server from straying. (This sets up chapter 9.)",
+    },
+  ],
+};
+
+const SCENARIO_LABELS: Record<Scenario, string> = {
+  sampling: "sampling",
+  elicitation: "elicitation",
+  roots: "roots",
+};
+
+const SCENARIO_BLURBS: Record<Scenario, string> = {
+  sampling: "server wants the host's LLM",
+  elicitation: "server asks the user a structured question",
+  roots: "client tells the server where it can operate",
+};
+
+export function ReverseFlowDiagram() {
+  const reduce = useReducedMotion();
+  const liveRegionId = useId();
+  const tablistId = useId();
+
+  const [scenario, setScenario] = useState<Scenario>("sampling");
+  // -1 = idle (no tick fired yet); 0..3 = tick fired.
+  const [tick, setTick] = useState<number>(-1);
+
+  const ticks = SCRIPTS[scenario];
+
+  const handleScenarioChange = useCallback((next: Scenario) => {
+    setScenario(next);
+    setTick(-1);
+  }, []);
+
+  const handleTickChange = useCallback((next: number) => {
+    // WidgetNav drives 0..total-1; we map it onto our -1..3 range.
+    setTick(next);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setTick(-1);
+  }, []);
+
+  const announce = useMemo(() => {
+    if (tick < 0) return `Idle on ${scenario}.`;
+    const t = ticks[tick];
+    return `Tick ${tick + 1} of ${ticks.length} — ${t.from} to ${t.to}, ${t.label}.`;
+  }, [tick, ticks, scenario]);
+
+  const captionText = useMemo(() => {
+    if (tick < 0) {
+      return `Pick a scenario, then step through the four ticks. Watch the ${SCENARIO_BLURBS[scenario]}.`;
+    }
+    if (tick >= ticks.length) {
+      return "Flow complete. Reset to play it again, or switch scenarios above.";
+    }
+    return ticks[tick].caption;
+  }, [tick, ticks, scenario]);
+
+  return (
+    <WidgetShell
+      title="Server-asks-back, three views — sampling, elicitation, roots"
+      measurements={
+        tick < 0
+          ? `tick 0 / ${ticks.length} · ${scenario}`
+          : `tick ${Math.min(tick + 1, ticks.length)} / ${ticks.length} · ${scenario}`
+      }
+      caption={captionText}
+      captionTone="prominent"
+      controls={
+        <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)]">
+          <WidgetNav
+            value={Math.max(tick, 0)}
+            total={ticks.length}
+            onChange={handleTickChange}
+            counterNoun="tick"
+            playable={true}
+          />
+          <button
+            type="button"
+            onClick={handleReset}
+            className="font-sans"
+            style={{
+              minHeight: 36,
+              padding: "6px 12px",
+              border: "1px solid var(--color-rule)",
+              borderRadius: "var(--radius-md)",
+              fontSize: "var(--text-ui)",
+              color: "var(--color-text-muted)",
+              background: "transparent",
+              cursor: "pointer",
+            }}
+            aria-label="Reset to idle"
+          >
+            ↺ reset
+          </button>
+        </div>
+      }
+    >
+      <div
+        id={liveRegionId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {announce}
+      </div>
+
+      <style>{`
+        .bs-rfd {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-md);
+        }
+        .bs-rfd-tabs {
+          display: flex;
+          gap: 4px;
+          padding: 4px;
+          background: color-mix(in oklab, var(--color-surface) 70%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-md);
+          flex-wrap: wrap;
+        }
+        .bs-rfd-tab {
+          flex: 1 1 100px;
+          min-height: 44px;
+          padding: 8px 12px;
+          font-family: var(--font-sans);
+          font-size: var(--text-ui);
+          color: var(--color-text-muted);
+          background: transparent;
+          border: 0;
+          border-radius: var(--radius-sm);
+          cursor: pointer;
+          letter-spacing: -0.005em;
+          text-align: center;
+        }
+        .bs-rfd-tab[aria-selected="true"] {
+          color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+        }
+        .bs-rfd-tab:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-rfd-tab-blurb {
+          display: block;
+          font-size: 11px;
+          font-family: var(--font-mono);
+          color: var(--color-text-muted);
+          margin-top: 2px;
+          opacity: 0.8;
+        }
+        .bs-rfd-stage {
+          background: color-mix(in oklab, var(--color-surface) 70%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-md);
+          padding: var(--spacing-md);
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-md);
+        }
+        .bs-rfd-lanes {
+          display: grid;
+          grid-template-columns: 80px 1fr;
+          gap: 8px var(--spacing-sm);
+          align-items: center;
+        }
+        .bs-rfd-lane-label {
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--color-text-muted);
+          text-transform: lowercase;
+          letter-spacing: 0.04em;
+          text-align: right;
+        }
+        .bs-rfd-lane {
+          position: relative;
+          height: 36px;
+          background: var(--color-bg);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-sm);
+          overflow: hidden;
+        }
+        .bs-rfd-lane[data-active="true"] {
+          border-color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 8%, var(--color-bg));
+        }
+        .bs-rfd-arrow-overlay {
+          margin-left: 80px;
+          margin-top: 4px;
+          position: relative;
+          height: 28px;
+        }
+        .bs-rfd-arrow {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          padding: 4px 10px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 12%, var(--color-surface));
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--color-text);
+          white-space: nowrap;
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .bs-rfd-arrow[data-hitl="true"] {
+          border-style: dashed;
+          background: color-mix(in oklab, var(--color-accent) 18%, var(--color-surface));
+        }
+        .bs-rfd-arrow-glyph {
+          color: var(--color-accent);
+          font-family: var(--font-mono);
+        }
+        .bs-rfd-hitl {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 2px 8px;
+          margin-left: 6px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 16%, transparent);
+          font-family: var(--font-mono);
+          font-size: 10px;
+          color: var(--color-accent);
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+        .bs-rfd-hitl-diamond {
+          display: inline-block;
+          width: 8px;
+          height: 8px;
+          background: var(--color-accent);
+          transform: rotate(45deg);
+        }
+        .bs-rfd-embed {
+          background: var(--color-bg);
+          border: 1px dashed var(--color-accent);
+          border-radius: var(--radius-md);
+          padding: var(--spacing-sm);
+        }
+        .bs-rfd-embed-eyebrow {
+          font-family: var(--font-mono);
+          font-size: 10px;
+          color: var(--color-accent);
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          margin-bottom: 8px;
+        }
+      `}</style>
+
+      <div className="bs-rfd">
+        {/* Scenario tabs */}
+        <div
+          className="bs-rfd-tabs"
+          role="tablist"
+          aria-label="Server-asks-back scenarios"
+          id={tablistId}
+        >
+          {(Object.keys(SCRIPTS) as Scenario[]).map((s) => {
+            const selected = scenario === s;
+            return (
+              <button
+                key={s}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                tabIndex={selected ? 0 : -1}
+                className="bs-rfd-tab"
+                onClick={() => handleScenarioChange(s)}
+              >
+                {SCENARIO_LABELS[s]}
+                <span className="bs-rfd-tab-blurb">{SCENARIO_BLURBS[s]}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Stage: three lanes + arrows + embed */}
+        <div className="bs-rfd-stage">
+          {(["server", "client", "user"] as Lane[]).map((lane) => {
+            const t = tick >= 0 && tick < ticks.length ? ticks[tick] : null;
+            const active = t ? t.from === lane || t.to === lane : false;
+            return (
+              <div key={lane} className="bs-rfd-lanes">
+                <div className="bs-rfd-lane-label">{lane}</div>
+                <div className="bs-rfd-lane" data-active={active}>
+                  <AnimatePresence>
+                    {t && (t.from === lane || t.to === lane) ? (
+                      <motion.div
+                        key={`${scenario}-${tick}-${lane}`}
+                        className="bs-rfd-arrow"
+                        data-hitl={t.hitl ? "true" : "false"}
+                        initial={
+                          reduce ? { opacity: 0 } : { opacity: 0, x: t.from === lane ? -8 : 8 }
+                        }
+                        animate={{
+                          opacity: 1,
+                          x: 0,
+                          left: lane === t.from ? "8px" : undefined,
+                          right: lane === t.to && lane !== t.from ? "8px" : undefined,
+                        }}
+                        exit={{ opacity: 0 }}
+                        transition={SPRING.smooth}
+                        style={{
+                          left: lane === t.from ? 8 : undefined,
+                          right: lane === t.to && lane !== t.from ? 8 : undefined,
+                        }}
+                      >
+                        <span className="bs-rfd-arrow-glyph">
+                          {t.from === t.to ? "↻" : lane === t.from ? "→" : "←"}
+                        </span>
+                        <span>{t.label}</span>
+                        {t.hitl && lane === "user" ? (
+                          <span className="bs-rfd-hitl">
+                            <span className="bs-rfd-hitl-diamond" aria-hidden />
+                            HITL
+                          </span>
+                        ) : null}
+                      </motion.div>
+                    ) : null}
+                  </AnimatePresence>
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Embed slot — mounts the relevant sub-widget when its tick fires. */}
+          <AnimatePresence mode="wait">
+            {tick >= 0 && tick < ticks.length && ticks[tick].embed ? (
+              <motion.div
+                key={`${scenario}-${tick}-embed`}
+                className="bs-rfd-embed"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.gentle}
+              >
+                <div className="bs-rfd-embed-eyebrow">
+                  what the host actually shows · try it
+                </div>
+                {ticks[tick].embed === "sampling-approval" ? (
+                  <SamplingApproval compact />
+                ) : null}
+                {ticks[tick].embed === "elicitation-form" ? (
+                  <ElicitationForm compact />
+                ) : null}
+                {ticks[tick].embed === "roots-manager" ? (
+                  <RootsManager compact />
+                ) : null}
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default ReverseFlowDiagram;

--- a/app/courses/mcps/_content/when-the-server-asks-back/widgets/ReverseQuiz.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/widgets/ReverseQuiz.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * ReverseQuiz — premise-quiz opener for chapter 8 (voice §12.1).
+ *
+ * The reader's instinct on sampling: "the server wants the LLM, the client
+ * forwards, the LLM replies, done — one HITL gate, maybe none." The
+ * chapter's correction: sampling has TWO human-approval checkpoints — one
+ * before the prompt reaches the LLM, one before the completion reaches the
+ * server. The wrong-answer verdict creates the demand the rest of the
+ * chapter pays back.
+ *
+ * Reuses the shipped <Quiz> primitive: radiogroup a11y, reduced-motion fall-
+ * back, frame-stable verdict slot, one-accent terracotta highlight.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+export function ReverseQuiz() {
+  return (
+    <WidgetShell
+      title="A server asks for the host's LLM. How many human-approval gates fire?"
+      caption={
+        <>
+          Predict before you read on. The chapter exists because most readers
+          arrive thinking sampling is a single forward call. It isn&apos;t —
+          and the gate count is what makes the spec safe by construction.
+        </>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        <Quiz
+          question={
+            <p
+              className="font-serif"
+              style={{
+                fontSize: "var(--text-body)",
+                lineHeight: 1.55,
+                margin: 0,
+              }}
+            >
+              A server sends{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>
+                sampling/createMessage
+              </code>{" "}
+              — <em>analyse these 47 flights, recommend the best.</em> Before
+              the response gets back to the server, how many human-approval
+              gates fire on the host?
+            </p>
+          }
+          correctId="two"
+          rightVerdict={
+            <>
+              Right. The host asks the user before forwarding the request to
+              the LLM (<em>does the user consent to this server sampling?</em>),
+              and asks again before sending the LLM&apos;s completion back to
+              the server (<em>does the user consent to this output going
+              back?</em>). Two gates, on either side of the model call.
+            </>
+          }
+          wrongVerdict={
+            <>
+              Sampling has <em>two</em> checkpoints, not one. The host gates
+              the request before it reaches the LLM, and gates the response
+              before it goes back to the server. A model the server asked for
+              still goes through the user — both ways.
+            </>
+          }
+          options={[
+            {
+              id: "zero",
+              label:
+                "Zero — sampling is fire-and-forget; the host forwards the prompt and pipes the completion straight back.",
+            },
+            {
+              id: "one",
+              label:
+                "One — the user approves the sampling request; once approved, the LLM's reply flows back automatically.",
+            },
+            {
+              id: "two",
+              label:
+                "Two — the user approves the request before the LLM is called, AND approves the response before it returns to the server.",
+            },
+            {
+              id: "three",
+              label:
+                "Three — request, model choice, and response each get their own gate.",
+            },
+          ]}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default ReverseQuiz;

--- a/app/courses/mcps/_content/when-the-server-asks-back/widgets/RootsManager.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/widgets/RootsManager.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+/**
+ * RootsManager — a small editor for the client's declared roots.
+ *
+ * Pedagogical role: roots are the directories the client tells the server
+ * "operate inside these." Coordination, NOT enforcement — the server
+ * SHOULD respect them, but nothing on the wire stops a malicious server
+ * from ignoring the list. (That sentence sets up chapter 9.)
+ *
+ * UX: a list of file:// URIs. Add, remove, and watch the
+ * `notifications/roots/list_changed` envelope render every time the list
+ * changes — the very notification a real client would emit.
+ *
+ * Two roles in the chapter:
+ *   - Standalone (Content.tsx, around the roots beat) — full WidgetShell,
+ *     two-pane (editor + envelope log).
+ *   - Embedded inside ReverseFlowDiagram's "roots" tab (compact mode).
+ */
+
+import { useState, useId, useRef } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+type Envelope = {
+  id: number;
+  method: "notifications/roots/list_changed" | "roots/list (response)";
+  ts: string;
+  body: string;
+};
+
+const INITIAL_ROOTS = [
+  "file:///Users/ada/projects/bytesize",
+  "file:///Users/ada/Documents/specs",
+];
+
+type RootsManagerProps = {
+  /** Compact = no WidgetShell. Default false. */
+  compact?: boolean;
+  /** Optional callback fired whenever the roots list changes. Lets the
+   *  parent diagram surface that the notification fired. */
+  onChange?: (roots: string[]) => void;
+};
+
+export function RootsManager({ compact = false, onChange }: RootsManagerProps) {
+  const reduce = useReducedMotion();
+  const inputId = useId();
+  const [roots, setRoots] = useState<string[]>(INITIAL_ROOTS);
+  const [draft, setDraft] = useState("");
+  const [envelopes, setEnvelopes] = useState<Envelope[]>([]);
+  const counterRef = useRef(0);
+
+  const fireEnvelope = (
+    method: Envelope["method"],
+    nextRoots: string[],
+  ) => {
+    counterRef.current += 1;
+    const ts = new Date().toLocaleTimeString(undefined, {
+      hour12: false,
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const body =
+      method === "notifications/roots/list_changed"
+        ? `{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}`
+        : `{
+  "jsonrpc": "2.0",
+  "id": ${counterRef.current},
+  "result": {
+    "roots": [
+${nextRoots.map((r) => `      { "uri": "${r}" }`).join(",\n")}
+    ]
+  }
+}`;
+    setEnvelopes((prev) =>
+      [{ id: counterRef.current, method, ts, body }, ...prev].slice(0, 6),
+    );
+  };
+
+  const addRoot = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    // Permissive normalisation — accept plain paths and prepend file://.
+    const normalised = /^[a-z]+:\/\//i.test(trimmed)
+      ? trimmed
+      : `file://${trimmed.startsWith("/") ? "" : "/"}${trimmed}`;
+    if (roots.includes(normalised)) {
+      setDraft("");
+      return;
+    }
+    const next = [...roots, normalised];
+    setRoots(next);
+    setDraft("");
+    playSound("Pop");
+    fireEnvelope("notifications/roots/list_changed", next);
+    onChange?.(next);
+  };
+
+  const removeRoot = (uri: string) => {
+    const next = roots.filter((r) => r !== uri);
+    setRoots(next);
+    playSound("Click");
+    fireEnvelope("notifications/roots/list_changed", next);
+    onChange?.(next);
+  };
+
+  const simulateRootsList = () => {
+    playSound("Progress-Tick");
+    fireEnvelope("roots/list (response)", roots);
+  };
+
+  const editor = (
+    <div className="bs-roots-grid">
+      <div className="bs-roots-editor">
+        <div className="bs-roots-eyebrow">
+          <span>your declared roots</span>
+          <span className="bs-roots-count">{roots.length}</span>
+        </div>
+        <ul className="bs-roots-list" aria-label="Declared filesystem roots">
+          <AnimatePresence initial={false}>
+            {roots.map((r) => (
+              <motion.li
+                key={r}
+                className="bs-roots-item"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, x: -4 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={reduce ? { opacity: 0 } : { opacity: 0, x: 4 }}
+                transition={SPRING.gentle}
+              >
+                <span className="bs-roots-uri">{r}</span>
+                <button
+                  type="button"
+                  className="bs-roots-remove"
+                  onClick={() => removeRoot(r)}
+                  aria-label={`remove ${r}`}
+                >
+                  ×
+                </button>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </ul>
+        <div className="bs-roots-add">
+          <label htmlFor={inputId} className="sr-only">
+            new root URI or path
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            className="bs-roots-input"
+            placeholder="file:///path/to/dir or /path/to/dir"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addRoot();
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="bs-roots-btn bs-roots-btn--primary"
+            onClick={addRoot}
+            disabled={!draft.trim()}
+          >
+            add root
+          </button>
+        </div>
+        <button
+          type="button"
+          className="bs-roots-btn bs-roots-btn--ghost"
+          onClick={simulateRootsList}
+          aria-label="Simulate the server calling roots/list"
+        >
+          ← simulate server calling roots/list
+        </button>
+      </div>
+      <div className="bs-roots-log">
+        <div className="bs-roots-log-head">envelope log</div>
+        {envelopes.length === 0 ? (
+          <div className="bs-roots-log-empty">
+            Add or remove a root to fire a{" "}
+            <code style={{ fontFamily: "var(--font-mono)" }}>
+              notifications/roots/list_changed
+            </code>{" "}
+            envelope. The server-side button simulates a{" "}
+            <code style={{ fontFamily: "var(--font-mono)" }}>roots/list</code>{" "}
+            response.
+          </div>
+        ) : (
+          <ul className="bs-roots-log-list">
+            <AnimatePresence initial={false}>
+              {envelopes.map((env) => (
+                <motion.li
+                  key={env.id}
+                  className="bs-roots-log-item"
+                  initial={reduce ? { opacity: 0 } : { opacity: 0, y: -4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={SPRING.gentle}
+                >
+                  <div className="bs-roots-log-meta">
+                    <span className="bs-roots-log-method">{env.method}</span>
+                    <span className="bs-roots-log-ts">{env.ts}</span>
+                  </div>
+                  <pre className="bs-roots-log-body">{env.body}</pre>
+                </motion.li>
+              ))}
+            </AnimatePresence>
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+
+  const styles = (
+    <style>{`
+      .bs-roots-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--spacing-md);
+      }
+      @container widget (min-width: 640px) {
+        .bs-roots-grid {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .bs-roots-editor {
+        background: var(--color-surface);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+      }
+      .bs-roots-eyebrow {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        color: var(--color-text);
+      }
+      .bs-roots-count {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+      }
+      .bs-roots-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-height: 60px;
+      }
+      .bs-roots-item {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        padding: 6px 8px;
+        background: var(--color-bg);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-sm);
+      }
+      .bs-roots-uri {
+        flex: 1 1 auto;
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        color: var(--color-text);
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+      .bs-roots-remove {
+        flex: 0 0 auto;
+        min-width: 32px;
+        min-height: 32px;
+        font-family: var(--font-sans);
+        font-size: 18px;
+        line-height: 1;
+        color: var(--color-text-muted);
+        background: transparent;
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+      }
+      .bs-roots-remove:hover { color: var(--color-accent); border-color: var(--color-accent); }
+      .bs-roots-remove:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 1px;
+      }
+      .bs-roots-add {
+        display: flex;
+        gap: var(--spacing-sm);
+        flex-wrap: wrap;
+      }
+      .bs-roots-input {
+        flex: 1 1 200px;
+        min-height: 44px;
+        padding: 8px 10px;
+        font-family: var(--font-mono);
+        font-size: var(--text-small);
+        background: var(--color-bg);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-sm);
+        color: var(--color-text);
+      }
+      .bs-roots-input:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 1px;
+        border-color: var(--color-accent);
+      }
+      .bs-roots-btn {
+        min-height: 44px;
+        padding: 8px 14px;
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-rule);
+        background: transparent;
+        color: var(--color-text);
+        cursor: pointer;
+      }
+      .bs-roots-btn:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px;
+      }
+      .bs-roots-btn--primary {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+      }
+      .bs-roots-btn--primary:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+      .bs-roots-btn--ghost {
+        font-size: var(--text-small);
+        color: var(--color-text-muted);
+      }
+      .bs-roots-log {
+        background: var(--color-surface);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        max-height: 380px;
+      }
+      .bs-roots-log-head {
+        padding: 8px var(--spacing-sm);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--color-text-muted);
+        text-transform: lowercase;
+        letter-spacing: 0.02em;
+        border-bottom: 1px solid var(--color-rule);
+      }
+      .bs-roots-log-empty {
+        padding: var(--spacing-md);
+        font-family: var(--font-serif);
+        font-size: var(--text-small);
+        color: var(--color-text-muted);
+        line-height: 1.55;
+      }
+      .bs-roots-log-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+        flex: 1 1 auto;
+      }
+      .bs-roots-log-item {
+        border-bottom: 1px solid var(--color-rule);
+        padding: 8px var(--spacing-sm);
+      }
+      .bs-roots-log-item:last-child { border-bottom: 0; }
+      .bs-roots-log-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-sm);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--color-text-muted);
+        margin-bottom: 4px;
+      }
+      .bs-roots-log-method {
+        color: var(--color-accent);
+      }
+      .bs-roots-log-body {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.5;
+        color: var(--color-text);
+        margin: 0;
+        white-space: pre;
+        overflow-x: auto;
+      }
+    `}</style>
+  );
+
+  if (compact) {
+    return (
+      <>
+        {styles}
+        {editor}
+      </>
+    );
+  }
+
+  return (
+    <WidgetShell
+      title="Roots — what the client tells the server it can touch"
+      caption={
+        <>
+          The list on the left is what the client declares; the log on the
+          right is the wire. Add or remove a path and watch the{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>
+            notifications/roots/list_changed
+          </code>{" "}
+          envelope fire.
+        </>
+      }
+    >
+      {styles}
+      {editor}
+    </WidgetShell>
+  );
+}
+
+export default RootsManager;

--- a/app/courses/mcps/_content/when-the-server-asks-back/widgets/SamplingApproval.tsx
+++ b/app/courses/mcps/_content/when-the-server-asks-back/widgets/SamplingApproval.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+/**
+ * SamplingApproval — a tiny in-page approval modal mock.
+ *
+ * Pedagogical role: make the human-in-the-loop checkpoint tactile. The
+ * server requested `sampling/createMessage`; before any prompt reaches the
+ * host's LLM, the host shows the user this gate. Three buttons:
+ * `Allow once`, `Allow always`, `Deny`. The HITL gate IS the spec's safety
+ * claim made concrete.
+ *
+ * Two roles in the chapter:
+ *   - Standalone (Content.tsx, around the sampling beat) — the reader can
+ *     poke at the gate independent of the timeline.
+ *   - Embedded inside ReverseFlowDiagram's "sampling" tab at the gate tick
+ *     (compact mode) — the same component, smaller chrome, so the diagram
+ *     teaches the same gesture without a second component drift.
+ */
+
+import { useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+type Decision = "pending" | "allow-once" | "allow-always" | "deny";
+
+type SamplingApprovalProps = {
+  /** Compact = no WidgetShell, render only the modal mock (used inside the
+   *  flow diagram). Default false = full WidgetShell with a caption. */
+  compact?: boolean;
+  /** Optional callback fired on any decision. Lets the parent diagram
+   *  advance its tick when the gate has been answered. */
+  onDecision?: (decision: Exclude<Decision, "pending">) => void;
+};
+
+const PROMPT_PREVIEW = `analyse the 47 flights in this dataset and
+recommend the best three by total cost,
+including layover penalties.`;
+
+export function SamplingApproval({
+  compact = false,
+  onDecision,
+}: SamplingApprovalProps) {
+  const reduce = useReducedMotion();
+  const [decision, setDecision] = useState<Decision>("pending");
+
+  const handle = (next: Exclude<Decision, "pending">) => {
+    playSound(next === "deny" ? "Error" : "Success");
+    setDecision(next);
+    onDecision?.(next);
+  };
+
+  const reset = () => {
+    playSound("Progress-Tick");
+    setDecision("pending");
+  };
+
+  const verdictText: Record<Exclude<Decision, "pending">, string> = {
+    "allow-once": "Allowed for this call. The host will ask again next time.",
+    "allow-always":
+      "Allowed for this server going forward. Future sampling requests skip the gate.",
+    deny: "Denied. The host returns an error to the server; the LLM is never called.",
+  };
+
+  const modal = (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Sampling approval"
+      className="bs-samp-modal"
+    >
+      <div className="bs-samp-head">
+        <span className="bs-samp-eyebrow">filesystem-server wants to sample your LLM</span>
+        <span className="bs-samp-pill">sampling/createMessage</span>
+      </div>
+      <pre className="bs-samp-prompt">{PROMPT_PREVIEW}</pre>
+      <div className="bs-samp-meta">
+        <span>maxTokens · 512</span>
+        <span>·</span>
+        <span>modelPreferences · speed</span>
+      </div>
+      <AnimatePresence mode="wait">
+        {decision === "pending" ? (
+          <motion.div
+            key="actions"
+            className="bs-samp-actions"
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.gentle}
+          >
+            <button
+              type="button"
+              className="bs-samp-btn bs-samp-btn--primary"
+              onClick={() => handle("allow-once")}
+            >
+              allow once
+            </button>
+            <button
+              type="button"
+              className="bs-samp-btn"
+              onClick={() => handle("allow-always")}
+            >
+              allow always
+            </button>
+            <button
+              type="button"
+              className="bs-samp-btn bs-samp-btn--deny"
+              onClick={() => handle("deny")}
+            >
+              deny
+            </button>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="verdict"
+            className="bs-samp-verdict"
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={SPRING.gentle}
+            data-decision={decision}
+          >
+            <span className="bs-samp-verdict-label">
+              {decision === "deny" ? "denied" : decision === "allow-once" ? "allowed once" : "allowed always"}
+            </span>
+            <span className="bs-samp-verdict-text">
+              {verdictText[decision]}
+            </span>
+            <button
+              type="button"
+              className="bs-samp-btn bs-samp-btn--reset"
+              onClick={reset}
+            >
+              reset
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+
+  const styles = (
+    <style>{`
+      .bs-samp-modal {
+        background: var(--color-surface);
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+        max-width: 100%;
+      }
+      .bs-samp-head {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-sm);
+      }
+      .bs-samp-eyebrow {
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        color: var(--color-text);
+        letter-spacing: -0.005em;
+      }
+      .bs-samp-pill {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+        white-space: nowrap;
+      }
+      .bs-samp-prompt {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.55;
+        color: var(--color-text);
+        background: color-mix(in oklab, var(--color-surface) 60%, var(--color-bg));
+        border: 1px solid var(--color-rule);
+        border-radius: var(--radius-sm);
+        padding: var(--spacing-sm);
+        margin: 0;
+        white-space: pre-wrap;
+        overflow-x: auto;
+      }
+      .bs-samp-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--color-text-muted);
+      }
+      .bs-samp-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--spacing-sm);
+        margin-top: 4px;
+      }
+      .bs-samp-btn {
+        min-height: 44px;
+        padding: 8px 14px;
+        font-family: var(--font-sans);
+        font-size: var(--text-ui);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--color-rule);
+        background: transparent;
+        color: var(--color-text);
+        cursor: pointer;
+        flex: 1 1 0;
+        min-width: 96px;
+      }
+      .bs-samp-btn:focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px;
+      }
+      .bs-samp-btn--primary {
+        border-color: var(--color-accent);
+        color: var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+      }
+      .bs-samp-btn--deny {
+        color: var(--color-text-muted);
+      }
+      .bs-samp-btn--reset {
+        flex: 0 0 auto;
+        min-width: 80px;
+      }
+      .bs-samp-verdict {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-sm);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-accent);
+        background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+      }
+      .bs-samp-verdict[data-decision="deny"] {
+        border-color: var(--color-rule);
+        background: color-mix(in oklab, var(--color-text-muted) 6%, transparent);
+      }
+      .bs-samp-verdict-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--color-accent);
+      }
+      .bs-samp-verdict[data-decision="deny"] .bs-samp-verdict-label {
+        color: var(--color-text-muted);
+      }
+      .bs-samp-verdict-text {
+        flex: 1 1 200px;
+        font-family: var(--font-serif);
+        font-size: var(--text-small);
+        color: var(--color-text);
+        line-height: 1.5;
+      }
+    `}</style>
+  );
+
+  if (compact) {
+    return (
+      <>
+        {styles}
+        {modal}
+      </>
+    );
+  }
+
+  return (
+    <WidgetShell
+      title="The sampling gate — what the host actually shows the user"
+      caption={
+        <>
+          The server&apos;s prompt arrives at the host. Before it reaches the
+          LLM, the host shows this. Three answers, three different sessions
+          downstream.
+        </>
+      }
+    >
+      {styles}
+      {modal}
+    </WidgetShell>
+  );
+}
+
+export default SamplingApproval;


### PR DESCRIPTION
## Summary

- Authors **Chapter 8 — When the server asks back: sampling, elicitation, roots** of the MCPs course.
- Ships five widgets: `ReverseQuiz` (premise-quiz opener), `ReverseFlowDiagram` (**load-bearing** three-tab diagram), `SamplingApproval`, `ElicitationForm`, `RootsManager`.
- Registers the chapter in `MCPS_CONTENT`; manifest entry already existed.

## Design notes

- **Load-bearing widget — `ReverseFlowDiagram`** has three tabs (sampling / elicitation / roots), each a 4-tick script across three actor lanes (server / client / user). HITL checkpoints render as terracotta diamonds in the user lane; the relevant sub-widget (`SamplingApproval` / `ElicitationForm` / `RootsManager`) mounts inline at the gate tick so the diagram is operable, not just diagrammed.
- **Sampling has two HITL gates, not one** — the opener anchors this and §3 cashes it in (request review + response review).
- **"Roots are coordination, not enforcement."** — present verbatim in §4; chapter 9 inherits the claim.
- Voice §12: premise-quiz opener, mechanism-first reframe (the protocol's other direction), `<Term>` on first appearance of every spec word (sampling, elicitation, roots, human-in-the-loop, modelPreferences), predict-and-reveal comprehension check, closer that loops back to the opener.
- Reduced-motion safe across all five widgets; one accent only (terracotta); no `<hr>`, no `<br>`, no `VerticalCutReveal`.

Resolves #77

## Test plan

- [ ] `npx tsc --noEmit` passes (no new errors; only pre-existing `@web-kits/audio` declaration shim missing).
- [ ] `npx next build` produces the static `/courses/mcps/when-the-server-asks-back` route.
- [ ] Dev server (port 3010) renders 200 and includes `sampling/createMessage`, `elicitation/create`, `notifications/roots/list_changed`, "human-in-the-loop", "coordination, not enforcement".
- [ ] Manual: step through the load-bearing diagram on each of the three tabs; verify the embedded sub-widgets mount at the right tick.
- [ ] Manual: 375 px viewport — no horizontal scroll, hit zones ≥ 44 × 44.
- [ ] Manual: dark mode parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)