### PR TITLE
feat(ui): migrate batch 3 widgets to new WidgetShell contract

### DIFF
--- a/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CallStackECs.tsx
@@ -357,42 +357,41 @@ export function CallStackECs({ initialStep = 0, codeSlot }: Props) {
     <WidgetShell
       title="call stack · execution contexts"
       measurements={`step ${clamped + 1}/${TOTAL}`}
-      caption={caption}
-      captionTone="prominent"
-    >
-      <div className="bs-csec">
-        <CallStackBoard
-          activeLine={current.activeLine}
-          stack={current.stack}
-          topId={topFrame.id}
-          consoleLog={consoleLog}
-          reducedMotion={Boolean(reducedMotion)}
-          codeSlot={codeSlot}
-          controls={controls}
-        />
-      </div>
-
-      <style>{`
-        .bs-csec {
-          display: flex;
-          flex-direction: column;
-          gap: var(--spacing-sm);
-          min-width: 0;
-        }
-        .bs-csec-controls {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 6px;
-          align-items: center;
-          justify-content: flex-start;
-          min-height: 48px;
-        }
-        .bs-csec-btn-label {
-          font-family: var(--font-sans);
-          font-size: var(--text-ui);
-        }
-      `}</style>
-    </WidgetShell>
+      state={caption}
+      canvas={
+        <div className="bs-csec">
+          <CallStackBoard
+            activeLine={current.activeLine}
+            stack={current.stack}
+            topId={topFrame.id}
+            consoleLog={consoleLog}
+            reducedMotion={Boolean(reducedMotion)}
+            codeSlot={codeSlot}
+          />
+          <style>{`
+            .bs-csec {
+              display: flex;
+              flex-direction: column;
+              gap: var(--spacing-sm);
+              min-width: 0;
+            }
+            .bs-csec-controls {
+              display: flex;
+              flex-wrap: wrap;
+              gap: 6px;
+              align-items: center;
+              justify-content: flex-start;
+              min-height: 48px;
+            }
+            .bs-csec-btn-label {
+              font-family: var(--font-sans);
+              font-size: var(--text-ui);
+            }
+          `}</style>
+        </div>
+      }
+      controls={controls}
+    />
   );
 }
 
@@ -407,7 +406,6 @@ function CallStackBoard({
   consoleLog,
   reducedMotion,
   codeSlot,
-  controls,
 }: {
   activeLine: number | null;
   stack: EC[];
@@ -415,7 +413,6 @@ function CallStackBoard({
   consoleLog: ConsoleLine[];
   reducedMotion: boolean;
   codeSlot?: ReactNode;
-  controls: ReactNode;
 }) {
   const boardRef = useRef<HTMLDivElement | null>(null);
   const codePaneRef = useRef<HTMLDivElement | null>(null);
@@ -589,10 +586,6 @@ function CallStackBoard({
         </div>
       </div>
 
-      {/* Controls — immediately below the stack viz. Cause + effect
-          colocated in the reader's eye-line. */}
-      <div className="bs-csec-region-controls">{controls}</div>
-
       {/* Console pane. Lines are derived from `STEPS[0..currentStep]
           .emit`, so stepping back removes lines that haven't fired yet
           and stepping forward replays them. AnimatePresence with
@@ -689,11 +682,6 @@ function CallStackBoard({
           font-variant-numeric: tabular-nums;
         }
         .bs-csec-console { min-height: 88px; }
-        .bs-csec-region-controls {
-          display: flex;
-          align-items: center;
-          min-height: 48px;
-        }
 
         .bs-csec-codeslot {
           position: relative;
@@ -737,12 +725,12 @@ function CallStackBoard({
         @container widget (min-width: 720px) {
           .bs-csec-board {
             grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-            grid-template-rows: auto auto auto;
+            grid-template-rows: auto auto;
           }
           /* code pane — top-left */
           .bs-csec-board > .bs-csec-code {
             grid-column: 1 / 2;
-            grid-row: 1 / 3;
+            grid-row: 1 / 2;
           }
           /* mobile glyph hides */
           .bs-csec-board > .bs-csec-glyph {
@@ -753,15 +741,10 @@ function CallStackBoard({
             grid-column: 2 / 3;
             grid-row: 1 / 2;
           }
-          /* controls — directly under stack viz, right column */
-          .bs-csec-board > .bs-csec-region-controls {
-            grid-column: 2 / 3;
-            grid-row: 2 / 3;
-          }
-          /* console — left column, row 3 (under code) */
+          /* console — full-width, row 2 (under both code and stack) */
           .bs-csec-board > .bs-csec-console {
             grid-column: 1 / 3;
-            grid-row: 3 / 4;
+            grid-row: 2 / 3;
           }
         }
       `}</style>

--- a/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/CreationVsExecution.tsx
@@ -144,8 +144,18 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
   return (
     <WidgetShell
       title="creation vs execution · var x = 5"
-      caption={caption}
-      captionTone="prominent"
+      state={caption}
+      canvas={<CveCanvas
+        clamped={clamped}
+        current={current}
+        TRACK_W={TRACK_W}
+        TRACK_PAD={TRACK_PAD}
+        TRACK_Y={TRACK_Y}
+        TRACK_H={TRACK_H}
+        TRACK_TOTAL_H={TRACK_TOTAL_H}
+        BOUNDARY_X={BOUNDARY_X}
+        CURSOR_X={CURSOR_X}
+      />}
       controls={
         <div className="w-full max-w-[420px]">
           <Scrubber
@@ -158,7 +168,33 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
           />
         </div>
       }
-    >
+    />
+  );
+}
+
+function CveCanvas({
+  clamped,
+  current,
+  TRACK_W,
+  TRACK_PAD,
+  TRACK_Y,
+  TRACK_H,
+  TRACK_TOTAL_H,
+  BOUNDARY_X,
+  CURSOR_X,
+}: {
+  clamped: number;
+  current: Stop;
+  TRACK_W: number;
+  TRACK_PAD: number;
+  TRACK_Y: number;
+  TRACK_H: number;
+  TRACK_TOTAL_H: number;
+  BOUNDARY_X: number;
+  CURSOR_X: number;
+}) {
+  return (
+    <>
       {/* Time track — mobile-first, scales fluidly */}
       <svg
         viewBox={`0 0 ${TRACK_W} ${TRACK_TOTAL_H}`}
@@ -427,6 +463,6 @@ export function CreationVsExecution({ initialStop = 0 }: Props) {
           }
         `}</style>
       </div>
-    </WidgetShell>
+    </>
   );
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/DeclarationStates.tsx
@@ -143,11 +143,186 @@ export function DeclarationStates({ initialKind = "var" }: Props) {
   const MEM_H = 76;
   const HEIGHT = MEM_Y + MEM_H + 14;
 
+  const canvasNode = (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      style={{
+        maxWidth: WIDTH,
+        height: "auto",
+        display: "block",
+        margin: "0 auto",
+      }}
+      role="img"
+      aria-label={`Declaration state. Kind: ${state.label}. Binding ${state.binding.name} = ${state.binding.valueText}.`}
+    >
+      <defs>
+        <pattern
+          id={hatchPattern}
+          patternUnits="userSpaceOnUse"
+          width="6"
+          height="6"
+          patternTransform="rotate(45)"
+        >
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke="var(--color-text-muted)"
+            strokeWidth="1.4"
+          />
+        </pattern>
+      </defs>
+
+      {/* Snippet pane */}
+      <rect
+        x={PAD}
+        y={SNIPPET_Y}
+        width={WIDTH - PAD * 2}
+        height={SNIPPET_H}
+        rx={3}
+        fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+      />
+      <text
+        x={PAD + 8}
+        y={SNIPPET_Y + 14}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        letterSpacing="0.08em"
+        fill="var(--color-text-muted)"
+      >
+        AT LINE 1
+      </text>
+
+      <motion.g
+        key={`snip-${state.id}`}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING.smooth}
+      >
+        {state.snippet.map((line, i) => (
+          <text
+            key={i}
+            x={PAD + 12}
+            y={SNIPPET_Y + 32 + i * 18}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill={i === 0 ? "var(--color-accent)" : "var(--color-text)"}
+          >
+            <tspan
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+            >
+              {i + 1}
+            </tspan>
+            <tspan dx={10}>{line}</tspan>
+          </text>
+        ))}
+      </motion.g>
+
+      {/* Memory pane */}
+      <rect
+        x={PAD}
+        y={MEM_Y}
+        width={WIDTH - PAD * 2}
+        height={MEM_H}
+        rx={3}
+        fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+        stroke="var(--color-accent)"
+        strokeWidth={1.4}
+      />
+      <text
+        x={PAD + 8}
+        y={MEM_Y + 14}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        letterSpacing="0.08em"
+        fill="var(--color-text-muted)"
+      >
+        MEMORY · CREATION-PHASE STATE
+      </text>
+
+      {/* Binding row — name + state cell */}
+      <motion.g
+        key={`mem-${state.id}`}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING.smooth}
+      >
+        <text
+          x={PAD + 14}
+          y={MEM_Y + 44}
+          fontFamily="var(--font-mono)"
+          fontSize={13}
+          fill="var(--color-text)"
+        >
+          {state.binding.name}
+        </text>
+
+        {/* The state cell — shape conveys state, not just colour. */}
+        {state.binding.shape === "value" ? (
+          <rect
+            x={WIDTH / 2 - 4}
+            y={MEM_Y + 30}
+            width={WIDTH / 2 - PAD - 4}
+            height={28}
+            rx={2}
+            fill="color-mix(in oklab, var(--color-accent) 18%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={1}
+          />
+        ) : state.binding.shape === "uninitialized" ? (
+          <g>
+            <rect
+              x={WIDTH / 2 - 4}
+              y={MEM_Y + 30}
+              width={WIDTH / 2 - PAD - 4}
+              height={28}
+              rx={2}
+              fill={`url(#${hatchPattern})`}
+              stroke="var(--color-text-muted)"
+              strokeWidth={1.4}
+              strokeDasharray="3 2"
+            />
+          </g>
+        ) : (
+          // fn-bound — rounded pill (different shape)
+          <rect
+            x={WIDTH / 2 - 4}
+            y={MEM_Y + 30}
+            width={WIDTH / 2 - PAD - 4}
+            height={28}
+            rx={14}
+            fill="color-mix(in oklab, var(--color-accent) 26%, transparent)"
+            stroke="var(--color-accent)"
+            strokeWidth={1.4}
+          />
+        )}
+
+        <text
+          x={WIDTH / 2 - 4 + (WIDTH / 2 - PAD - 4) / 2}
+          y={MEM_Y + 48}
+          textAnchor="middle"
+          fontFamily="var(--font-mono)"
+          fontSize={11}
+          fill="var(--color-text)"
+          fontWeight={state.binding.shape === "fn-bound" ? 600 : 400}
+        >
+          {state.binding.valueText}
+        </text>
+      </motion.g>
+    </svg>
+  );
+
   return (
     <WidgetShell
       title="declarations · at line 1"
-      caption={state.caption}
-      captionTone="prominent"
+      state={state.caption}
+      canvas={canvasNode}
       controls={
         <div
           role="group"
@@ -189,183 +364,6 @@ export function DeclarationStates({ initialKind = "var" }: Props) {
           })}
         </div>
       }
-    >
-      <svg
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        width="100%"
-        style={{
-          maxWidth: WIDTH,
-          height: "auto",
-          display: "block",
-          margin: "0 auto",
-        }}
-        role="img"
-        aria-label={`Declaration state. Kind: ${state.label}. Binding ${state.binding.name} = ${state.binding.valueText}.`}
-      >
-        <defs>
-          <pattern
-            id={hatchPattern}
-            patternUnits="userSpaceOnUse"
-            width="6"
-            height="6"
-            patternTransform="rotate(45)"
-          >
-            <line
-              x1="0"
-              y1="0"
-              x2="0"
-              y2="6"
-              stroke="var(--color-text-muted)"
-              strokeWidth="1.4"
-            />
-          </pattern>
-        </defs>
-
-        {/* Snippet pane */}
-        <rect
-          x={PAD}
-          y={SNIPPET_Y}
-          width={WIDTH - PAD * 2}
-          height={SNIPPET_H}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-        <text
-          x={PAD + 8}
-          y={SNIPPET_Y + 14}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          AT LINE 1
-        </text>
-
-        <motion.g
-          key={`snip-${state.id}`}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING.smooth}
-        >
-          {state.snippet.map((line, i) => (
-            <text
-              key={i}
-              x={PAD + 12}
-              y={SNIPPET_Y + 32 + i * 18}
-              fontFamily="var(--font-mono)"
-              fontSize={12}
-              fill={i === 0 ? "var(--color-accent)" : "var(--color-text)"}
-            >
-              <tspan
-                fontFamily="var(--font-mono)"
-                fontSize={10}
-                fill="var(--color-text-muted)"
-              >
-                {i + 1}
-              </tspan>
-              <tspan dx={10}>{line}</tspan>
-            </text>
-          ))}
-        </motion.g>
-
-        {/* Memory pane */}
-        <rect
-          x={PAD}
-          y={MEM_Y}
-          width={WIDTH - PAD * 2}
-          height={MEM_H}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-accent)"
-          strokeWidth={1.4}
-        />
-        <text
-          x={PAD + 8}
-          y={MEM_Y + 14}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          MEMORY · CREATION-PHASE STATE
-        </text>
-
-        {/* Binding row — name + state cell */}
-        <motion.g
-          key={`mem-${state.id}`}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING.smooth}
-        >
-          <text
-            x={PAD + 14}
-            y={MEM_Y + 44}
-            fontFamily="var(--font-mono)"
-            fontSize={13}
-            fill="var(--color-text)"
-          >
-            {state.binding.name}
-          </text>
-
-          {/* The state cell — shape conveys state, not just colour. */}
-          {state.binding.shape === "value" ? (
-            <rect
-              x={WIDTH / 2 - 4}
-              y={MEM_Y + 30}
-              width={WIDTH / 2 - PAD - 4}
-              height={28}
-              rx={2}
-              fill="color-mix(in oklab, var(--color-accent) 18%, transparent)"
-              stroke="var(--color-accent)"
-              strokeWidth={1}
-            />
-          ) : state.binding.shape === "uninitialized" ? (
-            <g>
-              <rect
-                x={WIDTH / 2 - 4}
-                y={MEM_Y + 30}
-                width={WIDTH / 2 - PAD - 4}
-                height={28}
-                rx={2}
-                fill={`url(#${hatchPattern})`}
-                stroke="var(--color-text-muted)"
-                strokeWidth={1.4}
-                strokeDasharray="3 2"
-              />
-            </g>
-          ) : (
-            // fn-bound — rounded pill (different shape)
-            <rect
-              x={WIDTH / 2 - 4}
-              y={MEM_Y + 30}
-              width={WIDTH / 2 - PAD - 4}
-              height={28}
-              rx={14}
-              fill="color-mix(in oklab, var(--color-accent) 26%, transparent)"
-              stroke="var(--color-accent)"
-              strokeWidth={1.4}
-            />
-          )}
-
-          <text
-            x={WIDTH / 2 - 4 + (WIDTH / 2 - PAD - 4) / 2}
-            y={MEM_Y + 48}
-            textAnchor="middle"
-            fontFamily="var(--font-mono)"
-            fontSize={11}
-            fill={
-              state.binding.shape === "uninitialized"
-                ? "var(--color-text)"
-                : "var(--color-text)"
-            }
-            fontWeight={state.binding.shape === "fn-bound" ? 600 : 400}
-          >
-            {state.binding.valueText}
-          </text>
-        </motion.g>
-      </svg>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/widgets/WhyTwoPasses.tsx
@@ -129,11 +129,159 @@ export function WhyTwoPasses({ initialReason = "callable" }: Props) {
   const OUTCOME_TOTAL_H = OUTCOME_H * 2 + OUTCOME_GAP;
   const HEIGHT = OUTCOME_Y + OUTCOME_TOTAL_H + 14;
 
+  const canvasNode = (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      style={{
+        maxWidth: WIDTH,
+        height: "auto",
+        display: "block",
+        margin: "0 auto",
+      }}
+      role="img"
+      aria-label={`Reason: ${reason.label}. Counterfactual: ${reason.without.body} With pre-walk: ${reason.withIt.body}`}
+    >
+      {/* Snippet pane */}
+      <rect
+        x={PAD}
+        y={SNIPPET_Y}
+        width={WIDTH - PAD * 2}
+        height={SNIPPET_H}
+        rx={3}
+        fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
+        stroke="var(--color-rule)"
+        strokeWidth={1}
+      />
+      <text
+        x={PAD + 8}
+        y={SNIPPET_Y + 14}
+        fontFamily="var(--font-sans)"
+        fontSize={9}
+        letterSpacing="0.08em"
+        fill="var(--color-text-muted)"
+      >
+        SNIPPET
+      </text>
+      <motion.g
+        key={`snip-${reason.id}`}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING.smooth}
+      >
+        {reason.snippet.map((line, i) => (
+          <text
+            key={i}
+            x={PAD + 12}
+            y={SNIPPET_Y + 30 + i * 16}
+            fontFamily="var(--font-mono)"
+            fontSize={12}
+            fill="var(--color-text)"
+          >
+            <tspan
+              fontFamily="var(--font-mono)"
+              fontSize={10}
+              fill="var(--color-text-muted)"
+            >
+              {i + 1}
+            </tspan>
+            <tspan dx={10}>{line}</tspan>
+          </text>
+        ))}
+      </motion.g>
+
+      {/* "Without" outcome — drawn first, dimmer */}
+      <motion.g
+        key={`without-${reason.id}`}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING.smooth}
+      >
+        <rect
+          x={PAD}
+          y={OUTCOME_Y}
+          width={WIDTH - PAD * 2}
+          height={OUTCOME_H}
+          rx={3}
+          fill="transparent"
+          stroke="var(--color-text-muted)"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+        <text
+          x={PAD + 8}
+          y={OUTCOME_Y + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-text-muted)"
+        >
+          {reason.without.label.toUpperCase()}
+        </text>
+        <text
+          x={PAD + 12}
+          y={OUTCOME_Y + 36}
+          fontFamily="var(--font-sans)"
+          fontSize={11}
+          fill="var(--color-text-muted)"
+        >
+          {wrapText(reason.without.body, 44).map((line, i) => (
+            <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
+              {line}
+            </tspan>
+          ))}
+        </text>
+      </motion.g>
+
+      {/* "With" outcome — drawn second, accented */}
+      <motion.g
+        key={`with-${reason.id}`}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...SPRING.smooth, delay: 0.06 }}
+      >
+        <rect
+          x={PAD}
+          y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP}
+          width={WIDTH - PAD * 2}
+          height={OUTCOME_H}
+          rx={3}
+          fill="color-mix(in oklab, var(--color-accent) 12%, transparent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.4}
+        />
+        <text
+          x={PAD + 8}
+          y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 14}
+          fontFamily="var(--font-sans)"
+          fontSize={9}
+          letterSpacing="0.08em"
+          fill="var(--color-accent)"
+        >
+          {reason.withIt.label.toUpperCase()}
+        </text>
+        <text
+          x={PAD + 12}
+          y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 36}
+          fontFamily="var(--font-sans)"
+          fontSize={11}
+          fill="var(--color-text)"
+        >
+          {wrapText(reason.withIt.body, 44).map((line, i) => (
+            <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
+              {line}
+            </tspan>
+          ))}
+        </text>
+      </motion.g>
+    </svg>
+  );
+
   return (
     <WidgetShell
       title="two passes · why"
-      caption={reason.caption}
-      captionTone="prominent"
+      state={reason.caption}
+      canvas={canvasNode}
       controls={
         <div
           role="group"
@@ -175,153 +323,7 @@ export function WhyTwoPasses({ initialReason = "callable" }: Props) {
           })}
         </div>
       }
-    >
-      <svg
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        width="100%"
-        style={{
-          maxWidth: WIDTH,
-          height: "auto",
-          display: "block",
-          margin: "0 auto",
-        }}
-        role="img"
-        aria-label={`Reason: ${reason.label}. Counterfactual: ${reason.without.body} With pre-walk: ${reason.withIt.body}`}
-      >
-        {/* Snippet pane */}
-        <rect
-          x={PAD}
-          y={SNIPPET_Y}
-          width={WIDTH - PAD * 2}
-          height={SNIPPET_H}
-          rx={3}
-          fill="color-mix(in oklab, var(--color-surface) 35%, transparent)"
-          stroke="var(--color-rule)"
-          strokeWidth={1}
-        />
-        <text
-          x={PAD + 8}
-          y={SNIPPET_Y + 14}
-          fontFamily="var(--font-sans)"
-          fontSize={9}
-          letterSpacing="0.08em"
-          fill="var(--color-text-muted)"
-        >
-          SNIPPET
-        </text>
-        <motion.g
-          key={`snip-${reason.id}`}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING.smooth}
-        >
-          {reason.snippet.map((line, i) => (
-            <text
-              key={i}
-              x={PAD + 12}
-              y={SNIPPET_Y + 30 + i * 16}
-              fontFamily="var(--font-mono)"
-              fontSize={12}
-              fill="var(--color-text)"
-            >
-              <tspan
-                fontFamily="var(--font-mono)"
-                fontSize={10}
-                fill="var(--color-text-muted)"
-              >
-                {i + 1}
-              </tspan>
-              <tspan dx={10}>{line}</tspan>
-            </text>
-          ))}
-        </motion.g>
-
-        {/* "Without" outcome — drawn first, dimmer */}
-        <motion.g
-          key={`without-${reason.id}`}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING.smooth}
-        >
-          <rect
-            x={PAD}
-            y={OUTCOME_Y}
-            width={WIDTH - PAD * 2}
-            height={OUTCOME_H}
-            rx={3}
-            fill="transparent"
-            stroke="var(--color-text-muted)"
-            strokeWidth={1}
-            strokeDasharray="3 3"
-          />
-          <text
-            x={PAD + 8}
-            y={OUTCOME_Y + 14}
-            fontFamily="var(--font-sans)"
-            fontSize={9}
-            letterSpacing="0.08em"
-            fill="var(--color-text-muted)"
-          >
-            {reason.without.label.toUpperCase()}
-          </text>
-          <text
-            x={PAD + 12}
-            y={OUTCOME_Y + 36}
-            fontFamily="var(--font-sans)"
-            fontSize={11}
-            fill="var(--color-text-muted)"
-          >
-            {wrapText(reason.without.body, 44).map((line, i) => (
-              <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
-                {line}
-              </tspan>
-            ))}
-          </text>
-        </motion.g>
-
-        {/* "With" outcome — drawn second, accented */}
-        <motion.g
-          key={`with-${reason.id}`}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ ...SPRING.smooth, delay: 0.06 }}
-        >
-          <rect
-            x={PAD}
-            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP}
-            width={WIDTH - PAD * 2}
-            height={OUTCOME_H}
-            rx={3}
-            fill="color-mix(in oklab, var(--color-accent) 12%, transparent)"
-            stroke="var(--color-accent)"
-            strokeWidth={1.4}
-          />
-          <text
-            x={PAD + 8}
-            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 14}
-            fontFamily="var(--font-sans)"
-            fontSize={9}
-            letterSpacing="0.08em"
-            fill="var(--color-accent)"
-          >
-            {reason.withIt.label.toUpperCase()}
-          </text>
-          <text
-            x={PAD + 12}
-            y={OUTCOME_Y + OUTCOME_H + OUTCOME_GAP + 36}
-            fontFamily="var(--font-sans)"
-            fontSize={11}
-            fill="var(--color-text)"
-          >
-            {wrapText(reason.withIt.body, 44).map((line, i) => (
-              <tspan key={i} x={PAD + 12} dy={i === 0 ? 0 : 14}>
-                {line}
-              </tspan>
-            ))}
-          </text>
-        </motion.g>
-      </svg>
-    </WidgetShell>
+    />
   );
 }
 

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/OriginMatrix.tsx
@@ -107,26 +107,38 @@ export function OriginMatrix() {
       : "var(--color-accent)"
     : "var(--color-text-muted)";
 
+  const stateNode = row ? (
+    <span aria-live="off">
+      <span style={{ color: tone, fontWeight: 500 }}>{decision}</span>
+      {" — "}
+      {row.caption}
+    </span>
+  ) : (
+    <span>
+      Tap any row. Terracotta marks the part that shifts the URL out of your
+      origin.
+    </span>
+  );
+
   return (
     <WidgetShell
       title="origin · scheme · host · port"
       measurements={`base · ${BASE.url}`}
-      captionTone="prominent"
-      caption={
-        row ? (
-          <span aria-live="off">
-            <span style={{ color: tone, fontWeight: 500 }}>{decision}</span>
-            {" — "}
-            {row.caption}
-          </span>
-        ) : (
-          <span>
-            Tap any row. Terracotta marks the part that shifts the URL out of
-            your origin.
-          </span>
-        )
-      }
-    >
+      state={stateNode}
+      canvas={<OriginMatrixCanvas focused={focused} setFocused={setFocused} />}
+    />
+  );
+}
+
+function OriginMatrixCanvas({
+  focused,
+  setFocused,
+}: {
+  focused: number;
+  setFocused: (i: number) => void;
+}) {
+  return (
+    <>
       {/* Mobile-first: stacked list of cards. Each card = url on its own line,
           a one-line scheme/host/port/path diff string with the differing piece
           in terracotta, and a verdict pill on the right. The full caption
@@ -370,6 +382,6 @@ export function OriginMatrix() {
           })}
         </tbody>
       </table>
-    </WidgetShell>
+    </>
   );
 }

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestClassifier.tsx
@@ -128,98 +128,96 @@ export function RequestClassifier({
         ? "Sent directly — but cookies only ride if the response carries Allow-Credentials: true and a named origin (no wildcard)."
         : "Safelisted. The request goes straight out; only the response is gated.";
 
-  return (
-    <WidgetShell
-      title="preflight classifier · request shape decides"
-      measurements={measurements}
-      captionTone="prominent"
-      caption={caption}
+  const controlsNode = (
+    <div
+      className="grid w-full gap-[var(--spacing-sm)]"
+      style={{ gridTemplateColumns: "minmax(0, 1fr)" }}
     >
-      {/* Fixed-frame grid: every row reserves its maximum height upfront so the
-          container never resizes when verdict / reasons / preflight panel
-          change. All transitions are color-, opacity-, or transform-only.
-          R6 hard-rule compliance. */}
-      <div
-        className="grid"
-        style={{
-          gap: "var(--spacing-md)",
-          gridTemplateRows: "auto auto auto",
+      <SegmentedRow
+        label="method"
+        options={METHODS}
+        value={method}
+        onChange={(v) => {
+          touch();
+          setMethod(v);
         }}
+      />
+      <SegmentedRow
+        label="Content-Type"
+        options={CONTENT_TYPES}
+        value={contentType}
+        onChange={(v) => {
+          touch();
+          setContentType(v);
+        }}
+        disabled={ctDisabled}
+        disabledHint={ctDisabled ? "(no body on this method)" : undefined}
+      />
+      <div
+        className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+        style={{ fontSize: "var(--text-ui)" }}
       >
-        {/* Row A — controls */}
-        <div className="grid gap-[var(--spacing-sm)]" style={{ gridTemplateColumns: "minmax(0, 1fr)" }}>
-          <SegmentedRow
-            label="method"
-            options={METHODS}
-            value={method}
-            onChange={(v) => {
+        <span
+          className="bs-classifier-label font-mono"
+          style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
+        >
+          extra headers
+        </span>
+        <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
+          <Toggle
+            label="Authorization"
+            pressed={auth}
+            onToggle={() => {
               touch();
-              setMethod(v);
+              setAuth((v) => !v);
             }}
           />
-          <SegmentedRow
-            label="Content-Type"
-            options={CONTENT_TYPES}
-            value={contentType}
-            onChange={(v) => {
+          <Toggle
+            label="X-Custom"
+            pressed={custom}
+            onToggle={() => {
               touch();
-              setContentType(v);
+              setCustom((v) => !v);
             }}
-            disabled={ctDisabled}
-            disabledHint={ctDisabled ? "(no body on this method)" : undefined}
           />
-          <div
-            className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
-            style={{ fontSize: "var(--text-ui)" }}
-          >
-            <span
-              className="bs-classifier-label font-mono"
-              style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
-            >
-              extra headers
-            </span>
-            <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
-              <Toggle
-                label="Authorization"
-                pressed={auth}
-                onToggle={() => {
-                  touch();
-                  setAuth((v) => !v);
-                }}
-              />
-              <Toggle
-                label="X-Custom"
-                pressed={custom}
-                onToggle={() => {
-                  touch();
-                  setCustom((v) => !v);
-                }}
-              />
-            </div>
-          </div>
-          <div
-            className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
-            style={{ fontSize: "var(--text-ui)" }}
-          >
-            <span
-              className="bs-classifier-label font-mono"
-              style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
-            >
-              credentials
-            </span>
-            <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
-              <CredentialsSwitch
-                value={credentials}
-                onChange={(v) => {
-                  touch();
-                  setCredentials(v);
-                }}
-              />
-            </div>
-          </div>
         </div>
+      </div>
+      <div
+        className="bs-classifier-row flex items-center gap-[var(--spacing-md)] flex-wrap font-sans"
+        style={{ fontSize: "var(--text-ui)" }}
+      >
+        <span
+          className="bs-classifier-label font-mono"
+          style={{ color: "var(--color-text-muted)", minWidth: "12ch" }}
+        >
+          credentials
+        </span>
+        <div className="bs-classifier-options flex items-center gap-[var(--spacing-2xs)] flex-wrap">
+          <CredentialsSwitch
+            value={credentials}
+            onChange={(v) => {
+              touch();
+              setCredentials(v);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
 
-        {/* Row B — verdict pill + reasons.
+  const canvasNode = (
+    /* Fixed-frame grid: every row reserves its maximum height upfront so the
+       container never resizes when verdict / reasons / preflight panel
+       change. All transitions are color-, opacity-, or transform-only.
+       R6 hard-rule compliance. */
+    <div
+      className="grid"
+      style={{
+        gap: "var(--spacing-md)",
+        gridTemplateRows: "auto auto",
+      }}
+    >
+      {/* Row A — verdict pill + reasons.
             Reserves space for up-to-five reasons so list growth is opacity-only. */}
         <div
           className="rounded-[var(--radius-sm)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
@@ -314,7 +312,16 @@ export function RequestClassifier({
           />
         </div>
       </div>
-    </WidgetShell>
+  );
+
+  return (
+    <WidgetShell
+      title="preflight classifier · request shape decides"
+      measurements={measurements}
+      state={caption}
+      canvas={canvasNode}
+      controls={controlsNode}
+    />
   );
 }
 

--- a/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/widgets/RequestJourney.tsx
@@ -97,8 +97,8 @@ export function RequestJourney({
     <WidgetShell
       title="request journey · the browser is the gatekeeper"
       measurements={`allow-origin ${allow ? "sent" : "missing"}`}
-      captionTone="prominent"
-      caption={current.caption(allow)}
+      state={current.caption(allow)}
+      canvas={<Journey step={step} allow={allow} current={current} />}
       controls={
         <div className="flex items-center justify-center gap-[var(--spacing-md)] flex-wrap w-full">
           <WidgetNav value={step} total={STEPS.length} onChange={setStep} />
@@ -123,9 +123,7 @@ export function RequestJourney({
           </motion.button>
         </div>
       }
-    >
-      <Journey step={step} allow={allow} current={current} />
-    </WidgetShell>
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Phase 2 batch 3 of the typography + widget revamp ([Phase 1 PR #88](https://github.com/iamartyaa/lainlog/pull/88)). Migrates every widget in two posts from the legacy `children` + `caption`/`captionTone` API to the strict-slot WidgetShell API (`title` / `canvas` / `state` / `controls`).

## Posts and widgets migrated

**`app/posts/why-fetch-fails-only-in-browser/`**
- `OriginMatrix` — tappable rows; no controls slot (rule allows it).
- `RequestClassifier` — radio chips lifted into the controls slot; verdict pill + preflight detail panel stay in the canvas slot.
- `RequestJourney` — `WidgetNav` + Allow-Origin pill in controls; SVG lane-pair in canvas.

**`app/posts/how-javascript-reads-its-own-future/`**
- `CallStackECs` — in-board controls cluster lifted to shell-level controls slot. Desktop two-column grid simplified (code | stack-viz; console full-width row 2). Per-region min-heights for the 240/256/88px reservations preserved.
- `CreationVsExecution` — Scrubber controls; SVG time-track + source/memory panes in canvas.
- `DeclarationStates` — segmented chips controls; SVG snippet+memory pane in canvas.
- `WhyTwoPasses` — segmented chips controls; SVG snippet + counterfactual outcomes in canvas.

## Exemptions

- **`OriginMatrix` viewport-flip** — the mobile stack-list ↔ desktop table flip happens at a `@container` breakpoint (viewport-driven, not interaction-driven). Per the layout-contract rule "stable per viewport", this is allowed and not flattened.
- **`ClosingDot` inline-prose** — typographic dot embedded inline in the closer paragraph. Codified exemption in `docs/interactive-components.md` §0. Not migrated to `WidgetShell`; left untouched.

## Frame-stability findings

Every widget audited step-by-step. None exhibit interaction-driven height jumps within a viewport — all already pin the canvas-internal regions (or render fixed-`viewBox` SVGs whose height is intrinsic to aspect ratio). No new `min-height` declarations were needed; the Phase 1 in-canvas reservations carry the contract.

## Validation

- [x] `npx tsc --noEmit` clean (only pre-existing `@web-kits/audio` resolution warnings, unchanged vs origin/main).
- [x] `pnpm lint` — no new errors vs origin/main (delta = 0; identical pre-existing react-hooks/set-state-in-effect count of 17).
- [x] `pnpm build` clean — both posts in the static-prerender list.
- [x] `pnpm dev` on port 3012 — `/posts/how-javascript-reads-its-own-future` and `/posts/why-fetch-fails-only-in-browser` both return 200.
- [x] `grep -r "from \"./WidgetShell\"" app/posts/why-fetch-fails-only-in-browser app/posts/how-javascript-reads-its-own-future` returns zero hits.
- [x] No remaining `caption=` / `captionTone=` props on any `<WidgetShell>` callsite in either post.

## Coordination

Disjoint post directories from the parallel batches (1 and 2). Shared `components/viz/WidgetShell.tsx` was READ-ONLY for this batch — no defects discovered.

## Test plan

- [ ] Reviewer drives each migrated widget through every step at 375px / 768px / 1280px and confirms the outer frame is stable.
- [ ] `CallStackECs` desktop layout reads correctly with controls below the board.
- [ ] State captions render in body-strong with the rotated terracotta marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)