### PR TITLE
feat(courses/mcps): chapter 7 — Build a client, and pick a transport

### DIFF
--- a/app/courses/mcps/_content/build-a-client-pick-a-transport/Content.tsx
+++ b/app/courses/mcps/_content/build-a-client-pick-a-transport/Content.tsx
@@ -1,0 +1,359 @@
+/**
+ * Chapter 7 — Build a client, pick a transport.
+ *
+ * Server component. Composes the chapter prose around four widgets:
+ *   1. OAuthGate          — premise-quiz opener (voice §12.1).
+ *   2. InitFlowAnimation  — six-step scripted stepper covering the full
+ *                           connect-through-tools/list exchange.
+ *   3. TransportPicker    — load-bearing scenario branch (4 deployments).
+ *   4. (Comprehension check is plain prose with details/summary; no
+ *      separate widget — the chapter already runs four interactive panels.)
+ *
+ * Voice §12 patterns honoured:
+ *   - <Term> on first appearance of every spec word (transport, stdio,
+ *     Streamable HTTP, session, SSE, HTTP+SSE, WWW-Authenticate, EOF).
+ *   - Mechanism-first reframe — transport choice is downstream of trust,
+ *     locality, and auth, not a free style choice.
+ *   - Just-in-time vocabulary; no glossary chapter.
+ *   - Closer loops back to the opener (server can ask back → ch 8).
+ *   - VerticalCutReveal banned; closer is still prose.
+ *
+ * No <hr>, no <br>. Section breaks ride on <H2> + spacing rhythm.
+ */
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { Aside, Callout, H2, H3, P, Term } from "@/components/prose";
+import { CodeBlock } from "@/components/code/CodeBlock";
+
+const OAuthGate = dynamic(
+  () => import("./widgets/OAuthGate").then((m) => m.OAuthGate),
+);
+const InitFlowAnimation = dynamic(
+  () =>
+    import("./widgets/InitFlowAnimation").then((m) => m.InitFlowAnimation),
+);
+const TransportPicker = dynamic(
+  () => import("./widgets/TransportPicker").then((m) => m.TransportPicker),
+);
+
+export function Content() {
+  return (
+    <>
+      <P>
+        You&apos;ve built a server in chapter 6 — a small{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>currency-server</code>{" "}
+        that exposes one tool and waits for someone to call it. The server
+        sits there ready. Nothing happens until a consumer shows up. Most
+        readers arrive thinking the consumer is the LLM. It isn&apos;t —
+        the consumer is a <Term>client</Term>, and the client&apos;s first
+        choice is also its hardest one: which <Term>transport</Term> does
+        it speak.
+      </P>
+
+      <P>
+        The 2025-06-18 spec leaves you with two answers. There used to be
+        three; one of them was deprecated this round, and the chapter exists
+        partly to keep you from tripping over old tutorials that still
+        reach for it. Before any of that, the opener — what does the spec
+        say a remote MCP server should do when a request shows up without
+        credentials?
+      </P>
+
+      <OAuthGate />
+
+      <H2>The client&apos;s job, in three sentences</H2>
+
+      <P>
+        A client opens a <Term>session</Term> with one server, drives the
+        lifecycle, and exposes the discovered surface to the host. It
+        speaks JSON-RPC over a transport you pick at construction time;
+        every later request and notification rides that wire. One host,
+        many clients — one per server, and that&apos;s the whole shape.
+      </P>
+
+      <P>
+        The smallest version that works fits on the back of an envelope.
+        A name, a transport, a connect, a list, a call. Everything else
+        is convenience.
+      </P>
+
+      <CodeBlock
+        lang="typescript"
+        filename="minimal-client.ts (stdio)"
+        code={`import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const transport = new StdioClientTransport({
+  command: "node",
+  args: ["./currency-server.js"],
+});
+
+const client = new Client({ name: "minimal-client", version: "0.1.0" });
+await client.connect(transport);
+
+const { tools } = await client.listTools();
+const result = await client.callTool({
+  name: "convert",
+  arguments: { amount: 100, from: "USD", to: "EUR" },
+});`}
+      />
+
+      <P>
+        The interesting line is{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          client.connect(transport)
+        </code>
+        . Under the hood it runs the three-message handshake from chapter 4
+        — same{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>initialize</code>{" "}
+        request, same response, same{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          notifications/initialized
+        </code>
+        . Capability negotiation, version pinning, the gate before the
+        session opens — all hidden behind one await. After it resolves,{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>listTools</code>{" "}
+        and{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>callTool</code>{" "}
+        are the two methods you reach for first.
+      </P>
+
+      <P>
+        The widget below shows what those five lines look like on the
+        wire — the transport opens, the handshake runs, then{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/list</code>{" "}
+        pulls the menu. Six messages, then your client has something to
+        call.
+      </P>
+
+      <InitFlowAnimation />
+
+      <H2>The transport question</H2>
+
+      <P>
+        The 2025-06-18 spec gives you two transports: <Term>stdio</Term>{" "}
+        for same-machine, and <Term>Streamable HTTP</Term> for
+        everywhere else. They&apos;re not interchangeable; each picks a
+        different set of trade-offs about trust, locality, and auth.
+      </P>
+
+      <H3>stdio</H3>
+
+      <P>
+        The client spawns the server as a child process and pipes
+        JSON-RPC over stdin and stdout. Logs go to stderr. The session
+        is bound to the process lifetime — when the process exits, you
+        get an <Term>EOF</Term> on the read side and the session is
+        over. No port to open, no TLS to terminate, no auth header to
+        forge: same machine, same user, no boundary. It&apos;s the
+        cheapest wire there is.
+      </P>
+
+      <P>
+        The trade-off lands on reach. stdio servers are single-instance,
+        single-tenant, local-only. There&apos;s no way for a stdio
+        server to be discovered, load-balanced, or accessed from a
+        different machine. If your client and server share a process
+        boundary, that&apos;s a feature; if they don&apos;t, it&apos;s
+        a wall.
+      </P>
+
+      <H3>Streamable HTTP</H3>
+
+      <P>
+        The client sends JSON-RPC over a single HTTP endpoint — usually
+        a <code style={{ fontFamily: "var(--font-mono)" }}>POST</code>{" "}
+        — and the server replies with either a normal JSON response or
+        a streamed{" "}
+        <Term>SSE</Term> body when it has more than one message to
+        deliver (think a long-running tool call that wants to push
+        progress notifications mid-flight). Auth is the same auth your
+        web infra already speaks: an{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>Authorization</code>{" "}
+        header, OAuth scoping, an HTTP-layer session id.
+      </P>
+
+      <P>
+        The session identity moves out of the process and into a header.
+        The server hands the client a session id on the response to{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>initialize</code>
+        ; every subsequent request carries it. That&apos;s how a
+        load-balanced, multi-instance, multi-tenant deployment can route
+        a tool call back to the same logical conversation — whichever
+        instance happens to take the next request can hydrate state from
+        the id.
+      </P>
+
+      <CodeBlock
+        lang="typescript"
+        filename="minimal-client.ts (Streamable HTTP variant)"
+        code={`import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://api.example.com/mcp"),
+  { requestInit: { headers: { Authorization: \`Bearer \${token}\` } } },
+);
+
+const client = new Client({ name: "minimal-client", version: "0.1.0" });
+await client.connect(transport);`}
+      />
+
+      <P>
+        Same client, same{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>connect</code>,
+        same handshake under the hood. The only thing that changed is
+        the transport constructor — a URL and a header in place of a
+        command and args. That&apos;s by design: the SDK keeps the
+        client surface identical, so your call sites don&apos;t care
+        which wire you picked.
+      </P>
+
+      <H2>The HTTP+SSE deprecation, named</H2>
+
+      <P>
+        Earlier MCP specs shipped a different remote transport — call it{" "}
+        <Term>HTTP+SSE</Term>. Two endpoints: a{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>POST</code>{" "}
+        endpoint the client wrote to, and a separate SSE endpoint the
+        client kept open to receive server-initiated messages. It
+        worked, but it asked every deployment to keep two paths in sync,
+        with auth scoping at two boundaries instead of one. The 2025-06-18
+        spec deprecated the pairing in favour of{" "}
+        <Term>Streamable HTTP</Term> — one endpoint, optional streaming
+        on response. If a tutorial sends you toward{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>/sse</code> and{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>/messages</code>{" "}
+        as separate paths, it&apos;s pointed at the deprecated shape.
+      </P>
+
+      <Aside>
+        The full auth story — PKCE, dynamic client registration, token
+        refresh — is out of scope for this chapter; OAuth gets a closer
+        look later in the course. For now the load-bearing fact is the
+        one the opener was about: 401 with a{" "}
+        <Term>WWW-Authenticate</Term> header is the spec&apos;s
+        recommended response to an unauthenticated request, and the
+        client follows the header to find the auth metadata.
+      </Aside>
+
+      <H2>Pick a transport for your scenario</H2>
+
+      <P>
+        Trust, locality, and auth are the three axes the choice sits on.
+        Same machine, same user, no auth boundary — stdio. Off-machine,
+        multi-tenant, or auth lives at HTTP — Streamable HTTP. The
+        widget below walks four real deployments. Pick the transport
+        you&apos;d ship; wrong picks reveal what would actually break.
+      </P>
+
+      <TransportPicker />
+
+      <H2>Operational concerns, in two paragraphs</H2>
+
+      <P>
+        Transports fail. With stdio the failure mode is loud and
+        process-shaped: the child crashes, the read pipe gets an EOF,
+        the client surfaces a transport error. There&apos;s nothing to
+        retry — the session is gone with the process. With Streamable
+        HTTP the failure mode is quieter: a connection drops, a load
+        balancer reaps an idle session, a server instance restarts. The
+        client typically re-issues the request; the spec&apos;s session
+        header is what makes the retry idempotent across instances.
+      </P>
+
+      <P>
+        Session expiration is the second thing to budget for. A
+        long-lived stdio session lives as long as the process; if you
+        kill the parent host, the children die with it. A Streamable
+        HTTP session lives as long as the server agrees — minutes, often
+        — and a stale session id will get a fresh{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>401</code> or{" "}
+        a{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>404</code>{" "}
+        depending on the server&apos;s policy. Either way, the client
+        has to be willing to re-handshake. It&apos;s the same shape as
+        re-establishing any other web session.
+      </P>
+
+      <H2>Comprehension check</H2>
+
+      <P>
+        Your remote MCP server is behind a load balancer. A client
+        connects, sends{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>initialize</code>,
+        and gets back an LB-assigned session id. Twenty minutes later it
+        sends{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>tools/call</code>
+        . What happens?
+      </P>
+
+      <details
+        className="font-serif"
+        style={{
+          marginTop: "1em",
+          marginBottom: "1em",
+          background: "var(--color-surface)",
+          padding: "var(--spacing-md)",
+          borderRadius: "var(--radius-md)",
+          fontSize: "var(--text-body)",
+          lineHeight: 1.6,
+          border: "1px solid var(--color-rule)",
+        }}
+      >
+        <summary
+          style={{
+            cursor: "pointer",
+            color: "var(--color-text-muted)",
+            fontFamily: "var(--font-sans)",
+            fontSize: "var(--text-small)",
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          }}
+        >
+          reveal answer
+        </summary>
+        <P>
+          It depends on the load balancer&apos;s session affinity. If
+          the LB pins the session id to the same instance, the request
+          lands on the instance that holds the conversation state and
+          succeeds. If it doesn&apos;t — round-robin, instance died,
+          deploy rotated — the request lands on a fresh instance that
+          has never seen this session id and either rejects with a{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>404</code>{" "}
+          (or 401, depending on the server&apos;s policy) or hydrates
+          state from a shared store. This is precisely why the spec
+          carries a session header and why session resumption matters
+          — Streamable HTTP makes the routing problem explicit so the
+          deployment can solve it instead of pretending the session
+          lives in process memory.
+        </P>
+      </details>
+
+      <H2>The session is open. Now what?</H2>
+
+      <P>
+        You&apos;ve got a server, a client, a transport, and the
+        primitives the host can reach for. Most messages flow
+        client-to-server: the host asks for the catalogue, calls a tool,
+        reads a resource. But sometimes the server has to ask back —
+        when it needs the LLM to complete a prompt, when it needs the
+        user to answer a question, when it needs the host to widen its
+        filesystem scope. The client&apos;s capability declarations are
+        the licence for those reverse calls. {" "}
+        <Link
+          href="/courses/mcps/when-the-server-asks-back"
+          className="font-sans"
+          style={{ color: "var(--color-accent)" }}
+        >
+          That&apos;s chapter 8.
+        </Link>
+      </P>
+    </>
+  );
+}
+
+export default Content;

--- a/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/InitFlowAnimation.tsx
+++ b/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/InitFlowAnimation.tsx
@@ -1,0 +1,770 @@
+"use client";
+
+/**
+ * InitFlowAnimation — six-step scripted stepper for chapter 7.
+ *
+ * Extends the visual grammar of chapter 4's HandshakeStepper to six
+ * messages, covering the full client-driven exchange the reader's own
+ * minimal client kicks off:
+ *   1. connect                     — transport open (no JSON-RPC yet)
+ *   2. initialize request          — c2s
+ *   3. initialize response         — s2c
+ *   4. notifications/initialized   — c2s, no reply
+ *   5. tools/list request          — c2s
+ *   6. tools/list response         — s2c
+ *
+ * After step 6, a "tools loaded" badge appears so the reader feels the
+ * payoff: this is the moment `await client.listTools()` resolves and the
+ * host has a real menu to render. Replay rewinds to idle. WidgetNav drives
+ * the step cursor; clicking a tab in the JSON inspector also jumps to that
+ * step.
+ *
+ * Decisions baked in:
+ * - Two horizontal "lanes" (client and server) at >= 480px container
+ *   width; lanes stack on phones.
+ * - Envelopes are small terracotta-bordered chips that translate from
+ *   sender to receiver. Reduced motion drops the translation — envelopes
+ *   appear at end positions instantly. Frame size identical either way.
+ * - Step 1 (`connect`) renders a thin "transport open" pill in both
+ *   lanes rather than a moving envelope — the connection is bidirectional
+ *   from there on, so there's no envelope to send.
+ * - One accent only — terracotta on envelope borders + active step
+ *   indicator. No second hue.
+ * - JSON inspector to the right of the lanes (or below, on phones):
+ *   every step reveals its body, syntax-coloured via plain spans.
+ * - aria-live announces "step N of 6 — <method>" on each advance.
+ */
+
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { WidgetNav } from "@/components/viz/WidgetNav";
+import { SPRING } from "@/lib/motion";
+import { playSound } from "@/lib/audio";
+
+type Direction = "c2s" | "s2c" | "both";
+type Kind = "transport" | "request" | "response" | "notification";
+
+type Step = {
+  id: string;
+  dir: Direction;
+  method: string;
+  kind: Kind;
+  caption: string;
+  json: string;
+};
+
+const STEPS: Step[] = [
+  {
+    id: "connect",
+    dir: "both",
+    method: "connect",
+    kind: "transport",
+    caption:
+      "Step 1 — the client opens the transport. With stdio that's a child-process spawn; with Streamable HTTP it's the first POST. No JSON-RPC body yet — just a wire.",
+    json: `// no JSON-RPC body — the transport is open
+// stdio:        spawn({ command, args })
+// Streamable HTTP:  POST <url>  (with optional Authorization)`,
+  },
+  {
+    id: "init-request",
+    dir: "c2s",
+    method: "initialize",
+    kind: "request",
+    caption:
+      "Step 2 — the client sends initialize. It carries the protocolVersion it speaks, who it is (clientInfo), and what it can do (capabilities).",
+    json: `{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-06-18",
+    "clientInfo": {
+      "name": "minimal-client",
+      "version": "0.1.0"
+    },
+    "capabilities": {}
+  }
+}`,
+  },
+  {
+    id: "init-response",
+    dir: "s2c",
+    method: "initialize",
+    kind: "response",
+    caption:
+      "Step 3 — the server replies, paired by id. It declares its serverInfo and the menu of capabilities it offers — tools, resources, prompts, logging.",
+    json: `{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": {
+      "name": "currency-server",
+      "version": "1.0.0"
+    },
+    "capabilities": {
+      "tools": { "listChanged": true }
+    }
+  }
+}`,
+  },
+  {
+    id: "initialized",
+    dir: "c2s",
+    method: "notifications/initialized",
+    kind: "notification",
+    caption:
+      "Step 4 — the client sends an initialized notification. No id, no reply expected: the session is open. Past this gate, every other request is fair game.",
+    json: `{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}`,
+  },
+  {
+    id: "tools-list-request",
+    dir: "c2s",
+    method: "tools/list",
+    kind: "request",
+    caption:
+      "Step 5 — the client asks for the tool catalogue. This is the first message your minimal client sends after connect() resolves; it's what await client.listTools() does on the wire.",
+    json: `{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/list"
+}`,
+  },
+  {
+    id: "tools-list-response",
+    dir: "s2c",
+    method: "tools/list",
+    kind: "response",
+    caption:
+      "Step 6 — the server returns the catalogue. Each tool has a name, a one-line description, and a JSON-schema input. The host now has a menu to render to the model.",
+    json: `{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "convert",
+        "description": "Convert between currencies",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "amount": { "type": "number" },
+            "from": { "type": "string" },
+            "to": { "type": "string" }
+          },
+          "required": ["amount", "from", "to"]
+        }
+      }
+    ]
+  }
+}`,
+  },
+];
+
+/** Tiny JSON pretty-printer. Matches the HandshakeStepper colouring rules. */
+function colourJson(src: string): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    // Line comments — used only by the connect step's stub body.
+    if (ch === "/" && src[i + 1] === "/") {
+      const end = src.indexOf("\n", i);
+      const stop = end === -1 ? src.length : end;
+      out.push(
+        <span
+          key={key++}
+          style={{
+            color: "var(--color-text-muted)",
+            fontStyle: "italic",
+          }}
+        >
+          {src.slice(i, stop)}
+        </span>,
+      );
+      i = stop;
+      continue;
+    }
+    if (ch === '"') {
+      const end = src.indexOf('"', i + 1);
+      if (end === -1) {
+        out.push(<span key={key++}>{src.slice(i)}</span>);
+        break;
+      }
+      const token = src.slice(i, end + 1);
+      let j = end + 1;
+      while (j < src.length && /\s/.test(src[j])) j += 1;
+      const isKey = src[j] === ":";
+      out.push(
+        <span
+          key={key++}
+          style={{
+            color: isKey
+              ? "color-mix(in oklab, var(--color-accent) 80%, var(--color-text))"
+              : "var(--color-text)",
+          }}
+        >
+          {token}
+        </span>,
+      );
+      i = end + 1;
+    } else if (/[0-9]/.test(ch)) {
+      const m = /^[0-9.]+/.exec(src.slice(i));
+      const len = m ? m[0].length : 1;
+      out.push(
+        <span key={key++} style={{ color: "var(--color-text)" }}>
+          {src.slice(i, i + len)}
+        </span>,
+      );
+      i += len;
+    } else if (
+      src.startsWith("true", i) ||
+      src.startsWith("false", i) ||
+      src.startsWith("null", i)
+    ) {
+      const lit = src.startsWith("true", i)
+        ? "true"
+        : src.startsWith("false", i)
+          ? "false"
+          : "null";
+      out.push(
+        <span key={key++} style={{ color: "var(--color-text-muted)" }}>
+          {lit}
+        </span>,
+      );
+      i += lit.length;
+    } else {
+      out.push(
+        <span key={key++} style={{ color: "var(--color-text-muted)" }}>
+          {ch}
+        </span>,
+      );
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function KindGlyph({ kind }: { kind: Kind }) {
+  if (kind === "transport") {
+    return (
+      <span
+        aria-hidden
+        style={{
+          fontSize: 11,
+          color: "var(--color-accent)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        ⇌
+      </span>
+    );
+  }
+  if (kind === "notification") {
+    return (
+      <span aria-hidden style={{ fontSize: 11, color: "var(--color-accent)" }}>
+        ⤳
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      style={{
+        fontSize: 11,
+        color: "var(--color-accent)",
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      {kind === "request" ? "→" : "←"}
+    </span>
+  );
+}
+
+export function InitFlowAnimation() {
+  const reduce = useReducedMotion();
+  const liveRegionId = useId();
+
+  // -1 = nothing fired; 0..5 = step has fired; >=6 = tools loaded.
+  const [stepIndex, setStepIndex] = useState<number>(-1);
+
+  const advanceTo = useCallback((next: number) => {
+    setStepIndex(next);
+  }, []);
+
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const announceText = useMemo(() => {
+    if (stepIndex < 0) return "Idle. No messages sent yet.";
+    if (stepIndex >= STEPS.length) return "Tools loaded. Ready to call.";
+    const s = STEPS[stepIndex];
+    return `Step ${stepIndex + 1} of ${STEPS.length} — ${s.method} ${
+      s.kind === "transport"
+        ? "transport"
+        : s.kind === "notification"
+          ? "notification"
+          : s.kind
+    }${s.dir === "both" ? "" : s.dir === "c2s" ? ", client to server" : ", server to client"}.`;
+  }, [stepIndex]);
+
+  const handleReplay = useCallback(() => {
+    playSound("Progress-Tick");
+    setStepIndex(-1);
+  }, []);
+
+  const handleStep = useCallback(() => {
+    playSound("Progress-Tick");
+    setStepIndex((prev) => Math.min(prev + 1, STEPS.length));
+  }, []);
+
+  const ready = stepIndex >= STEPS.length;
+
+  const caption = useMemo(() => {
+    if (stepIndex < 0) {
+      return "Press Step (or Play) to send the first message. Six messages, then the tool catalogue is in hand.";
+    }
+    if (ready) {
+      return "Six messages exchanged. The session is open and the tool catalogue is loaded — your minimal client now has a menu to call into.";
+    }
+    return STEPS[stepIndex].caption;
+  }, [stepIndex, ready]);
+
+  const [inspected, setInspected] = useState<number | null>(null);
+  const inspectedFiredAndValid =
+    inspected !== null && inspected <= stepIndex && stepIndex >= 0;
+  const effectiveInspected = inspectedFiredAndValid
+    ? (inspected as number)
+    : Math.min(Math.max(stepIndex, 0), STEPS.length - 1);
+
+  return (
+    <WidgetShell
+      title="The init flow — connect through tools/list"
+      measurements={
+        ready
+          ? "tools loaded"
+          : stepIndex < 0
+            ? `0 of ${STEPS.length}`
+            : `${stepIndex + 1} of ${STEPS.length}`
+      }
+      caption={caption}
+      captionTone="prominent"
+      controls={
+        <div className="flex flex-wrap items-center justify-center gap-[var(--spacing-sm)]">
+          <WidgetNav
+            value={Math.max(stepIndex, 0)}
+            total={STEPS.length}
+            onChange={(next) => advanceTo(next)}
+            counterNoun="message"
+            playable={true}
+          />
+          <button
+            type="button"
+            onClick={handleReplay}
+            className="font-sans"
+            style={{
+              minHeight: 36,
+              padding: "6px 12px",
+              border: "1px solid var(--color-rule)",
+              borderRadius: "var(--radius-md)",
+              fontSize: "var(--text-ui)",
+              color: "var(--color-text-muted)",
+              background: "transparent",
+              cursor: "pointer",
+            }}
+            aria-label="Replay init flow from the start"
+          >
+            ↺ replay
+          </button>
+          <button
+            type="button"
+            onClick={handleStep}
+            disabled={ready}
+            className="font-sans"
+            style={{
+              minHeight: 36,
+              padding: "6px 12px",
+              border: "1px solid var(--color-accent)",
+              borderRadius: "var(--radius-md)",
+              fontSize: "var(--text-ui)",
+              color: ready ? "var(--color-text-muted)" : "var(--color-accent)",
+              background: ready
+                ? "transparent"
+                : "color-mix(in oklab, var(--color-accent) 10%, transparent)",
+              cursor: ready ? "not-allowed" : "pointer",
+              opacity: ready ? 0.5 : 1,
+            }}
+          >
+            {ready ? "tools loaded ✓" : "step ›"}
+          </button>
+        </div>
+      }
+    >
+      <div
+        id={liveRegionId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {announceText}
+      </div>
+
+      <style>{`
+        .bs-init {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-md);
+        }
+        @container widget (min-width: 640px) {
+          .bs-init {
+            grid-template-columns: 1.4fr 1fr;
+          }
+        }
+        .bs-init-lanes {
+          position: relative;
+          background: color-mix(in oklab, var(--color-surface) 70%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-md);
+          padding: var(--spacing-md);
+          min-height: 320px;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          gap: var(--spacing-sm);
+        }
+        .bs-init-lane {
+          display: flex;
+          align-items: center;
+          gap: var(--spacing-sm);
+          font-family: var(--font-mono);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+        }
+        .bs-init-lane-pill {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 4px 10px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: var(--color-surface);
+          color: var(--color-text);
+        }
+        .bs-init-tracks {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .bs-init-track {
+          position: relative;
+          height: 32px;
+          margin: 0 calc(var(--spacing-md) * -0.5);
+        }
+        .bs-init-trackline {
+          position: absolute;
+          left: 8%;
+          right: 8%;
+          top: 50%;
+          height: 1px;
+          background: color-mix(in oklab, var(--color-text-muted) 30%, transparent);
+        }
+        .bs-init-envelope {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          padding: 3px 9px;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 12%, var(--color-surface));
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--color-text);
+          white-space: nowrap;
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .bs-init-envelope[data-kind="notification"] {
+          padding: 2px 7px;
+          font-size: 10px;
+          background: color-mix(in oklab, var(--color-accent) 8%, var(--color-surface));
+          border-style: dashed;
+        }
+        .bs-init-envelope[data-kind="transport"] {
+          left: 50% !important;
+          transform: translate(-50%, -50%);
+          background: transparent;
+          border-style: dotted;
+          color: var(--color-text-muted);
+        }
+        .bs-init-ready {
+          align-self: center;
+          margin-top: var(--spacing-sm);
+          padding: 4px 10px;
+          border-radius: 999px;
+          border: 1px solid var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 16%, transparent);
+          font-family: var(--font-mono);
+          font-size: 11px;
+          color: var(--color-accent);
+          letter-spacing: 0.04em;
+        }
+        .bs-init-inspector {
+          background: var(--color-surface);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-md);
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+        }
+        .bs-init-tabs {
+          display: flex;
+          border-bottom: 1px solid var(--color-rule);
+          overflow-x: auto;
+        }
+        .bs-init-tab {
+          flex: 1 0 auto;
+          min-height: 36px;
+          padding: 8px 8px;
+          font-family: var(--font-mono);
+          font-size: 10px;
+          color: var(--color-text-muted);
+          background: transparent;
+          border: 0;
+          border-right: 1px solid var(--color-rule);
+          cursor: pointer;
+          text-align: center;
+          letter-spacing: 0.02em;
+          white-space: nowrap;
+        }
+        .bs-init-tab:last-child { border-right: 0; }
+        .bs-init-tab[aria-current="step"] {
+          color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 10%, transparent);
+        }
+        .bs-init-tab:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
+        .bs-init-tab:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: -2px;
+        }
+        .bs-init-json {
+          font-family: var(--font-mono);
+          font-size: 11px;
+          line-height: 1.55;
+          padding: var(--spacing-sm) var(--spacing-md);
+          margin: 0;
+          white-space: pre;
+          overflow-x: auto;
+          color: var(--color-text);
+          min-height: 220px;
+        }
+      `}</style>
+
+      <div className="bs-init" ref={canvasRef}>
+        <div className="bs-init-lanes">
+          <div className="bs-init-lane" aria-hidden>
+            <span className="bs-init-lane-pill">
+              <span style={{ color: "var(--color-text-muted)" }}>client</span>
+              <span style={{ color: "var(--color-accent)" }}>●</span>
+            </span>
+            <span style={{ color: "var(--color-text-muted)" }}>
+              minimal-client
+            </span>
+          </div>
+
+          <div className="bs-init-tracks">
+            {STEPS.map((s, i) => {
+              const fired = stepIndex >= i;
+              const isLatest = stepIndex === i;
+              return (
+                <Track
+                  key={s.id}
+                  step={s}
+                  fired={fired}
+                  isLatest={isLatest}
+                  reduce={!!reduce}
+                />
+              );
+            })}
+          </div>
+
+          <div className="bs-init-lane" aria-hidden>
+            <span className="bs-init-lane-pill">
+              <span style={{ color: "var(--color-text-muted)" }}>server</span>
+              <span style={{ color: "var(--color-accent)" }}>●</span>
+            </span>
+            <span style={{ color: "var(--color-text-muted)" }}>
+              currency-server
+            </span>
+          </div>
+
+          <AnimatePresence>
+            {ready ? (
+              <motion.span
+                key="ready"
+                className="bs-init-ready"
+                initial={reduce ? { opacity: 0 } : { opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={SPRING.gentle}
+              >
+                tools loaded
+              </motion.span>
+            ) : null}
+          </AnimatePresence>
+        </div>
+
+        <div className="bs-init-inspector">
+          <div
+            className="bs-init-tabs"
+            role="tablist"
+            aria-label="Message bodies"
+          >
+            {STEPS.map((s, i) => {
+              const fired = stepIndex >= i;
+              const active = effectiveInspected === i && fired;
+              const tabLabel =
+                s.method === "notifications/initialized"
+                  ? "initialized"
+                  : s.method;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="tab"
+                  className="bs-init-tab"
+                  aria-current={active ? "step" : undefined}
+                  aria-selected={active}
+                  disabled={!fired}
+                  onClick={() => setInspected(i)}
+                >
+                  {i + 1}. {tabLabel}
+                </button>
+              );
+            })}
+          </div>
+          {stepIndex < 0 ? (
+            <div
+              className="bs-init-json"
+              style={{
+                color: "var(--color-text-muted)",
+                fontStyle: "italic",
+                fontFamily: "var(--font-serif)",
+                fontSize: "var(--text-small)",
+                whiteSpace: "normal",
+              }}
+            >
+              JSON appears here once a message has been sent. Click any
+              fired step to inspect its body.
+            </div>
+          ) : (
+            <pre className="bs-init-json" key={effectiveInspected}>
+              {colourJson(STEPS[effectiveInspected].json)}
+            </pre>
+          )}
+        </div>
+      </div>
+    </WidgetShell>
+  );
+}
+
+function Track({
+  step,
+  fired,
+  isLatest,
+  reduce,
+}: {
+  step: Step;
+  fired: boolean;
+  isLatest: boolean;
+  reduce: boolean;
+}) {
+  // c2s: left → right; s2c: right → left; transport: stays centred.
+  const startPct =
+    step.dir === "c2s"
+      ? "8%"
+      : step.dir === "s2c"
+        ? "calc(92% - var(--env-w, 110px))"
+        : "50%";
+  const endPct =
+    step.dir === "c2s"
+      ? "calc(92% - var(--env-w, 110px))"
+      : step.dir === "s2c"
+        ? "8%"
+        : "50%";
+
+  const restPct = endPct;
+
+  return (
+    <div className="bs-init-track" aria-hidden>
+      <div className="bs-init-trackline" />
+      <AnimatePresence>
+        {fired ? (
+          <motion.span
+            key={step.id}
+            className="bs-init-envelope"
+            data-kind={step.kind}
+            initial={
+              reduce
+                ? { left: restPct, opacity: 0 }
+                : isLatest
+                  ? { left: startPct, opacity: 0.4 }
+                  : { left: restPct, opacity: 1 }
+            }
+            animate={
+              reduce
+                ? { left: restPct, opacity: 1 }
+                : { left: restPct, opacity: 1 }
+            }
+            exit={{ opacity: 0 }}
+            transition={
+              reduce
+                ? { duration: 0 }
+                : isLatest
+                  ? { ...SPRING.smooth }
+                  : { duration: 0 }
+            }
+          >
+            <KindGlyph kind={step.kind} />
+            <span>
+              {step.method === "notifications/initialized"
+                ? "initialized"
+                : step.method}
+            </span>
+            {step.kind === "request" || step.kind === "response" ? (
+              <span style={{ color: "var(--color-text-muted)" }}>
+                · id {step.id.includes("init") ? 1 : 2}
+              </span>
+            ) : null}
+          </motion.span>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default InitFlowAnimation;

--- a/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/OAuthGate.tsx
+++ b/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/OAuthGate.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * OAuthGate — premise-quiz opener for chapter 7 (voice §12.1).
+ *
+ * The reader's instinct: if a remote MCP server gets a request without
+ * credentials, it should return 403 (forbidden). The chapter's correction:
+ * the spec recommends 401 with a `WWW-Authenticate` header — the same
+ * response a browser would get hitting any OAuth-gated HTTP API. 401 is
+ * "you didn't say who you are"; 403 is "I know who you are and the answer
+ * is no."
+ *
+ * The wrong-answer verdict creates the demand for the chapter's later
+ * Streamable-HTTP-with-auth section, without requiring OAuth as a
+ * prerequisite. The widget reuses the shipped <Quiz> primitive: radiogroup
+ * a11y, reduced-motion fallback, frame-stable verdict slot, one-accent
+ * terracotta highlight. No second hue.
+ */
+
+import { Quiz } from "@/components/widgets/Quiz";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+
+export function OAuthGate() {
+  return (
+    <WidgetShell
+      title="What HTTP code should a remote MCP server return on an unauthenticated request?"
+      caption={
+        <>
+          Predict before you read on. Most readers reach for 403 — the
+          spec reaches for 401, and the difference is load-bearing once
+          OAuth enters the picture.
+        </>
+      }
+    >
+      <div className="flex flex-col gap-[var(--spacing-md)]">
+        <pre
+          aria-label="Sample HTTP request"
+          style={{
+            margin: 0,
+            padding: "var(--spacing-sm) var(--spacing-md)",
+            background: "var(--color-surface)",
+            border: "1px solid var(--color-rule)",
+            borderRadius: "var(--radius-sm)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "12px",
+            lineHeight: 1.55,
+            color: "var(--color-text)",
+            whiteSpace: "pre",
+            overflowX: "auto",
+          }}
+        >
+{`POST /mcp HTTP/1.1
+Host: api.example.com
+Content-Type: application/json
+
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { ... } }`}
+        </pre>
+
+        <Quiz
+          question={
+            <p
+              className="font-serif"
+              style={{
+                fontSize: "var(--text-body)",
+                lineHeight: 1.55,
+                margin: 0,
+              }}
+            >
+              The request above lands at a remote{" "}
+              <em>Streamable HTTP</em> MCP server. There&apos;s no{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>
+                Authorization
+              </code>{" "}
+              header. Per the 2025-06-18 spec, what HTTP status code does
+              the server return — and what header does it pair with it?
+            </p>
+          }
+          correctId="401-www-auth"
+          rightVerdict={
+            <>
+              Right. The spec recommends{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>
+                401 Unauthorized
+              </code>{" "}
+              with a{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>
+                WWW-Authenticate
+              </code>{" "}
+              header pointing at the auth metadata. 401 is the "you
+              didn&apos;t say who you are" code; the header tells the
+              client where to go to say it. 403 would mean the server
+              already identified the caller and chose to refuse.
+            </>
+          }
+          wrongVerdict={
+            <>
+              The spec is explicit:{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>401</code>{" "}
+              with a{" "}
+              <code style={{ fontFamily: "var(--font-mono)" }}>
+                WWW-Authenticate
+              </code>{" "}
+              header. 403 implies the caller is known and refused, 426
+              demands a protocol upgrade, 451 is reserved for legal
+              blocks. This isn&apos;t any of those — it&apos;s the same
+              dance any OAuth-gated API does.
+            </>
+          }
+          options={[
+            {
+              id: "401-www-auth",
+              label:
+                "401 Unauthorized, paired with a WWW-Authenticate header that names the auth scheme.",
+            },
+            {
+              id: "403",
+              label:
+                "403 Forbidden — the request reached the server without credentials, so access is denied.",
+            },
+            {
+              id: "426",
+              label:
+                "426 Upgrade Required — the server needs the client to switch to an authenticated protocol.",
+            },
+            {
+              id: "451",
+              label:
+                "451 Unavailable For Legal Reasons — auth-gated content is the same surface as legal-gated content.",
+            },
+          ]}
+        />
+      </div>
+    </WidgetShell>
+  );
+}
+
+export default OAuthGate;

--- a/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/TransportPicker.tsx
+++ b/app/courses/mcps/_content/build-a-client-pick-a-transport/widgets/TransportPicker.tsx
@@ -1,0 +1,682 @@
+"use client";
+
+/**
+ * TransportPicker — the load-bearing widget for chapter 7.
+ *
+ * Four deployment scenarios; for each, the reader picks `stdio` or
+ * `Streamable HTTP`. The verdict reveals the right answer plus a one-line
+ * justification, and on the wrong pick a sentence on what would actually
+ * break. The widget walks all four scenarios in sequence — one at a time —
+ * with a progress chip (`n / 4`) so the reader feels the weight of the
+ * choice landing in real deployments rather than as abstract preference.
+ *
+ * The four scenarios (in order):
+ *   1. local CLI debugger that runs MCP servers as child processes  → stdio
+ *   2. SaaS-hosted MCP server consumed by Claude Desktop worldwide  → HTTP
+ *   3. enterprise service behind SSO, accessed from VS Code         → HTTP
+ *   4. MCP server inside a Cloudflare Worker, public on the net     → HTTP
+ *
+ * Decisions baked in:
+ * - One scenario card visible at a time. `next` advances after a verdict
+ *   reveals; the previous card collapses into a tiny tick mark above the
+ *   active card so the reader sees the trail of decisions accumulating.
+ * - Two big segmented buttons per card — `stdio` and `Streamable HTTP` —
+ *   reflow to a single column under 380px container width.
+ * - Right pick: button pulses, terracotta highlight; wrong pick: nod.
+ *   Reduced motion: pulse + nod collapse to opacity-only.
+ * - One accent only — terracotta for "right", desaturated muted for
+ *   "wrong". No reds, no greens.
+ * - aria-live announces the verdict on every pick.
+ * - At the end, a small "all four picked" panel summarises the
+ *   trade-off in one sentence: stdio wins where you control both ends and
+ *   share a machine; Streamable HTTP wins everywhere else.
+ *
+ * Pedagogical role: scenario branch (4 paths). Reuses the visual grammar
+ * of <Quiz> but lifts the multi-question flow inline rather than pulling
+ * in a shared MultiQuiz primitive — that lift is a follow-on per the issue.
+ */
+
+import { useCallback, useId, useMemo, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
+import { WidgetShell } from "@/components/viz/WidgetShell";
+import { SPRING } from "@/lib/motion";
+import { ClickSpark } from "@/components/fancy/click-spark";
+import { playSound } from "@/lib/audio";
+
+type Choice = "stdio" | "http";
+
+type Scenario = {
+  id: string;
+  title: string;
+  body: React.ReactNode;
+  /** The transport the spec / spec deployment patterns recommend. */
+  correct: Choice;
+  /** Verdict for the right pick — one short sentence. */
+  rightVerdict: React.ReactNode;
+  /**
+   * Verdict for picking stdio when HTTP was right (or vice versa) — the
+   * "what would break" sentence. Indexed by the pick the reader made,
+   * keyed by the wrong choice so each scenario has a single tailored
+   * sentence (the wrong pick is always the *other* one).
+   */
+  wrongVerdict: React.ReactNode;
+};
+
+const SCENARIOS: Scenario[] = [
+  {
+    id: "local-cli",
+    title: "Local CLI debugger",
+    body: (
+      <>
+        You&apos;re building a local CLI debugger that spawns MCP
+        servers as child processes — same machine, same user, no auth
+        boundary, fastest possible round trip. Which transport does the
+        spec point you at?
+      </>
+    ),
+    correct: "stdio",
+    rightVerdict: (
+      <>
+        <strong>stdio</strong> — same machine, no auth boundary, process
+        I/O is the cheapest wire you can buy.
+      </>
+    ),
+    wrongVerdict: (
+      <>
+        Streamable HTTP would work, but you&apos;d be standing up a
+        local web server, opening a port, and paying TLS / parsing
+        overhead to talk to a process you already control. stdio is the
+        right answer; the chapter&apos;s "trust + locality" rule fires
+        here.
+      </>
+    ),
+  },
+  {
+    id: "saas-claude-desktop",
+    title: "SaaS MCP server, Claude Desktop users worldwide",
+    body: (
+      <>
+        You&apos;re shipping a SaaS-hosted MCP server consumed by Claude
+        Desktop users on every continent. Each user is on a different
+        machine; auth, billing, and rate-limiting all live at the HTTP
+        layer. Which transport?
+      </>
+    ),
+    correct: "http",
+    rightVerdict: (
+      <>
+        <strong>Streamable HTTP</strong> — clients are remote, auth is
+        at HTTP, and the spec&apos;s session header is exactly the
+        substrate billing and rate-limiting want.
+      </>
+    ),
+    wrongVerdict: (
+      <>
+        stdio assumes the client and server share a machine. They
+        don&apos;t — your users are everywhere. There&apos;s no way for
+        Claude Desktop on a laptop in São Paulo to spawn a process on
+        your servers in Virginia. Streamable HTTP is the only fit.
+      </>
+    ),
+  },
+  {
+    id: "enterprise-sso",
+    title: "Enterprise service behind SSO, accessed from VS Code",
+    body: (
+      <>
+        An internal MCP server sits behind your company&apos;s SSO,
+        accessed from VS Code over the corporate VPN. Every request
+        carries an OAuth bearer token; the auth boundary is the HTTP
+        request. Which transport?
+      </>
+    ),
+    correct: "http",
+    rightVerdict: (
+      <>
+        <strong>Streamable HTTP</strong> — the auth boundary is the
+        request, the transport already speaks{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          Authorization
+        </code>{" "}
+        headers, and OAuth scoping is one boundary instead of two.
+      </>
+    ),
+    wrongVerdict: (
+      <>
+        stdio has no auth surface — there&apos;s no header to put a
+        bearer token in. Bolting OAuth onto a stdio process means
+        rebuilding HTTP&apos;s auth middleware, and you&apos;d still
+        have no way to reach the server from VS Code over a VPN.
+      </>
+    ),
+  },
+  {
+    id: "cloudflare-worker",
+    title: "MCP server inside a Cloudflare Worker, public on the internet",
+    body: (
+      <>
+        Your MCP server runs inside a Cloudflare Worker — no
+        long-running process, no filesystem, no ability to fork. Public
+        on the internet, secured by OAuth. Which transport?
+      </>
+    ),
+    correct: "http",
+    rightVerdict: (
+      <>
+        <strong>Streamable HTTP</strong> — three reasons stack: Workers
+        can&apos;t fork, clients are off-machine, auth is at HTTP. The
+        only fit the spec offers.
+      </>
+    ),
+    wrongVerdict: (
+      <>
+        Workers can&apos;t spawn child processes — there&apos;s no
+        stdio to pipe through. Even if they could, a remote client
+        can&apos;t reach a stdin/stdout pair across the public internet.
+        Streamable HTTP is the only transport that works here.
+      </>
+    ),
+  },
+];
+
+const NOD_KEYFRAMES = [0, -6, 6, -4, 4, 0];
+
+type Verdict = "right" | "wrong";
+
+type CardState = {
+  /** Which option the reader picked, or null if untouched. */
+  pick: Choice | null;
+  /** Set once the verdict is revealed. */
+  verdict: Verdict | null;
+};
+
+function emptyState(): CardState {
+  return { pick: null, verdict: null };
+}
+
+export function TransportPicker() {
+  const reduce = useReducedMotion();
+  const liveId = useId();
+
+  const [active, setActive] = useState(0);
+  const [states, setStates] = useState<CardState[]>(() =>
+    SCENARIOS.map(emptyState),
+  );
+
+  const current = SCENARIOS[active];
+  const currentState = states[active];
+  const allDone = states.every((s) => s.verdict !== null);
+
+  const handlePick = useCallback(
+    (choice: Choice) => {
+      setStates((prev) => {
+        if (prev[active].verdict !== null) return prev;
+        const next = prev.slice();
+        const correct = SCENARIOS[active].correct === choice;
+        next[active] = { pick: choice, verdict: correct ? "right" : "wrong" };
+        playSound("Click");
+        // Slight delay-free pairing — verdict cue lands ~250ms after the
+        // click via animation lag, matching the <Quiz> primitive's
+        // audio vocabulary.
+        playSound(correct ? "Success" : "Error");
+        return next;
+      });
+    },
+    [active],
+  );
+
+  const goNext = useCallback(() => {
+    if (active >= SCENARIOS.length - 1) return;
+    playSound("Progress-Tick");
+    setActive((a) => a + 1);
+  }, [active]);
+
+  const goPrev = useCallback(() => {
+    if (active <= 0) return;
+    playSound("Progress-Tick");
+    setActive((a) => a - 1);
+  }, [active]);
+
+  const reset = useCallback(() => {
+    playSound("Progress-Tick");
+    setActive(0);
+    setStates(SCENARIOS.map(emptyState));
+  }, []);
+
+  const announceText = useMemo(() => {
+    if (!currentState.verdict) {
+      return `Scenario ${active + 1} of ${SCENARIOS.length}: ${current.title}.`;
+    }
+    return currentState.verdict === "right"
+      ? `Correct. The right transport for "${current.title}" is ${current.correct === "stdio" ? "stdio" : "Streamable HTTP"}.`
+      : `Not quite. The right transport for "${current.title}" is ${current.correct === "stdio" ? "stdio" : "Streamable HTTP"}.`;
+  }, [active, current, currentState]);
+
+  return (
+    <WidgetShell
+      title="Pick a transport — four real deployments"
+      measurements={`${states.filter((s) => s.verdict !== null).length} / ${SCENARIOS.length}`}
+      caption={
+        allDone ? (
+          <>
+            Four picks, three of them HTTP. The pattern is small: stdio
+            wins where you control both ends and share a machine;
+            Streamable HTTP wins everywhere else. Trust + locality
+            chooses stdio. Distance, multi-tenancy, or auth chooses
+            Streamable HTTP.
+          </>
+        ) : (
+          <>
+            Pick the transport you&apos;d ship for each deployment.
+            Wrong picks reveal what would actually break — the lesson
+            is in the failure mode, not the verdict.
+          </>
+        )
+      }
+      captionTone="prominent"
+    >
+      {/* sr-only live region — sighted users see the verdict copy below
+          the buttons; screen readers get the same announcement here. */}
+      <div
+        id={liveId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {announceText}
+      </div>
+
+      <style>{`
+        .bs-tp-trail {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          margin-bottom: var(--spacing-sm);
+        }
+        .bs-tp-trail-tick {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          padding: 3px 8px;
+          font-family: var(--font-mono);
+          font-size: 10px;
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+          border-radius: 999px;
+          color: var(--color-text-muted);
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          border: 1px solid var(--color-rule);
+          cursor: pointer;
+        }
+        .bs-tp-trail-tick[data-active="true"] {
+          color: var(--color-accent);
+          border-color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+        }
+        .bs-tp-trail-tick[data-verdict="right"] {
+          color: var(--color-accent);
+          border-color: color-mix(in oklab, var(--color-accent) 50%, transparent);
+        }
+        .bs-tp-trail-tick[data-verdict="wrong"] {
+          color: var(--color-text-muted);
+          filter: saturate(0.4);
+        }
+        .bs-tp-trail-tick:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-tp-card {
+          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          border: 1px solid var(--color-rule);
+          border-radius: var(--radius-md);
+          padding: var(--spacing-md);
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+        }
+        .bs-tp-scenario-title {
+          font-family: var(--font-sans);
+          font-size: var(--text-ui);
+          letter-spacing: 0.02em;
+          color: var(--color-text-muted);
+          text-transform: uppercase;
+        }
+        .bs-tp-scenario-body {
+          font-family: var(--font-serif);
+          font-size: var(--text-body);
+          line-height: 1.55;
+          color: var(--color-text);
+          margin: 0;
+        }
+        .bs-tp-options {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: var(--spacing-2xs);
+        }
+        @container widget (min-width: 480px) {
+          .bs-tp-options {
+            grid-template-columns: 1fr 1fr;
+          }
+        }
+        .bs-tp-option {
+          width: 100%;
+          min-height: 64px;
+          padding: 14px 16px;
+          font-family: var(--font-mono);
+          font-size: var(--text-ui);
+          line-height: 1.45;
+          text-align: left;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--color-rule);
+          background: var(--color-surface);
+          color: var(--color-text);
+          cursor: pointer;
+          transition: background 200ms, color 200ms, border-color 200ms, opacity 200ms;
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .bs-tp-option:hover:not(:disabled) {
+          background: color-mix(in oklab, var(--color-accent) 8%, transparent);
+        }
+        .bs-tp-option:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+        .bs-tp-option:disabled { cursor: default; }
+        .bs-tp-option-label {
+          font-family: var(--font-mono);
+          font-size: var(--text-ui);
+          color: var(--color-text);
+        }
+        .bs-tp-option-sub {
+          font-family: var(--font-sans);
+          font-size: var(--text-small);
+          color: var(--color-text-muted);
+          line-height: 1.4;
+        }
+        .bs-tp-verdict {
+          min-height: 4.5em;
+          font-family: var(--font-serif);
+          font-size: var(--text-small);
+          line-height: 1.6;
+          color: var(--color-text-muted);
+        }
+        .bs-tp-controls {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--spacing-sm);
+          align-items: center;
+          justify-content: space-between;
+        }
+        .bs-tp-btn {
+          min-height: 36px;
+          padding: 6px 12px;
+          border-radius: var(--radius-md);
+          font-family: var(--font-sans);
+          font-size: var(--text-ui);
+          color: var(--color-text-muted);
+          background: transparent;
+          border: 1px solid var(--color-rule);
+          cursor: pointer;
+        }
+        .bs-tp-btn:not(:disabled):hover {
+          color: var(--color-accent);
+          border-color: var(--color-accent);
+        }
+        .bs-tp-btn:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
+        .bs-tp-btn-primary {
+          color: var(--color-accent);
+          border-color: var(--color-accent);
+          background: color-mix(in oklab, var(--color-accent) 10%, transparent);
+        }
+        .bs-tp-btn:focus-visible {
+          outline: 2px solid var(--color-accent);
+          outline-offset: 2px;
+        }
+      `}</style>
+
+      <div className="bs-tp-trail" aria-label="Scenario progress">
+        {SCENARIOS.map((s, i) => {
+          const st = states[i];
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => {
+                playSound("Progress-Tick");
+                setActive(i);
+              }}
+              data-active={i === active}
+              data-verdict={st.verdict ?? "none"}
+              className="bs-tp-trail-tick"
+              aria-current={i === active ? "step" : undefined}
+              aria-label={`Scenario ${i + 1}: ${s.title}${st.verdict ? ` — ${st.verdict === "right" ? "answered correctly" : "answered"}` : " — unanswered"}`}
+            >
+              <span aria-hidden>{i + 1}</span>
+              <span aria-hidden style={{ opacity: 0.5 }}>·</span>
+              <span aria-hidden>
+                {st.verdict === "right"
+                  ? "✓"
+                  : st.verdict === "wrong"
+                    ? "·"
+                    : "·"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={current.id}
+          className="bs-tp-card"
+          role="radiogroup"
+          aria-label={`Pick a transport for ${current.title}`}
+          initial={reduce ? { opacity: 0 } : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reduce ? { opacity: 0 } : { opacity: 0, y: -8 }}
+          transition={SPRING.gentle}
+        >
+          <div className="bs-tp-scenario-title">{current.title}</div>
+          <p className="bs-tp-scenario-body">{current.body}</p>
+
+          <div className="bs-tp-options">
+            <OptionButton
+              choice="stdio"
+              label="stdio"
+              sub="process pipe — same-machine, no HTTP layer"
+              card={current}
+              state={currentState}
+              onPick={handlePick}
+              reduce={!!reduce}
+            />
+            <OptionButton
+              choice="http"
+              label="Streamable HTTP"
+              sub="single endpoint — POST + optional SSE upstream"
+              card={current}
+              state={currentState}
+              onPick={handlePick}
+              reduce={!!reduce}
+            />
+          </div>
+
+          <div className="bs-tp-verdict" aria-live="polite">
+            <AnimatePresence initial={false} mode="wait">
+              {currentState.verdict ? (
+                <motion.div
+                  key={currentState.verdict}
+                  initial={
+                    reduce ? { opacity: 0 } : { opacity: 0, y: 4 }
+                  }
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={SPRING.gentle}
+                >
+                  {currentState.verdict === "right"
+                    ? current.rightVerdict
+                    : current.wrongVerdict}
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </div>
+
+          <div className="bs-tp-controls">
+            <button
+              type="button"
+              className="bs-tp-btn"
+              onClick={goPrev}
+              disabled={active === 0}
+              aria-label="Previous scenario"
+            >
+              ← prev
+            </button>
+            <span
+              className="font-mono tabular-nums"
+              style={{
+                fontSize: "var(--text-small)",
+                color: "var(--color-text-muted)",
+              }}
+              aria-hidden
+            >
+              {active + 1} / {SCENARIOS.length}
+            </span>
+            {active < SCENARIOS.length - 1 ? (
+              <button
+                type="button"
+                className={`bs-tp-btn ${currentState.verdict ? "bs-tp-btn-primary" : ""}`}
+                onClick={goNext}
+                disabled={!currentState.verdict}
+                aria-label="Next scenario"
+              >
+                next →
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="bs-tp-btn"
+                onClick={reset}
+                aria-label="Reset all scenarios"
+              >
+                ↺ reset
+              </button>
+            )}
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </WidgetShell>
+  );
+}
+
+/**
+ * One large segmented option button. Wraps the correct option in
+ * <ClickSpark> so the right pick emits a small terracotta burst.
+ * The animation rules mirror the <Quiz> primitive: pulse on right,
+ * nod on wrong, opacity-only under reduced motion.
+ */
+function OptionButton({
+  choice,
+  label,
+  sub,
+  card,
+  state,
+  onPick,
+  reduce,
+}: {
+  choice: Choice;
+  label: string;
+  sub: string;
+  card: Scenario;
+  state: CardState;
+  onPick: (c: Choice) => void;
+  reduce: boolean;
+}) {
+  const isChosen = state.pick === choice;
+  const isCorrect = card.correct === choice;
+  const revealed = state.verdict !== null;
+  const showCorrectMark = revealed && isCorrect;
+  const isWrongChosen = revealed && isChosen && !isCorrect;
+  const dim = revealed && !isChosen && !isCorrect;
+
+  const animate =
+    !reduce && revealed && isChosen
+      ? isCorrect
+        ? { scale: [1, 1.04, 1] as number[] }
+        : { x: NOD_KEYFRAMES }
+      : { scale: 1, x: 0 };
+
+  const transition =
+    !reduce && revealed && isChosen
+      ? isCorrect
+        ? { duration: 0.25, times: [0, 0.5, 1] }
+        : { duration: 0.35, ease: "easeInOut" as const }
+      : SPRING.gentle;
+
+  const button = (
+    <motion.button
+      type="button"
+      role="radio"
+      aria-checked={isChosen}
+      onClick={() => onPick(choice)}
+      disabled={revealed}
+      whileTap={revealed || reduce ? undefined : { scale: 0.97 }}
+      animate={animate}
+      transition={transition}
+      className="bs-tp-option"
+      style={{
+        borderColor: showCorrectMark
+          ? "var(--color-accent)"
+          : isWrongChosen
+            ? "color-mix(in oklab, var(--color-text-muted) 70%, transparent)"
+            : isChosen
+              ? "var(--color-accent)"
+              : "var(--color-rule)",
+        background: showCorrectMark
+          ? "color-mix(in oklab, var(--color-accent) 16%, transparent)"
+          : isWrongChosen
+            ? "color-mix(in oklab, var(--color-accent) 6%, transparent)"
+            : isChosen
+              ? "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+              : undefined,
+        opacity: dim ? 0.5 : 1,
+        filter: isWrongChosen ? "saturate(0.4)" : undefined,
+      }}
+    >
+      <span className="bs-tp-option-label">
+        {showCorrectMark ? (
+          <span
+            aria-hidden
+            style={{
+              color: "var(--color-accent)",
+              fontSize: 12,
+              marginRight: 8,
+            }}
+          >
+            ✓
+          </span>
+        ) : null}
+        {label}
+      </span>
+      <span className="bs-tp-option-sub">{sub}</span>
+    </motion.button>
+  );
+
+  return isCorrect ? <ClickSpark>{button}</ClickSpark> : button;
+}
+
+export default TransportPicker;

--- a/app/courses/mcps/_content/registry.ts
+++ b/app/courses/mcps/_content/registry.ts
@@ -19,14 +19,22 @@ import HostClientServerContent from "./host-client-server/Content";
 import TheRoomBeforeProtocolContent from "./the-room-before-the-protocol/Content";
 import JsonRpcTheWireContent from "./json-rpc-the-wire/Content";
 import TheHandshakeContent from "./the-handshake/Content";
+<<<<<<< HEAD
 import ToolsResourcesPromptsContent from "./tools-resources-prompts/Content";
 import BuildAServerContent from "./build-a-server/Content";
+=======
+import BuildAClientPickATransportContent from "./build-a-client-pick-a-transport/Content";
+>>>>>>> 17f3e5e (feat(courses/mcps): chapter 7 — Build a client, and pick a transport)
 
 export const MCPS_CONTENT: Record<string, ComponentType> = {
   "the-room-before-the-protocol": TheRoomBeforeProtocolContent,
   "host-client-server": HostClientServerContent,
   "json-rpc-the-wire": JsonRpcTheWireContent,
   "the-handshake": TheHandshakeContent,
+<<<<<<< HEAD
   "tools-resources-prompts": ToolsResourcesPromptsContent,
   "build-a-server": BuildAServerContent,
+=======
+  "build-a-client-pick-a-transport": BuildAClientPickATransportContent,
+>>>>>>> 17f3e5e (feat(courses/mcps): chapter 7 — Build a client, and pick a transport)
 };


### PR DESCRIPTION
## Summary

- Authors chapter 7 of the MCPs mini-course. Walks the reader through the smallest MCP client (initialize, listTools, callTool) and frames the transport choice — `stdio` for trust + locality, Streamable HTTP for distance + auth — as downstream of deployment shape, not free style. Names the HTTP+SSE deprecation explicitly so old tutorials don't trip the reader up.
- Three widgets ship: `OAuthGate` (premise-quiz opener — 401 + WWW-Authenticate vs 403/426/451), `InitFlowAnimation` (six-step scripted stepper from `connect` through `tools/list`, extending ch 4's HandshakeStepper visual grammar), and `TransportPicker` (load-bearing scenario branch — four real deployments, picks reveal what would actually break on the wrong one).
- Adds `<Term>` on first use of `client`, `transport`, `session`, `stdio`, `Streamable HTTP`, `EOF`, `SSE`, `HTTP+SSE`, `WWW-Authenticate`. No `<hr>`, no `<br>`, no `VerticalCutReveal`. Closer is still prose, with the "server can ask back" cliffhanger pointing at chapter 8.

Resolves #76.

## Test plan

- [ ] `pnpm build` succeeds; `/courses/mcps/build-a-client-pick-a-transport` is in the static route table.
- [ ] Chapter URL renders at HTTP 200 in dev (`PORT=3009 pnpm dev`).
- [ ] All three widgets are interactive: OAuthGate quiz, InitFlowAnimation stepper through six ticks, TransportPicker walks four scenarios with verdicts.
- [ ] Reduced-motion fallback verified — envelopes appear at end positions instantly, button pulses collapse to opacity-only.
- [ ] Mobile (375 px): no horizontal scroll, hit targets ≥ 44 × 44, transport buttons reflow to one column.
- [ ] Dark mode parity verified.
- [ ] Lighthouse perf + a11y ≥ 95 on the chapter URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)