### PR TITLE
feat(ui): migrate batch 2 widgets to new WidgetShell contract

### DIFF
--- a/app/posts/the-function-that-remembered/widgets/LoopLet.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopLet.tsx
@@ -48,8 +48,7 @@ export function LoopLet() {
     <WidgetShell
       title="loop · let"
       measurements={`${N} callbacks · ${N} cells`}
-      caption={captionFor(step)}
-      captionTone="prominent"
+      state={captionFor(step)}
       controls={
         <WidgetNav
           value={step}
@@ -59,8 +58,9 @@ export function LoopLet() {
           ariaLabel="Step let-loop timeline"
         />
       }
-    >
-      <div className="bs-looplet-wide">
+      canvas={
+        <>
+          <div className="bs-looplet-wide">
         <svg
           viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
           width="100%"
@@ -215,14 +215,16 @@ export function LoopLet() {
           </g>
         </svg>
       </div>
-      <div className="bs-looplet-narrow">
-        <NarrowLoopLet
-          firedCount={firedCount}
-          printedValues={printedValues}
-          letBindings={letBindings}
-        />
-      </div>
-    </WidgetShell>
+          <div className="bs-looplet-narrow">
+            <NarrowLoopLet
+              firedCount={firedCount}
+              printedValues={printedValues}
+              letBindings={letBindings}
+            />
+          </div>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/LoopVar.tsx
+++ b/app/posts/the-function-that-remembered/widgets/LoopVar.tsx
@@ -50,8 +50,7 @@ export function LoopVar() {
     <WidgetShell
       title="loop · var"
       measurements={`${N} callbacks · 1 cell`}
-      caption={captionFor(step)}
-      captionTone="prominent"
+      state={captionFor(step)}
       controls={
         <WidgetNav
           value={step}
@@ -61,8 +60,9 @@ export function LoopVar() {
           ariaLabel="Step var-loop timeline"
         />
       }
-    >
-      <div className="bs-loopvar-wide">
+      canvas={
+        <>
+          <div className="bs-loopvar-wide">
         <svg
           viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
           width="100%"
@@ -210,14 +210,16 @@ export function LoopVar() {
           </g>
         </svg>
       </div>
-      <div className="bs-loopvar-narrow">
-        <NarrowLoopVar
-          firedCount={firedCount}
-          printedValues={printedValues}
-          sharedVar={sharedVar}
-        />
-      </div>
-    </WidgetShell>
+          <div className="bs-loopvar-narrow">
+            <NarrowLoopVar
+              firedCount={firedCount}
+              printedValues={printedValues}
+              sharedVar={sharedVar}
+            />
+          </div>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/RenderBroken.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderBroken.tsx
@@ -78,8 +78,7 @@ export function RenderBroken() {
     <WidgetShell
       title="render · broken"
       measurements="count + 1"
-      captionTone="prominent"
-      caption={captionFor(step)}
+      state={captionFor(step)}
       controls={
         <WidgetNav
           value={step}
@@ -90,8 +89,9 @@ export function RenderBroken() {
           ariaLabel="Step broken-render timeline"
         />
       }
-    >
-      <div className="bs-renderbroken-wide">
+      canvas={
+        <>
+          <div className="bs-renderbroken-wide">
         <svg
           viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
           width="100%"
@@ -327,10 +327,12 @@ export function RenderBroken() {
           </g>
         </svg>
       </div>
-      <div className="bs-renderbroken-narrow">
-        <MemoNarrowRenderBroken step={step} tick={tick} />
-      </div>
-    </WidgetShell>
+          <div className="bs-renderbroken-narrow">
+            <MemoNarrowRenderBroken step={step} tick={tick} />
+          </div>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/RenderFixed.tsx
+++ b/app/posts/the-function-that-remembered/widgets/RenderFixed.tsx
@@ -70,8 +70,7 @@ export function RenderFixed() {
     <WidgetShell
       title="render · fixed"
       measurements="c => c + 1"
-      captionTone="prominent"
-      caption={captionFor(step)}
+      state={captionFor(step)}
       controls={
         <WidgetNav
           value={step}
@@ -82,8 +81,9 @@ export function RenderFixed() {
           ariaLabel="Step fixed-render timeline"
         />
       }
-    >
-      <div className="bs-renderfixed-wide">
+      canvas={
+        <>
+          <div className="bs-renderfixed-wide">
         <svg
           viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
           width="100%"
@@ -307,10 +307,12 @@ export function RenderFixed() {
           </g>
         </svg>
       </div>
-      <div className="bs-renderfixed-narrow">
-        <MemoNarrowRenderFixed step={step} tick={tick} />
-      </div>
-    </WidgetShell>
+          <div className="bs-renderfixed-narrow">
+            <MemoNarrowRenderFixed step={step} tick={tick} />
+          </div>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
+++ b/app/posts/the-function-that-remembered/widgets/TetherScope.tsx
@@ -99,12 +99,12 @@ export function TetherScope() {
 
   return (
     <WidgetShell
-      title="TetherScope"
-      caption={s.caption}
-      captionTone="prominent"
+      title="tether · scope"
+      state={s.caption}
       controls={<WidgetNav value={step} total={STEPS.length} onChange={setStep} playInterval={1500} />}
-    >
-      <div className="bs-tetherscope-wide">
+      canvas={
+        <>
+          <div className="bs-tetherscope-wide">
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -413,10 +413,12 @@ export function TetherScope() {
         </text>
       </svg>
       </div>
-      <div className="bs-tetherscope-narrow">
-        <MemoNarrowTetherScope step={step} s={s} />
-      </div>
-    </WidgetShell>
+          <div className="bs-tetherscope-narrow">
+            <MemoNarrowTetherScope step={step} s={s} />
+          </div>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/AgentLoopMap.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/AgentLoopMap.tsx
@@ -76,8 +76,7 @@ export function AgentLoopMap() {
   return (
     <WidgetShell
       title="agent loop · six stages"
-      captionTone="prominent"
-      caption={
+      state={
         <AnimatePresence mode="wait">
           <motion.span
             key={step}
@@ -134,8 +133,8 @@ export function AgentLoopMap() {
           counterNoun="stage"
         />
       }
-    >
-      <div className="mx-auto" style={{ maxWidth: 420 }}>
+      canvas={
+        <div className="mx-auto" style={{ maxWidth: 420 }}>
         <svg
           viewBox="0 0 360 360"
           role="img"
@@ -274,7 +273,8 @@ export function AgentLoopMap() {
             </motion.text>
           </AnimatePresence>
         </svg>
-      </div>
-    </WidgetShell>
+        </div>
+      }
+    />
   );
 }

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/DefenceCoverage.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/DefenceCoverage.tsx
@@ -71,8 +71,7 @@ export function DefenceCoverage() {
     <WidgetShell
       title="defence coverage"
       measurements={focus ? `focus · ${focus.label}` : "3 layers · 6 stages"}
-      captionTone="prominent"
-      caption={
+      state={
         <AnimatePresence mode="wait">
           <motion.span
             key={focus?.key ?? "none"}
@@ -100,8 +99,9 @@ export function DefenceCoverage() {
           </motion.span>
         </AnimatePresence>
       }
-    >
-      <div className="bs-dc">
+      canvas={
+        <>
+          <div className="bs-dc">
         {/* header row with stage names */}
         <div className="bs-dc-header">
           <span />
@@ -215,7 +215,9 @@ export function DefenceCoverage() {
           }
         }
       `}</style>
-    </WidgetShell>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/HostilePageScan.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/HostilePageScan.tsx
@@ -67,8 +67,36 @@ export function HostilePageScan() {
       measurements={
         scanning ? "3 injections · unmasked" : "3 injections · hidden"
       }
-      captionTone="prominent"
-      caption={
+      canvas={
+        <>
+          <div className="bs-hps-grid">
+            <PageCanvas
+              key={scanKey}
+              scanning={scanning}
+              reducedMotion={!!prefersReducedMotion}
+            />
+            <ChipTrack
+              key={`c-${scanKey}`}
+              scanning={scanning}
+              reducedMotion={!!prefersReducedMotion}
+            />
+          </div>
+          <style>{`
+            .bs-hps-grid {
+              display: grid;
+              grid-template-columns: 1fr;
+              gap: var(--spacing-md);
+              align-items: stretch;
+            }
+            @container widget (min-width: 640px) {
+              .bs-hps-grid {
+                grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+              }
+            }
+          `}</style>
+        </>
+      }
+      state={
         scanning ? (
           <>
             The page the human reads shows a tepid three-star review.{" "}
@@ -137,33 +165,7 @@ export function HostilePageScan() {
           ) : null}
         </div>
       }
-    >
-      <div className="bs-hps-grid">
-        <PageCanvas
-          key={scanKey}
-          scanning={scanning}
-          reducedMotion={!!prefersReducedMotion}
-        />
-        <ChipTrack
-          key={`c-${scanKey}`}
-          scanning={scanning}
-          reducedMotion={!!prefersReducedMotion}
-        />
-      </div>
-      <style>{`
-        .bs-hps-grid {
-          display: grid;
-          grid-template-columns: 1fr;
-          gap: var(--spacing-md);
-          align-items: stretch;
-        }
-        @container widget (min-width: 640px) {
-          .bs-hps-grid {
-            grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
-          }
-        }
-      `}</style>
-    </WidgetShell>
+    />
   );
 }
 

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/InfectiousJailbreak.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/InfectiousJailbreak.tsx
@@ -125,8 +125,7 @@ export function InfectiousJailbreak() {
     <WidgetShell
       title="infectious jailbreak"
       measurements={`${infected.size}/${N} infected`}
-      captionTone="prominent"
-      caption={
+      state={
         state === "start" ? (
           <>
             Fourteen agents, one seeded infected.{" "}
@@ -205,8 +204,8 @@ export function InfectiousJailbreak() {
           ) : null}
         </div>
       }
-    >
-      <div className="mx-auto" style={{ maxWidth: 540 }}>
+      canvas={
+        <div className="mx-auto" style={{ maxWidth: 540 }}>
         <svg
           viewBox="0 0 360 240"
           role="img"
@@ -272,7 +271,8 @@ export function InfectiousJailbreak() {
             );
           })}
         </svg>
-      </div>
-    </WidgetShell>
+        </div>
+      }
+    />
   );
 }

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/MemoryPoisonTimeline.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/MemoryPoisonTimeline.tsx
@@ -114,8 +114,7 @@ export function MemoryPoisonTimeline() {
     <WidgetShell
       title="memory · delayed write"
       measurements={s.label}
-      captionTone="prominent"
-      caption={
+      state={
         <AnimatePresence mode="wait">
           <motion.span
             key={step}
@@ -136,29 +135,30 @@ export function MemoryPoisonTimeline() {
           playInterval={3000}
         />
       }
-    >
-      <div
-        className="grid gap-[var(--spacing-md)]"
-        style={{ gridTemplateColumns: "1fr" }}
-      >
-        <Panel title="context" when={s.when}>
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={`ctx-${step}`}
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={SPRING.smooth}
-            >
-              {s.context}
-            </motion.div>
-          </AnimatePresence>
-        </Panel>
-        <Panel title="agent memory">
-          <MemoryState state={s.memoryState} />
-        </Panel>
-      </div>
-    </WidgetShell>
+      canvas={
+        <div
+          className="grid gap-[var(--spacing-md)]"
+          style={{ gridTemplateColumns: "1fr", minHeight: 280 }}
+        >
+          <Panel title="context" when={s.when}>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={`ctx-${step}`}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -4 }}
+                transition={SPRING.smooth}
+              >
+                {s.context}
+              </motion.div>
+            </AnimatePresence>
+          </Panel>
+          <Panel title="agent memory">
+            <MemoryState state={s.memoryState} />
+          </Panel>
+        </div>
+      }
+    />
   );
 }
 

--- a/app/posts/the-webpage-that-reads-the-agent/widgets/ParseVsRender.tsx
+++ b/app/posts/the-webpage-that-reads-the-agent/widgets/ParseVsRender.tsx
@@ -26,8 +26,7 @@ export function ParseVsRender() {
       measurements={
         view === "human" ? "human view · rendered" : "agent view · parsed"
       }
-      captionTone="prominent"
-      caption={
+      state={
         view === "human" ? (
           <>
             This is the page a human sees — a tepid three-star review.{" "}
@@ -96,33 +95,34 @@ export function ParseVsRender() {
           ))}
         </div>
       }
-    >
-      <div className="relative" style={{ minHeight: 260 }}>
-        <AnimatePresence initial={false} mode="wait">
-          {view === "human" ? (
-            <motion.div
-              key="human"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -6 }}
-              transition={SPRING.smooth}
-            >
-              <HumanView />
-            </motion.div>
-          ) : (
-            <motion.div
-              key="agent"
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -6 }}
-              transition={SPRING.smooth}
-            >
-              <AgentView />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-    </WidgetShell>
+      canvas={
+        <div className="relative" style={{ minHeight: 260 }}>
+          <AnimatePresence initial={false} mode="wait">
+            {view === "human" ? (
+              <motion.div
+                key="human"
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={SPRING.smooth}
+              >
+                <HumanView />
+              </motion.div>
+            ) : (
+              <motion.div
+                key="agent"
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={SPRING.smooth}
+              >
+                <AgentView />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Phase 2 batch 2 of the UI revamp (Phase 1 = #88). Moves every non-inline widget in `the-webpage-that-reads-the-agent` and `the-function-that-remembered` from the legacy `children` + `caption` + `captionTone` `WidgetShell` API onto Phase 1's strict-slot `canvas` / `state` / `controls` API. The shared shell, `WidgetNav`, and `Quiz` are unchanged.

## Posts and widgets touched (11 widgets)

`app/posts/the-webpage-that-reads-the-agent/widgets/`:
- `HostilePageScan` — strict slots; custom scan / replay / reset cluster preserved in `controls`.
- `AgentLoopMap` — strict slots; `WidgetNav` preserved.
- `ParseVsRender` — strict slots; custom human / agent tablist preserved in `controls`.
- `InfectiousJailbreak` — strict slots; custom play / pause / reset cluster preserved in `controls`.
- `MemoryPoisonTimeline` — strict slots; canvas `min-height: 280px` added to absorb step-driven content swing.
- `DefenceCoverage` — strict slots; tap-row matrix lives in `canvas` (no separate controls — the rows are the interaction).

`app/posts/the-function-that-remembered/widgets/`:
- `LoopVar`, `LoopLet`, `RenderBroken`, `RenderFixed` — strict slots; `WidgetNav` preserved.
- `TetherScope` — strict slots **and** title fix `"TetherScope"` → `"tether · scope"` (CamelCase leak per `docs/interactive-components.md` §5).

## Inline-prose exemptions (per `docs/interactive-components.md` §0)

- `app/posts/the-webpage-that-reads-the-agent/widgets/DomReveal.tsx` — `MediaBetweenText` chip used inline inside §3 prose. No `WidgetShell` to migrate.
- `app/posts/the-function-that-remembered/widgets/PredictReveal.tsx` — inline reveal chip used inside `<P>...</P>`. No `WidgetShell` to migrate. Visual weight already satisfies Phase 1's interaction-contrast principle (muted-text → accent on click); the brief's optional bump is deliberately not pursued so the chip stays calm next to the prose.

## Frame-stability findings

- Widgets with fixed `viewBox` SVG canvases (`AgentLoopMap`, `InfectiousJailbreak`, `LoopVar`, `LoopLet`, `RenderBroken`, `RenderFixed`, `TetherScope`) are height-invariant by construction — no fix needed.
- `HostilePageScan` already pins `minHeight: 320` on the inner page-canvas and `minHeight: 160` on the pristine chip-track; states share the same outer grid — no fix needed.
- `ParseVsRender` already pins `minHeight: 260` on the canvas wrapper — no fix needed.
- `DefenceCoverage` is a CSS grid; row count is constant — no fix needed.
- `MemoryPoisonTimeline` canvas content varies per step (doc lines vs chat lines vs memory entries). Pinned `minHeight: 280px` on the canvas grid wrapper.

## Validation

- [x] `npx tsc --noEmit` — clean (the two `@web-kits/audio` errors are pre-existing on `main`; verified by stashing the diff).
- [x] `pnpm lint` — no new errors vs `origin/main` (verified by stashing the diff; the same 117 pre-existing problems remain, none in the touched files).
- [x] `pnpm build` — clean; both target post pages prerender as static HTML.
- [x] `pnpm dev` background-mode on `0.0.0.0:3011`; both `/posts/the-function-that-remembered` and `/posts/the-webpage-that-reads-the-agent` returned `200`.
- [x] `grep -r 'from "./WidgetShell"' app/posts/the-webpage-that-reads-the-agent app/posts/the-function-that-remembered` → 0 hits.
- [x] `grep -nE 'captionTone|caption=\{|caption="' app/posts/the-webpage-that-reads-the-agent app/posts/the-function-that-remembered` → 0 hits.

## Test plan

- [ ] Visit `/posts/the-webpage-that-reads-the-agent` and `/posts/the-function-that-remembered` at 360 px and 720 px container widths.
- [ ] Drive each interactive widget through every step. Confirm canvas height holds, state line always present, controls always at the bottom.
- [ ] Confirm `DomReveal` (in §3) and `PredictReveal` (in §1) still render inline with surrounding prose unchanged.

## References

- Phase 1 PR: #88
- Layout contract: `docs/interactive-components.md` §0

🤖 Generated with [Claude Code](https://claude.com/claude-code)