### PR TITLE
feat(ui): typography + widget layout contract revamp

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,19 +79,34 @@ Spacing scale uses semantic names (`--spacing-sm`, `--spacing-md`), never pixel-
 
 ## 4. Type ramp (Plex family, 1.25 ratio)
 
-| Token          | Size                                 | Family     | Tracking | Line-height |
-| -------------- | ------------------------------------ | ---------- | -------- | ----------- |
-| `--text-h1`    | `clamp(2.25rem, 1.8rem + 2vw, 3rem)` | Plex Sans  | −0.02em  | 1.05        |
-| `--text-h2`    | `clamp(1.5rem, …, 1.75rem)`          | Plex Sans  | −0.01em  | 1.15        |
-| `--text-h3`    | `1.25rem`                            | Plex Sans  | 0em      | 1.25        |
-| `--text-body`  | `1.125rem` (18px)                    | Plex Serif | 0em      | 1.7         |
-| `--text-ui`    | `0.9375rem`                          | Plex Sans  | 0em      | 1.4         |
-| `--text-mono`  | `0.9375rem`                          | Plex Mono  | 0em      | 1.5         |
-| `--text-small` | `0.8125rem`                          | Plex Sans  | 0em      | 1.4         |
+Each token couples size + weight + line-height + tracking via paired CSS custom properties (`--text-h1`, `--text-h1-weight`, `--text-h1-lh`, `--text-h1-tracking`, `--text-h1-family`). The size-only `--text-*` shorthand stays compatible with existing inline `style={{ fontSize: "var(--text-…)" }}` consumers; new prose components use the paired vars (or the `.bs-h1` / `.bs-h2` / `.bs-h3` / `.bs-body-strong` utility classes in `globals.css`).
 
-Body is **Plex Serif at 18px, 1.7 line-height** — this is the load-bearing choice for editorial-calm.
+| Token                | Size                                       | Family     | Weight | Tracking | Line-height |
+| -------------------- | ------------------------------------------ | ---------- | ------ | -------- | ----------- |
+| `--text-h1`          | `clamp(2.5rem, 2rem + 3.5vw, 4rem)`        | Plex Sans  | 700    | −0.025em | 1.05        |
+| `--text-h2`          | `clamp(1.5rem, 1.3rem + 0.8vw, 1.75rem)`   | Plex Sans  | 600    | −0.015em | 1.20        |
+| `--text-h3`          | `1.25rem`                                  | Plex Sans  | 600    | −0.005em | 1.30        |
+| `--text-h4`          | `1.0625rem`                                | Plex Sans  | 600    | 0.06em (uppercase) | 1.30 |
+| `--text-body`        | `1.125rem` (18px)                          | Plex Serif | 400    | 0em      | 1.70        |
+| `--text-body-strong` | `1.125rem`                                 | Plex Serif | 500    | 0em      | 1.70        |
+| `--text-medium`      | `1.0625rem`                                | Plex Serif | 400    | 0em      | 1.55        |
+| `--text-ui`          | `0.9375rem`                                | Plex Sans  | 500    | 0.005em  | 1.50        |
+| `--text-mono`        | `0.9375rem`                                | Plex Mono  | 400    | 0em      | 1.70        |
+| `--text-small`       | `0.8125rem`                                | Plex Sans  | 500    | 0.01em   | 1.50        |
 
-**Weight subset (Path B-lite):** Plex Serif 400/500/600 + 400 italic, Plex Sans 400/500/600, Plex Mono 400/500. Weight 700 is not rendered anywhere in the current UI; the heaviest used weight is 600 (`font-semibold`). Proper Path A (self-hosted variable fonts) is deferred to a follow-up phase once VF glyph coverage is verified against the content corpus.
+Body is **Plex Serif at 18 px, 1.7 line-height** — the load-bearing choice for editorial-calm. Code blocks now match that 1.7 lh so prose ↔ code transitions read as one continuous rhythm (was 1.55 before the Phase 1 ramp revamp).
+
+**`--text-h4` (NEW)** — uppercase label register. Used by `<Callout>`'s leading "Note —" / "Watch out —" tags so the label rule lives in one place.
+
+**`--text-body-strong` (NEW)** — paragraph-load register. Opt-in via the `.bs-body-strong` utility class on a `<span>` (or any prose element) authors want to read as body-strong. Pre-existing `<strong>` and `<Em>` rendering are deliberately unchanged in Phase 1; whether and where to roll the body-strong register out across post copy is a Phase 2 (or later editorial-pass) decision.
+
+**`--text-medium` (NEW)** — was previously undefined; consumers' `var(--text-medium, 1.0625rem)` fallbacks were rendering at the browser's `medium` keyword. Now resolves correctly.
+
+**`--brand-tracking: -0.03em`** — scoped tracking for the home-page wordmark (intentionally tighter than `--text-h1-tracking` to read as a logotype).
+
+**`font-feature-settings`** — body has `"ss02"`, `"kern"`, `"liga"` enabled. `ss02` is Plex's neutral 'a' alt; `kern` and `liga` are off by default in some rendering paths and explicit opt-in gives a small but real legibility lift.
+
+**Weight subset (Path B-lite, expanded):** Plex Serif 300/400/500/600 + 400 italic, Plex Sans 400/500/600/700, Plex Mono 400/500. 13 font files vs the previous 11 — within the same Path B-lite envelope. Plex Serif 300 powers chrome / metadata copy that wants a lighter editorial register; Plex Sans 700 powers `--text-h1`. Proper Path A (self-hosted variable fonts) is still deferred to a follow-up phase once VF glyph coverage is verified against the content corpus.
 
 ## 5. Prose components (explicit, typed, semantic HTML)
 
@@ -129,24 +144,25 @@ Every piece of text inside a post is a typed JSX element. No regex classifiers, 
 
 ## 7. Widget design rules
 
-Every custom widget follows this skeleton. This is what "uniform UI" means.
+Every custom widget follows this skeleton. This is what "uniform UI" means. The detailed body order — Title → Canvas → State → Controls — and the per-zone min-height contract live in [`docs/interactive-components.md` §0](./docs/interactive-components.md). The skeleton below is the high-level shape; the playbook is the load-bearing reference for the slot API.
 
 ```
 <FullBleed>
   <Figure>
-    <Header>                    ← optional
+    <Header>                    ← title metadata row
       <Title>BitArray</Title>
       <Measurements>m=16 · set=5 · FPR=2.1%</Measurements>
     </Header>
-    <Canvas>…</Canvas>           ← SVG or HTML viz
-    <Controls>                   ← always below, left-aligned
-      <StepperBar /> <Slider />
+    <Canvas>…</Canvas>           ← SVG or HTML viz, opaque surface, 1px border
+    <State>…</State>             ← teacher-voice line, body-strong + terra marker
+    <Controls>                   ← always below, centred
+      <WidgetNav /> <Slider />
     </Controls>
   </Figure>
 </FullBleed>
 ```
 
-- **Canvas** has no visible border. If a background is needed, `--color-surface` at 40%.
+- **Canvas** is opaque `--color-surface` with a 1 px `--color-rule` border (Phase 1 visual-weight lift; was 40 % alpha-mixed surface, no border).
 - **Measurement labels**: top-right of header, Plex Mono tabular-nums, `--text-small`, separated by `·`. **Never duplicate the step counter here** — `WidgetNav` renders the only `n / N` indicator anywhere on the widget.
 - **Step controls**: `<WidgetNav>` (`components/viz/WidgetNav.tsx`) exclusively. The legacy `<Stepper>` exists only as a shim that forwards to `WidgetNav` for one release; new code reaches for `WidgetNav` directly.
 - **Controls slot**: centred via `WidgetShell`'s `flex flex-wrap items-center justify-center mx-auto px-[--spacing-md]` — every widget's controls row is mobile-first centred with horizontal margin that holds at 360 px.

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,14 +51,85 @@
   --font-mono: var(--font-plex-mono), ui-monospace, "SFMono-Regular", Menlo,
     monospace;
 
-  /* Type ramp — 1.25 ratio, clamp for display sizes. */
-  --text-h1: clamp(2.25rem, 1.8rem + 2vw, 3rem);
+  /* Type ramp — 1.25 ratio, clamp for display sizes.
+     Each token couples size + weight + line-height + tracking + family via a
+     paired set of helper variables so consumers can read the full register
+     from one place. The size-only `--text-*` shorthand stays compatible with
+     existing inline `style={{ fontSize: "var(--text-…)" }}` consumers; new
+     callers compose the paired vars (or the `.bs-*` utility classes below). */
+
+  /* h1 — heaviest sans, real weight differentiation vs h2/h3. */
+  --text-h1: clamp(2.5rem, 2rem + 3.5vw, 4rem);
+  --text-h1-weight: 700;
+  --text-h1-lh: 1.05;
+  --text-h1-tracking: -0.025em;
+  --text-h1-family: var(--font-sans);
+
   --text-h2: clamp(1.5rem, 1.3rem + 0.8vw, 1.75rem);
+  --text-h2-weight: 600;
+  --text-h2-lh: 1.20;
+  --text-h2-tracking: -0.015em;
+  --text-h2-family: var(--font-sans);
+
   --text-h3: 1.25rem;
+  --text-h3-weight: 600;
+  --text-h3-lh: 1.30;
+  --text-h3-tracking: -0.005em;
+  --text-h3-family: var(--font-sans);
+
+  /* h4 — uppercase label register. Used by Callout label etc. */
+  --text-h4: 1.0625rem;
+  --text-h4-weight: 600;
+  --text-h4-lh: 1.30;
+  --text-h4-tracking: 0.06em;
+  --text-h4-family: var(--font-sans);
+
   --text-body: 1.125rem;
+  --text-body-weight: 400;
+  --text-body-lh: 1.70;
+  --text-body-tracking: 0;
+  --text-body-family: var(--font-serif);
+
+  /* body-strong — paragraph-load register. Opt-in via `.bs-body-strong`. */
+  --text-body-strong: 1.125rem;
+  --text-body-strong-weight: 500;
+  --text-body-strong-lh: 1.70;
+  --text-body-strong-tracking: 0;
+  --text-body-strong-family: var(--font-serif);
+
+  /* medium — was undefined; resolves the post-subtitle fallback that was
+     rendering at the browser's `medium` keyword. */
+  --text-medium: 1.0625rem;
+  --text-medium-weight: 400;
+  --text-medium-lh: 1.55;
+  --text-medium-tracking: 0;
+  --text-medium-family: var(--font-serif);
+
   --text-ui: 0.9375rem;
+  --text-ui-weight: 500;
+  --text-ui-lh: 1.50;
+  --text-ui-tracking: 0.005em;
+  --text-ui-family: var(--font-sans);
+
   --text-mono: 0.9375rem;
+  --text-mono-weight: 400;
+  --text-mono-lh: 1.70;
+  --text-mono-tracking: 0;
+  --text-mono-family: var(--font-mono);
+
   --text-small: 0.8125rem;
+  --text-small-weight: 500;
+  --text-small-lh: 1.50;
+  --text-small-tracking: 0.01em;
+  --text-small-family: var(--font-sans);
+
+  /* Brand-specific tracking — the home wordmark moment. Carved out of the
+     ramp because it's intentionally tighter than h1 to read as a logotype. */
+  --brand-tracking: -0.03em;
+
+  /* Widget controls slot floor — keeps single-button vs full WidgetNav rows
+     at the same frame height across widgets. */
+  --widget-controls-min: 44px;
 
   /* Motion. */
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
@@ -118,7 +189,10 @@ body {
   font-family: var(--font-serif);
   font-size: var(--text-body);
   line-height: 1.7;
-  font-feature-settings: "ss02"; /* Plex "a" alt — slightly more neutral */
+  /* ss02 — Plex's neutral 'a' alt. kern + liga are off by default in some
+     rendering paths; explicit opt-in gives a small but real legibility lift
+     across body prose without changing the type's character. */
+  font-feature-settings: "ss02", "kern", "liga";
 
   /* Subtle diagonal hatch visible only outside the centred content container.
      Content blocks the hatch by painting its own solid --color-bg on top.
@@ -563,6 +637,95 @@ html[data-theme-transitioning] {
   .bs-press {
     animation: none;
   }
+}
+
+/* ---------------------------------------------------------------------------
+   Type-ramp utility classes — one consumer per token. Prose components apply
+   these and drop their inline weight / lh / tracking duplications, so
+   globals.css remains the single source of truth for the ramp.
+--------------------------------------------------------------------------- */
+.bs-h1 {
+  font-family: var(--text-h1-family);
+  font-size: var(--text-h1);
+  font-weight: var(--text-h1-weight);
+  line-height: var(--text-h1-lh);
+  letter-spacing: var(--text-h1-tracking);
+}
+.bs-h2 {
+  font-family: var(--text-h2-family);
+  font-size: var(--text-h2);
+  font-weight: var(--text-h2-weight);
+  line-height: var(--text-h2-lh);
+  letter-spacing: var(--text-h2-tracking);
+}
+.bs-h3 {
+  font-family: var(--text-h3-family);
+  font-size: var(--text-h3);
+  font-weight: var(--text-h3-weight);
+  line-height: var(--text-h3-lh);
+  letter-spacing: var(--text-h3-tracking);
+}
+
+/* Opt-in body-strong consumer. Pre-existing `<strong>` browser-default
+   rendering is intentionally NOT changed — authors apply this class to
+   sentences inside paragraphs that "carry the load." */
+.bs-body-strong {
+  font-family: var(--text-body-strong-family);
+  font-size: var(--text-body-strong);
+  font-weight: var(--text-body-strong-weight);
+  line-height: var(--text-body-strong-lh);
+  letter-spacing: var(--text-body-strong-tracking);
+  font-style: normal;
+}
+
+/* ---------------------------------------------------------------------------
+   WidgetShell layout-contract surfaces. The shell renders the body order
+   Title → Canvas → State → Controls; these classes own the visual weight
+   so the shell's JSX stays declarative.
+--------------------------------------------------------------------------- */
+.bs-widget-shell {
+  display: flex;
+  flex-direction: column;
+}
+.bs-widget-canvas {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md) var(--spacing-sm);
+}
+.bs-widget-state {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-md);
+  font-family: var(--text-body-strong-family);
+  font-size: var(--text-body-strong);
+  font-weight: var(--text-body-strong-weight);
+  line-height: var(--text-body-strong-lh);
+  color: var(--color-text);
+  min-height: 5.25em;
+}
+.bs-widget-state-marker {
+  flex-shrink: 0;
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-top: 0.5em;
+  background: var(--color-accent);
+  transform: rotate(45deg);
+  user-select: none;
+}
+.bs-widget-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding-top: var(--spacing-sm);
+  padding-inline: var(--spacing-md);
+  margin-inline: auto;
+  min-height: var(--widget-controls-min, 44px);
 }
 
 /* ---------------------------------------------------------------------------

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,15 +10,16 @@ import { MotionConfigProvider } from "@/components/providers/motion-config";
 import { GoatCounter } from "@/components/analytics/GoatCounter";
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/site";
 
-// Path B-lite: pre-flight grep found no `font-bold` / fontWeight 700 usage
-// (600 is the heaviest actually rendered weight via `font-semibold`), so we
-// drop 700 from both subsets. 14 font files → 11. Proper Path A (self-hosted
-// variable fonts) is deferred to Phase 7 once VF glyph coverage is verified
-// against the content corpus.
+// Path B-lite, expanded for the Phase 1 type-ramp revamp: Plex Serif gains
+// 300 (lighter editorial register for chrome / metadata copy); Plex Sans
+// gains 700 so h1 has real weight differentiation against h2/h3 (600). 11
+// font files → 13. Proper Path A (self-hosted variable fonts) is still
+// deferred to a follow-up phase once VF glyph coverage is verified against
+// the content corpus.
 const plexSerif = IBM_Plex_Serif({
   variable: "--font-plex-serif",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["300", "400", "500", "600"],
   style: ["normal", "italic"],
   display: "swap",
 });
@@ -26,7 +27,7 @@ const plexSerif = IBM_Plex_Serif({
 const plexSans = IBM_Plex_Sans({
   variable: "--font-plex-sans",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["400", "500", "600", "700"],
   display: "swap",
 });
 

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/CacheWalk.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/CacheWalk.tsx
@@ -5,7 +5,7 @@ import { motion } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { PRESS, SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type LocalityId = "hot" | "warm" | "cold";
 

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
@@ -8,7 +8,7 @@ import { SvgDefs } from "@/components/viz/SvgDefs";
 import type { BlockState } from "@/components/viz/Block";
 import { SPRING, SVG_SONAR } from "@/lib/motion";
 import { BitArray } from "./BitArray";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type HashLaneStep = {
   kind: "insert" | "query" | "remove";

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/NetflixSplit.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/NetflixSplit.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { motion } from "motion/react";
 import { PRESS, SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type InputId = "dotted" | "tagged" | "both";
 

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormaliseWalk.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormaliseWalk.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { motion } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const TYPED = "J.Ohn.Doe+promo@gmail.com";
 

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceMargin.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceMargin.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { motion } from "motion/react";
 import { Scrubber } from "@/components/viz/Scrubber";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type Props = {
   initialAMs?: number;

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceVerdict.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceVerdict.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import { motion } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type Tick = {
   caption: React.ReactNode;

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/TypingPause.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/TypingPause.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { PRESS, SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const SAMPLE = "johndoe@gmail.com";
 const KEYSTROKE_MS = 90; // human-realistic typing cadence

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/WidgetShell.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/WidgetShell.tsx
@@ -1,1 +1,0 @@
-export { WidgetShell } from "@/components/viz/WidgetShell";

--- a/app/posts/the-browser-stopped-asking/widgets/CostMatrix.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/CostMatrix.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import { TextHighlighter } from "@/components/fancy";
 import { SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";

--- a/app/posts/the-browser-stopped-asking/widgets/DropTiming.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/DropTiming.tsx
@@ -3,7 +3,7 @@
 import { memo, useMemo, useState } from "react";
 import { Scrubber } from "@/components/viz/Scrubber";
 import { TextHighlighter } from "@/components/fancy";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import {
   classify,
   ClassifiedEvent,

--- a/app/posts/the-browser-stopped-asking/widgets/GapDuration.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/GapDuration.tsx
@@ -3,7 +3,7 @@
 import { memo, useMemo, useState } from "react";
 import { Scrubber } from "@/components/viz/Scrubber";
 import { TextHighlighter } from "@/components/fancy";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import {
   classify,
   ClassifiedEvent,

--- a/app/posts/the-browser-stopped-asking/widgets/HandshakeSteps.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/HandshakeSteps.tsx
@@ -3,7 +3,7 @@
 import { memo, useState } from "react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { TextHighlighter } from "@/components/fancy";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import {
   SPEC_SAMPLE,
   StepsCanvasNarrow,

--- a/app/posts/the-browser-stopped-asking/widgets/KeyDerivation.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/KeyDerivation.tsx
@@ -6,7 +6,7 @@ import { PRESS } from "@/lib/motion";
 import { TextHighlighter } from "@/components/fancy";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import {
   ComputeBox,
   type Computed,

--- a/app/posts/the-browser-stopped-asking/widgets/LongPoll.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/LongPoll.tsx
@@ -6,7 +6,7 @@ import { PRESS } from "@/lib/motion";
 import { TextHighlighter } from "@/components/fancy";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import { ProtocolCanvas, StatLine, usePlayClock } from "./_pipe-canvas";
 import { DURATION_MS, simLongPoll } from "./_pipe-sim";
 

--- a/app/posts/the-browser-stopped-asking/widgets/Polling.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/Polling.tsx
@@ -6,7 +6,7 @@ import { PRESS } from "@/lib/motion";
 import { TextHighlighter } from "@/components/fancy";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import { ProtocolCanvas, StatLine, usePlayClock } from "./_pipe-canvas";
 import { DURATION_MS, simPolling } from "./_pipe-sim";
 

--- a/app/posts/the-browser-stopped-asking/widgets/WebSocketStream.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/WebSocketStream.tsx
@@ -6,7 +6,7 @@ import { PRESS } from "@/lib/motion";
 import { TextHighlighter } from "@/components/fancy";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import { ProtocolCanvas, StatLine, usePlayClock } from "./_pipe-canvas";
 import { DURATION_MS, simWebSocket } from "./_pipe-sim";
 

--- a/app/posts/the-browser-stopped-asking/widgets/WidgetShell.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/WidgetShell.tsx
@@ -1,1 +1,0 @@
-export { WidgetShell } from "@/components/viz/WidgetShell";

--- a/app/posts/the-function-that-remembered/widgets/LoopLet.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopLet.tsx
@@ -6,7 +6,7 @@ import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SvgDefs } from "@/components/viz/SvgDefs";
 import { Arrow } from "@/components/viz/Arrow";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const N = 5;
 const TOTAL_STEPS = N + 1;

--- a/app/posts/the-function-that-remembered/widgets/LoopVar.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopVar.tsx
@@ -6,7 +6,7 @@ import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SvgDefs } from "@/components/viz/SvgDefs";
 import { Arrow } from "@/components/viz/Arrow";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const N = 5;
 const TOTAL_STEPS = N + 1;

--- a/app/posts/the-function-that-remembered/widgets/RenderBroken.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderBroken.tsx
@@ -6,7 +6,7 @@ import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SvgDefs } from "@/components/viz/SvgDefs";
 import { Arrow } from "@/components/viz/Arrow";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const TICK_STEPS = 6;
 

--- a/app/posts/the-function-that-remembered/widgets/RenderFixed.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderFixed.tsx
@@ -5,7 +5,7 @@ import { motion } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SvgDefs } from "@/components/viz/SvgDefs";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 const TICK_STEPS = 6;
 

--- a/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
+++ b/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
@@ -6,7 +6,7 @@ import { WidgetNav } from "@/components/viz/WidgetNav";
 import { SvgDefs } from "@/components/viz/SvgDefs";
 import { Arrow } from "@/components/viz/Arrow";
 import { SPRING } from "@/lib/motion";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type Step = {
   activeLines: number[];

--- a/app/posts/the-function-that-remembered/widgets/WidgetShell.tsx
+++ b/app/posts/the-function-that-remembered/widgets/WidgetShell.tsx
@@ -1,1 +1,0 @@
-export { WidgetShell } from "@/components/viz/WidgetShell";

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 import { playSound } from "@/lib/audio";
 
 type Row = {

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { motion } from "motion/react";
 import { PRESS, SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type Method = "GET" | "POST" | "PUT" | "DELETE";
 type ContentType =

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -5,7 +5,7 @@ import { motion } from "motion/react";
 import { WidgetNav } from "@/components/viz/WidgetNav";
 import { PRESS, SPRING } from "@/lib/motion";
 import { playSound } from "@/lib/audio";
-import { WidgetShell } from "./WidgetShell";
+import { WidgetShell } from "@/components/viz/WidgetShell";
 
 type Step = {
   id: string;

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/WidgetShell.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/WidgetShell.tsx
@@ -1,1 +1,0 @@
-export { WidgetShell } from "@/components/viz/WidgetShell";

--- a/components/code/CodeBlock.tsx
+++ b/components/code/CodeBlock.tsx
@@ -90,9 +90,15 @@ export async function CodeBlock({
       <div className="relative">
         {tone !== "terminal" ? <CopyButton text={trimmed} /> : null}
         <div
-          className="bs-code-body overflow-x-auto px-[var(--spacing-md)] py-[var(--spacing-md)] leading-[1.55]"
+          className="bs-code-body overflow-x-auto px-[var(--spacing-md)] py-[var(--spacing-md)]"
           data-numbered={numbered ? "true" : undefined}
-          style={{ touchAction: "pan-x" }}
+          style={{
+            touchAction: "pan-x",
+            // Match the prose body line-height (1.7) so code scrolls past
+            // prose without a visible rhythm seam. Was 1.55 before the
+            // Phase 1 ramp revamp — that gap was the seam.
+            lineHeight: "var(--text-mono-lh, 1.7)",
+          }}
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </div>

--- a/components/nav/AboutColumn.tsx
+++ b/components/nav/AboutColumn.tsx
@@ -36,13 +36,16 @@ export function AboutColumn({ readerCount }: AboutColumnProps) {
           collapses back to a block (eyes hidden here, rendered in their
           desktop slot below). */}
       <div className="flex items-center justify-between gap-[var(--spacing-md)] lg:block">
-        {/* Giant serif wordmark — brand moment. */}
+        {/* Giant serif wordmark — brand moment. Size is intentionally bigger
+            than --text-h1 (this is the home logotype, not a hero h1), but
+            tracking is sourced from --brand-tracking so the brand moment
+            stays consistent with the type ramp's tracking philosophy. */}
         <h1
           className="font-serif font-semibold"
           style={{
             fontSize: "clamp(3rem, 2.2rem + 3vw, 4.5rem)",
             lineHeight: 0.95,
-            letterSpacing: "-0.03em",
+            letterSpacing: "var(--brand-tracking)",
             color: "var(--color-text)",
           }}
         >

--- a/components/nav/PostList.tsx
+++ b/components/nav/PostList.tsx
@@ -52,9 +52,12 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
               <h3
                 className="font-serif font-semibold transition-colors group-hover:text-[color:var(--color-accent)]"
                 style={{
+                  // Size stays as a custom clamp (the row-title is
+                  // intentionally larger than --text-h3 for nan.fyi-like
+                  // density). Tracking sourced from the type ramp.
                   fontSize: "clamp(1.125rem, 1.05rem + 0.7vw, 1.5rem)",
                   lineHeight: 1.2,
-                  letterSpacing: "-0.01em",
+                  letterSpacing: "var(--text-h2-tracking)",
                   color: "var(--color-text)",
                 }}
               >

--- a/components/prose/Callout.tsx
+++ b/components/prose/Callout.tsx
@@ -26,11 +26,17 @@ export function Callout({
         lineHeight: 1.6,
       }}
     >
+      {/* Label uses the new --text-h4 register: uppercase, sans, semibold,
+          0.06em tracking. Weight + size + tracking all come from the paired
+          --text-h4-* vars so the label rule lives in one place. */}
       <span
-        className="mr-2 font-sans font-semibold uppercase tracking-wider"
+        className="mr-2 font-sans uppercase"
         style={{
-          fontSize: "0.7rem",
-          letterSpacing: "0.08em",
+          fontFamily: "var(--text-h4-family)",
+          fontSize: "var(--text-h4)",
+          fontWeight: "var(--text-h4-weight)",
+          lineHeight: "var(--text-h4-lh)",
+          letterSpacing: "var(--text-h4-tracking)",
           color: "var(--color-accent)",
         }}
       >

--- a/components/prose/H1.tsx
+++ b/components/prose/H1.tsx
@@ -7,16 +7,12 @@ export function H1({
   children: ReactNode;
   style?: CSSProperties;
 }) {
+  // Token-driven type ramp. Size + weight + lh + tracking come from the
+  // paired --text-h1-* vars via the `.bs-h1` utility class in globals.css.
+  // `font-sans` stays for SSR-safe family fallback; `mt-0` zeroes the
+  // browser's default top margin so the post hero sits flush.
   return (
-    <h1
-      className="mt-0 font-sans font-semibold"
-      style={{
-        fontSize: "var(--text-h1)",
-        letterSpacing: "-0.02em",
-        lineHeight: 1.05,
-        ...style,
-      }}
-    >
+    <h1 className="bs-h1 mt-0 font-sans" style={style}>
       {children}
     </h1>
   );

--- a/components/prose/H2.tsx
+++ b/components/prose/H2.tsx
@@ -4,15 +4,12 @@ import { slugify } from "@/lib/utils/slug";
 export function H2({ children, id }: { children: ReactNode; id?: string }) {
   const slug = id ?? slugify(children);
 
+  // `bs-h2` doubles as both the type-ramp consumer (size + weight + lh +
+  // tracking) AND the anchor-reveal hook (`bs-h2:target .bs-h2-anchor`).
   return (
     <h2
       id={slug}
-      className="bs-h2 group relative mt-[2.75em] mb-[0.8em] font-sans font-semibold"
-      style={{
-        fontSize: "var(--text-h2)",
-        letterSpacing: "-0.01em",
-        lineHeight: 1.15,
-      }}
+      className="bs-h2 group relative mt-[2.75em] mb-[0.8em] font-sans"
     >
       {children}
       <a

--- a/components/prose/H3.tsx
+++ b/components/prose/H3.tsx
@@ -2,10 +2,7 @@ import type { ReactNode } from "react";
 
 export function H3({ children }: { children: ReactNode }) {
   return (
-    <h3
-      className="mt-[2em] mb-[0.6em] font-sans font-semibold"
-      style={{ fontSize: "var(--text-h3)", lineHeight: 1.25 }}
-    >
+    <h3 className="bs-h3 mt-[2em] mb-[0.6em] font-sans">
       {children}
     </h3>
   );

--- a/components/viz/WidgetNav.tsx
+++ b/components/viz/WidgetNav.tsx
@@ -165,9 +165,14 @@ export function WidgetNav({
   const atEnd = value >= total - 1;
   const onlyOne = total <= 1;
 
+  // Phase 1 visual-weight lift: buttons read as deliberate chips — full
+  // text contrast, 1 px rule border, opaque surface at rest. Hover stays
+  // terracotta (existing behaviour). Disabled keeps the §11 0.4 floor.
   const btnClass =
     "relative z-10 inline-flex items-center justify-center min-h-[44px] min-w-[44px] " +
     "px-[var(--spacing-sm)] py-[var(--spacing-2xs)] rounded-[var(--radius-md)] " +
+    "border border-[color:var(--color-rule)] bg-[color:var(--color-surface)] " +
+    "text-[color:var(--color-text)] " +
     "transition-colors disabled:opacity-40 disabled:cursor-not-allowed " +
     "hover:enabled:text-[color:var(--color-accent)] focus-visible:outline-none " +
     "focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]";

--- a/components/viz/WidgetShell.tsx
+++ b/components/viz/WidgetShell.tsx
@@ -6,48 +6,107 @@ import { FullBleed } from "@/components/prose";
 import { SPRING } from "@/lib/motion";
 
 type Props = {
+  /** Widget title (left of the metadata row, sans, muted). */
   title: string;
+  /** Optional measurements (right of metadata row, mono tabular-nums). */
   measurements?: string;
-  caption?: ReactNode;
+
+  /* --- Strict slot API (Phase 1+) --- */
+
   /**
-   * Visual weight of the caption.
-   * - `muted` (default) — sidenote-voice, Plex Sans small, muted colour.
-   * - `prominent` — teacher-voice. Plex Serif body, full contrast, with
-   *   a leading terracotta marker so the eye lands on it naturally.
+   * The interactive surface (SVG / HTML viz). Renders inside an opaque
+   * `--color-surface` canvas with a 1 px `--color-rule` border.
+   *
+   * Min-height contract: the shell does NOT impose a min-height on the
+   * post-hydration canvas — per-widget tuning is the widget's job (Phase 2
+   * sets each widget's tallest reachable state). The pre-hydration SSR-dot
+   * fallback retains its `min-h-[120px]` floor so the pre-hydration size
+   * is stable across all widgets.
    */
-  captionTone?: "muted" | "prominent";
+  canvas?: ReactNode;
+  /**
+   * The teacher-voice line that names what just happened. Renders in the
+   * body-strong register (Plex Serif 500 / lh 1.7) with a 10 × 10 rotated
+   * terracotta square as the leading marker.
+   *
+   * Min-height contract: shell sets `min-height: 5.25em` so the state line
+   * never causes a layout jump when copy changes.
+   */
+  state?: ReactNode;
+  /**
+   * Step / mode controls (typically `<WidgetNav />`, sometimes custom).
+   *
+   * Min-height contract: shell sets `min-height: var(--widget-controls-min,
+   * 44px)` so single-button vs full WidgetNav rows don't change frame
+   * height between widgets.
+   */
   controls?: ReactNode;
-  children: ReactNode;
+
+  /* --- Compat shim (Phase 1 → Phase 2) ---
+   * The 23+ existing widget callsites pass `children` (canvas) and
+   * `caption` (state) under the old API. Both forms continue to render
+   * correctly: if `canvas` is omitted we render `children`; if `state` is
+   * omitted we render `caption`. `captionTone` is preserved for completeness
+   * but the new contract treats every state line as `prominent` — the
+   * `muted` tone is no longer applied to new shells. Removed at the end of
+   * Phase 2 once every widget has migrated.
+   */
+  /** @deprecated Use `canvas`. */
+  children?: ReactNode;
+  /** @deprecated Use `state`. */
+  caption?: ReactNode;
+  /** @deprecated The new contract is always prominent. */
+  captionTone?: "muted" | "prominent";
 };
 
 /**
- * WidgetShell — the canonical skeleton for every lainlog widget. DESIGN.md §7:
- * <FullBleed><Figure><Header><Canvas><Controls></Figure></FullBleed>.
+ * WidgetShell — the canonical skeleton for every lainlog widget. DESIGN.md
+ * §7 + `docs/interactive-components.md` §0 layout contract:
+ *
+ *     Title metadata row  →  Canvas  →  State caption  →  Controls
  *
  * The outer wrapper declares `container-type: inline-size` so nested widgets
  * can drive orientation flips via `@container` queries against the two
  * canonical breakpoints in globals.css (--flip-narrow, --flip-wide).
  *
- * SSR renders a single 6×6 terracotta dot centred in the canvas area. On
- * hydration the dot fades out and the real interactive canvas fades in with
- * SPRING.smooth — consistent brand grammar across all 13 widgets, in place
- * of ad-hoc spinners or skeleton shimmer.
+ * SSR renders a single 6×6 terracotta dot centred in the canvas area inside
+ * a `min-h-[120px]` floor. On hydration the dot fades out and the real
+ * interactive canvas fades in with SPRING.smooth — consistent brand grammar
+ * across all 13+ widgets, in place of ad-hoc spinners or skeleton shimmer.
+ *
+ * Visual weight (Phase 1 lift):
+ * - Canvas surface is opaque `--color-surface` with a 1 px `--color-rule`
+ *   border (was 40% alpha-mixed surface, no border).
+ * - State caption renders in the body-strong register with a leading 10×10
+ *   rotated terracotta square. DESIGN.md §12 compliant — the marker is a
+ *   small standalone glyph, not a left stripe.
+ * - Controls slot owns its own min-height so single-button widgets line up
+ *   with full WidgetNav rows.
  */
 export function WidgetShell({
   title,
   measurements,
-  caption,
-  captionTone = "muted",
+  canvas,
+  state,
   controls,
   children,
+  caption,
+  // captionTone is intentionally unused — the new contract is always
+  // prominent. Kept in the prop signature for API compat.
 }: Props) {
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => setHydrated(true), []);
 
+  // Compat resolution: prefer the strict slots, fall back to the legacy props.
+  const canvasNode = canvas ?? children;
+  const stateNode = state ?? caption;
+
   return (
     <FullBleed>
-      <div className="bs-widget-container">
+      <div className="bs-widget-container bs-widget-shell">
         <figcaption className="sr-only">{title}</figcaption>
+
+        {/* 1. Title metadata row. */}
         <div
           className="flex items-baseline justify-between gap-[var(--spacing-sm)] pb-[var(--spacing-sm)]"
           style={{ fontSize: "var(--text-ui)" }}
@@ -72,12 +131,8 @@ export function WidgetShell({
           ) : null}
         </div>
 
-        <div
-          className="relative rounded-[var(--radius-md)] px-[var(--spacing-sm)] py-[var(--spacing-md)]"
-          style={{
-            background: "color-mix(in oklab, var(--color-surface) 40%, transparent)",
-          }}
-        >
+        {/* 2. Canvas — opaque surface, 1 px rule border. */}
+        <div className="bs-widget-canvas">
           <AnimatePresence initial={false} mode="wait">
             {hydrated ? (
               <motion.div
@@ -87,7 +142,7 @@ export function WidgetShell({
                 exit={{ opacity: 0 }}
                 transition={SPRING.smooth}
               >
-                {children}
+                {canvasNode}
               </motion.div>
             ) : (
               <motion.div
@@ -107,53 +162,18 @@ export function WidgetShell({
           </AnimatePresence>
         </div>
 
-        {controls ? (
-          <div
-            className="pt-[var(--spacing-sm)] flex flex-wrap items-center justify-center gap-[var(--spacing-sm)] mx-auto px-[var(--spacing-md)]"
-          >
-            {controls}
+        {/* 3. State caption — body-strong register + rotated terracotta
+            square marker. Always-on in the new contract. */}
+        {stateNode ? (
+          <div className="bs-widget-state">
+            <span aria-hidden className="bs-widget-state-marker" />
+            <div>{stateNode}</div>
           </div>
         ) : null}
 
-        {caption ? (
-          captionTone === "prominent" ? (
-            <div
-              className="pt-[var(--spacing-md)] flex gap-[var(--spacing-sm)] items-start"
-              style={{
-                fontSize: "var(--text-body)",
-                fontFamily: "var(--font-serif)",
-                color: "var(--color-text)",
-                lineHeight: 1.55,
-                minHeight: "5.25em",
-              }}
-            >
-              <span
-                aria-hidden
-                className="shrink-0 select-none"
-                style={{
-                  display: "inline-block",
-                  width: 10,
-                  height: 10,
-                  marginTop: "0.5em",
-                  background: "var(--color-accent)",
-                  transform: "rotate(45deg)",
-                }}
-              />
-              <div>{caption}</div>
-            </div>
-          ) : (
-            <div
-              className="pt-[var(--spacing-sm)] font-sans"
-              style={{
-                fontSize: "var(--text-small)",
-                color: "var(--color-text-muted)",
-                lineHeight: 1.5,
-                minHeight: "5.25em",
-              }}
-            >
-              {caption}
-            </div>
-          )
+        {/* 4. Controls — bottom of the widget, always. */}
+        {controls ? (
+          <div className="bs-widget-controls">{controls}</div>
         ) : null}
       </div>
     </FullBleed>

--- a/components/widgets/Quiz.tsx
+++ b/components/widgets/Quiz.tsx
@@ -192,8 +192,10 @@ export function Quiz({
           line-height: 1.45;
           text-align: left;
           border-radius: var(--radius-sm);
+          /* Phase 1 visual-weight lift: opaque surface (was 60% alpha-mix)
+             so chips read as deliberate picks, not ghost text. */
           border: 1px solid var(--color-rule);
-          background: color-mix(in oklab, var(--color-surface) 60%, transparent);
+          background: var(--color-surface);
           color: var(--color-text);
           cursor: pointer;
           transition: background 200ms, color 200ms, border-color 200ms, opacity 200ms;
@@ -304,6 +306,10 @@ export function Quiz({
                       : isChosen
                         ? "var(--color-accent)"
                         : "var(--color-rule)",
+                  // Phase 1 — selected chip reads as a deliberate pick via
+                  // a 2 px border (was 1 px). Resting border stays 1 px so
+                  // the surface only tightens once the reader has chosen.
+                  borderWidth: isChosen || showCorrectMark ? 2 : 1,
                   background: showCorrectMark
                     ? "color-mix(in oklab, var(--color-accent) 16%, transparent)"
                     : isWrongChosen

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -6,6 +6,41 @@ Cross-reference: [`DESIGN.md`](../DESIGN.md), [`voice-profile.md`](./voice-profi
 
 ---
 
+## 0. Widget layout contract
+
+Every widget rendered in a post follows this body order, top to bottom:
+
+1. **Title** (metadata row) — sans, muted, left; mono tabular-nums measurements right.
+2. **Canvas** — the interactive surface (SVG / HTML viz). Opaque `--color-surface` with a 1 px `--color-rule` border.
+3. **State caption** — the teacher-voice line that names what just happened. `--text-body-strong`, full contrast, with a 10 × 10 rotated terracotta square marker.
+4. **Controls** — `<WidgetNav>` or a custom controls cluster. Bottom of the widget, always.
+
+**Frame stability is per-viewport.** Within a viewport, widget bounding-box dimensions MUST NOT change as the user interacts with the widget. Layout flips driven by `@container` queries (viewport-width-driven) are still allowed — the constraint is interaction-stability, not viewport-stability.
+
+The contract is enforced by [`components/viz/WidgetShell.tsx`](../components/viz/WidgetShell.tsx). New widgets compose the shell with the strict slot props:
+
+```tsx
+<WidgetShell
+  title="HashLane"
+  measurements="m=16 · set=5"
+  canvas={<HashLaneCanvas …/>}
+  state={<>The lane just collided. Each new probe walks one slot right.</>}
+  controls={<WidgetNav value={step} total={N} onChange={setStep} />}
+/>
+```
+
+The legacy `children` (canvas) and `caption` (state) props remain functional through the Phase 1 → Phase 2 gap so the existing 23+ widget callsites still render correctly during the migration. Phase 2 retires the compat shim and migrates each widget to the strict slots one at a time.
+
+**Per-zone min-height contract** (set by the shell, not by the widget):
+
+- `canvas`: no shell-level min-height on the post-hydration canvas — per-widget responsibility (Phase 2 sets each widget's tallest reachable state). The pre-hydration SSR-dot path retains its `min-h-[120px]` floor so the pre-hydration size is stable.
+- `state`: shell sets `min-height: 5.25em` so the state line never causes a layout jump when copy changes.
+- `controls`: shell sets `min-height: var(--widget-controls-min, 44px)` so single-button vs full-WidgetNav rows don't change frame height between widgets.
+
+**Inline-prose exemption.** `PredictReveal`, `DomReveal`, and `ClosingDot` are typographic punctuation embedded inside paragraphs — not standalone widgets. They render inline and do not follow the layout contract.
+
+---
+
 ## 1. The widget-shape taxonomy
 
 Every widget we've shipped collapses to one of seven shapes. Pick the shape that matches the teaching claim before picking the widget's visual design.


### PR DESCRIPTION
## Summary
- Typography tokens rebuilt: size + weight + line-height + tracking paired per `--text-*` token. Adds `--text-h4`, `--text-body-strong`, defines the missing `--text-medium`. Fixes code/prose line-height mismatch (1.55 → 1.7). Plex Serif gains weight 300, Plex Sans gains weight 700.
- New WidgetShell layout contract: **Title → Canvas → State → Controls**. State caption gets full-contrast body-strong with the rotated terracotta square marker. Canvas surface goes opaque with a 1px rule border. Codified in `docs/interactive-components.md §0` so future widgets are gated on it.
- Visual weight bump on interactions: WidgetNav buttons gain full-contrast text, 1px borders, opaque surface backgrounds at rest. Quiz option chips go opaque; selected border bumps to 2px.
- Drift cleanup: 4 post-local `WidgetShell.tsx` re-export files deleted; 23 widget files repointed to `@/components/viz/WidgetShell`. Compat shim on the shared component preserves `children`/`caption`/`captionTone` props during the gap to Phase 2.

Plan-review history: 3 rounds, ended at avg 4.8. Two resolutions worth noting:
- No global `strong { font-weight: 500 }` rule — body-strong is opt-in via `.bs-body-strong` class only (avoids re-rendering 62 existing `<strong>` instances).
- State-marker uses the existing rotated 10×10 terracotta square primitive (DESIGN.md §12 compliant), not a `border-left`.

This PR is **Phase 1 of 4** in a UI revamp. Phase 2 dispatches three parallel migrations (3+2+2 posts) on merge.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] `pnpm dev` on 3010, homepage + 1 post smoke-checked
- [x] WCAG AA verified on body text + UI controls in both themes
- [x] Theme flip (light ↔ dark) smooth on opaque surfaces
- [x] Reduced-motion preference respected
- [ ] Reviewer: confirm 3-zone widget order on the rendered post
- [ ] Reviewer: confirm no drift files remain (`grep -r "from \"./WidgetShell\"" app/posts` returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)