### PR TITLE
feat(ui): migrate batch 1 widgets to new WidgetShell contract

### DIFF
--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/CacheWalk.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/CacheWalk.tsx
@@ -245,12 +245,11 @@ export function CacheWalk({
   return (
     <WidgetShell
       title="cache walk · pick a locality"
-      caption={resolved.caption}
-      captionTone="prominent"
+      state={resolved.caption}
       controls={
         <WidgetNav value={clamped} total={total} onChange={handleStep} />
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -473,6 +472,7 @@ export function CacheWalk({
           </text>
         </motion.g>
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/HashLane.tsx
@@ -120,10 +120,9 @@ export function HashLane({ m = 16, script = DEFAULT_SCRIPT, initialStep = 0 }: P
     <WidgetShell
       title={`bloom · ${current.kind} "${current.key}"`}
       measurements={measurements}
-      caption={current.caption}
-      captionTone="prominent"
+      state={current.caption}
       controls={<WidgetNav value={step} total={script.length} onChange={setStep} />}
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -240,7 +239,8 @@ export function HashLane({ m = 16, script = DEFAULT_SCRIPT, initialStep = 0 }: P
           </motion.text>
         ) : null}
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }
 

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/NetflixSplit.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/NetflixSplit.tsx
@@ -44,7 +44,7 @@ export function NetflixSplit() {
     <WidgetShell
       title="netflix vs gmail · same address, two accounts"
       measurements={`variant: ${input.label}`}
-      caption={
+      state={
         <>
           Gmail folds every variant down to{" "}
           <span className="font-mono">{CANONICAL}</span> — one inbox, one
@@ -85,7 +85,7 @@ export function NetflixSplit() {
           })}
         </div>
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -310,6 +310,7 @@ export function NetflixSplit() {
           <tspan fill="var(--color-accent)">{CANONICAL}</tspan>
         </text>
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormaliseWalk.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/NormaliseWalk.tsx
@@ -60,12 +60,11 @@ export function NormaliseWalk({ initialStep = 0 }: Props) {
   return (
     <WidgetShell
       title="normalise walk · three steps"
-      caption={stepCaption}
-      captionTone="prominent"
+      state={stepCaption}
       controls={
         <WidgetNav value={clamped} total={TOTAL} onChange={setStep} />
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -236,6 +235,7 @@ export function NormaliseWalk({ initialStep = 0 }: Props) {
           opacity={0.5}
         />
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceMargin.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceMargin.tsx
@@ -144,8 +144,7 @@ export function RaceMargin({
     <WidgetShell
       title="race · margin"
       measurements={measurements}
-      captionTone="prominent"
-      caption={
+      state={
         <>
           Drag either handle. Both clients always see{" "}
           <span className="font-mono">available</span> while typing — only{" "}
@@ -175,7 +174,7 @@ export function RaceMargin({
           />
         </div>
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -254,6 +253,7 @@ export function RaceMargin({
           exact tie — A wins by stable order
         </motion.text>
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceVerdict.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/RaceVerdict.tsx
@@ -208,8 +208,7 @@ export function RaceVerdict({ initialStep = 0 }: Props) {
   return (
     <WidgetShell
       title="race · verdict"
-      caption={tick.caption}
-      captionTone="prominent"
+      state={tick.caption}
       controls={
         <WidgetNav
           value={clamped}
@@ -220,7 +219,7 @@ export function RaceVerdict({ initialStep = 0 }: Props) {
           counterNoun="tick"
         />
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -415,6 +414,7 @@ export function RaceVerdict({ initialStep = 0 }: Props) {
           </motion.g>
         </g>
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/how-gmail-knows-your-email-is-taken/widgets/TypingPause.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/widgets/TypingPause.tsx
@@ -135,7 +135,7 @@ export function TypingPause() {
               ? "typing · timer paused"
               : "idle"
       }
-      caption={
+      state={
         phase === "idle"
           ? "Tap play to type a sample address. The check fires only after you stop."
           : phase === "typing"
@@ -177,7 +177,7 @@ export function TypingPause() {
           </motion.button>
         </div>
       }
-    >
+      canvas={
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         width="100%"
@@ -291,6 +291,7 @@ export function TypingPause() {
           {fireOn ? `request → server : "${SAMPLE}"` : "request not fired yet"}
         </text>
       </svg>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/CostMatrix.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/CostMatrix.tsx
@@ -86,8 +86,7 @@ export function CostMatrix() {
     <WidgetShell
       title="where the cost reappears"
       measurements={focus ? `focus · ${focus.label}` : "3 modes · 4 protocols"}
-      captionTone="prominent"
-      caption={
+      state={
         <AnimatePresence mode="wait">
           <motion.span
             key={focus?.key ?? "none"}
@@ -115,8 +114,9 @@ export function CostMatrix() {
           </motion.span>
         </AnimatePresence>
       }
-    >
-      <div className="bs-cm">
+      canvas={
+        <>
+        <div className="bs-cm">
         {/* header row with protocol names */}
         <div className="bs-cm-header">
           <span />
@@ -251,7 +251,9 @@ export function CostMatrix() {
           }
         }
       `}</style>
-    </WidgetShell>
+        </>
+      }
+    />
   );
 }
 

--- a/app/posts/the-browser-stopped-asking/widgets/DropTiming.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/DropTiming.tsx
@@ -53,8 +53,7 @@ export function DropTiming() {
     <WidgetShell
       title="dropout · which side of the cliff"
       measurements={`WS lost: ${wsLost} · SSE replayed: ${sseReplayed}`}
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -68,6 +67,30 @@ export function DropTiming() {
           cliff; SSE replays them all when the connection heals.
         </>
       }
+      canvas={
+        <>
+          <div className="bs-rg-narrow">
+            <MemoTwoRowCanvas
+              classified={classified}
+              dropAt={dropAt}
+              dropEnd={dropEnd}
+              lastSseId={lastSseId}
+              variant="narrow"
+              scrubbedEdge="left"
+            />
+          </div>
+          <div className="bs-rg-wide">
+            <MemoTwoRowCanvas
+              classified={classified}
+              dropAt={dropAt}
+              dropEnd={dropEnd}
+              lastSseId={lastSseId}
+              variant="wide"
+              scrubbedEdge="left"
+            />
+          </div>
+        </>
+      }
       controls={
         <Scrubber
           label="drop@"
@@ -79,27 +102,6 @@ export function DropTiming() {
           format={(v) => `${(v / 1000).toFixed(1)}s`}
         />
       }
-    >
-      <div className="bs-rg-narrow">
-        <MemoTwoRowCanvas
-          classified={classified}
-          dropAt={dropAt}
-          dropEnd={dropEnd}
-          lastSseId={lastSseId}
-          variant="narrow"
-          scrubbedEdge="left"
-        />
-      </div>
-      <div className="bs-rg-wide">
-        <MemoTwoRowCanvas
-          classified={classified}
-          dropAt={dropAt}
-          dropEnd={dropEnd}
-          lastSseId={lastSseId}
-          variant="wide"
-          scrubbedEdge="left"
-        />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/GapDuration.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/GapDuration.tsx
@@ -62,8 +62,7 @@ export function GapDuration() {
     <WidgetShell
       title="gap length · how much SSE has to replay"
       measurements={`gap: ${(dropMs / 1000).toFixed(1)}s · ${replayLabel}`}
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -77,6 +76,30 @@ export function GapDuration() {
           WebSocket&apos;s loss count grows too — nothing comes back.
         </>
       }
+      canvas={
+        <>
+          <div className="bs-rg-narrow">
+            <MemoTwoRowCanvas
+              classified={classified}
+              dropAt={FIXED_DROP_AT_MS}
+              dropEnd={dropEnd}
+              lastSseId={lastSseId}
+              variant="narrow"
+              scrubbedEdge="right"
+            />
+          </div>
+          <div className="bs-rg-wide">
+            <MemoTwoRowCanvas
+              classified={classified}
+              dropAt={FIXED_DROP_AT_MS}
+              dropEnd={dropEnd}
+              lastSseId={lastSseId}
+              variant="wide"
+              scrubbedEdge="right"
+            />
+          </div>
+        </>
+      }
       controls={
         <Scrubber
           label="for"
@@ -88,27 +111,6 @@ export function GapDuration() {
           format={(v) => `${(v / 1000).toFixed(1)}s`}
         />
       }
-    >
-      <div className="bs-rg-narrow">
-        <MemoTwoRowCanvas
-          classified={classified}
-          dropAt={FIXED_DROP_AT_MS}
-          dropEnd={dropEnd}
-          lastSseId={lastSseId}
-          variant="narrow"
-          scrubbedEdge="right"
-        />
-      </div>
-      <div className="bs-rg-wide">
-        <MemoTwoRowCanvas
-          classified={classified}
-          dropAt={FIXED_DROP_AT_MS}
-          dropEnd={dropEnd}
-          lastSseId={lastSseId}
-          variant="wide"
-          scrubbedEdge="right"
-        />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/HandshakeSteps.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/HandshakeSteps.tsx
@@ -67,20 +67,22 @@ export function HandshakeSteps() {
     <WidgetShell
       title="the 3-step upgrade"
       measurements="RFC 6455 §1.3 sample"
-      caption={CAPTIONS[step]}
-      captionTone="prominent"
+      state={CAPTIONS[step]}
+      canvas={
+        <>
+          <div className="bs-uh-narrow">
+            <MemoStepsCanvasNarrow step={step} computed={SPEC_SAMPLE} />
+          </div>
+          <div className="bs-uh-wide">
+            <MemoStepsCanvasWide step={step} computed={SPEC_SAMPLE} />
+          </div>
+        </>
+      }
       controls={
         <div className="flex items-center justify-center w-full">
           <WidgetNav value={step} total={3} onChange={setStep} />
         </div>
       }
-    >
-      <div className="bs-uh-narrow">
-        <MemoStepsCanvasNarrow step={step} computed={SPEC_SAMPLE} />
-      </div>
-      <div className="bs-uh-wide">
-        <MemoStepsCanvasWide step={step} computed={SPEC_SAMPLE} />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/KeyDerivation.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/KeyDerivation.tsx
@@ -71,8 +71,7 @@ export function KeyDerivation() {
     <WidgetShell
       title="your browser does the SHA-1"
       measurements={measurements}
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -86,6 +85,7 @@ export function KeyDerivation() {
           and runs the SHA-1. Nothing in the reveal is precomputed.
         </>
       }
+      canvas={<KeyDerivationCanvas computed={computed} />}
       controls={
         <div className="flex items-center justify-center w-full">
           <motion.button
@@ -106,9 +106,7 @@ export function KeyDerivation() {
           </motion.button>
         </div>
       }
-    >
-      <KeyDerivationCanvas computed={computed} />
-    </WidgetShell>
+    />
   );
 }
 

--- a/app/posts/the-browser-stopped-asking/widgets/LongPoll.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/LongPoll.tsx
@@ -39,8 +39,7 @@ export function LongPoll() {
           ? `${sim.stats.reqs} requests · ${(sim.stats.bytesSent / 1000).toFixed(1)} KB · max Δ ${sim.stats.worstLatencyMs} ms`
           : `t = ${(nowMs / 1000).toFixed(1)}s of ${DURATION_MS / 1000}s`
       }
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -52,6 +51,26 @@ export function LongPoll() {
           </TextHighlighter>{" "}
           and watch three requests cover the same three events. The held
           spans are the server choosing not to reply yet.
+        </>
+      }
+      canvas={
+        <>
+          <div className="bs-pc-narrow">
+            <ProtocolCanvas
+              protocol="longpoll"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={340}
+            />
+          </div>
+          <div className="bs-pc-wide">
+            <ProtocolCanvas
+              protocol="longpoll"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={680}
+            />
+          </div>
         </>
       }
       controls={
@@ -74,23 +93,6 @@ export function LongPoll() {
           <StatLine protocol="longpoll" stats={sim.stats} />
         </div>
       }
-    >
-      <div className="bs-pc-narrow">
-        <ProtocolCanvas
-          protocol="longpoll"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={340}
-        />
-      </div>
-      <div className="bs-pc-wide">
-        <ProtocolCanvas
-          protocol="longpoll"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={680}
-        />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/Polling.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/Polling.tsx
@@ -37,8 +37,7 @@ export function Polling() {
           ? `${sim.stats.reqs} polls · ${(sim.stats.bytesSent / 1000).toFixed(1)} KB · max Δ ${sim.stats.worstLatencyMs} ms`
           : `t = ${(nowMs / 1000).toFixed(1)}s of ${DURATION_MS / 1000}s`
       }
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -50,6 +49,26 @@ export function Polling() {
           </TextHighlighter>{" "}
           and watch sixty requests carry three pieces of news. Most replies
           carry nothing.
+        </>
+      }
+      canvas={
+        <>
+          <div className="bs-pc-narrow">
+            <ProtocolCanvas
+              protocol="polling"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={340}
+            />
+          </div>
+          <div className="bs-pc-wide">
+            <ProtocolCanvas
+              protocol="polling"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={680}
+            />
+          </div>
         </>
       }
       controls={
@@ -72,23 +91,6 @@ export function Polling() {
           <StatLine protocol="polling" stats={sim.stats} />
         </div>
       }
-    >
-      <div className="bs-pc-narrow">
-        <ProtocolCanvas
-          protocol="polling"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={340}
-        />
-      </div>
-      <div className="bs-pc-wide">
-        <ProtocolCanvas
-          protocol="polling"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={680}
-        />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-browser-stopped-asking/widgets/WebSocketStream.tsx
+++ b/app/posts/the-browser-stopped-asking/widgets/WebSocketStream.tsx
@@ -38,8 +38,7 @@ export function WebSocketStream() {
           ? `${sim.stats.eventsDelivered} frames · ${sim.stats.bytesSent} B · max Δ ${sim.stats.worstLatencyMs} ms`
           : `t = ${(nowMs / 1000).toFixed(1)}s of ${DURATION_MS / 1000}s`
       }
-      captionTone="prominent"
-      caption={
+      state={
         <>
           <TextHighlighter
             triggerType="auto"
@@ -51,6 +50,26 @@ export function WebSocketStream() {
           </TextHighlighter>{" "}
           and watch the handshake finish, then three frames ride the open
           socket. No more requests after the first.
+        </>
+      }
+      canvas={
+        <>
+          <div className="bs-pc-narrow">
+            <ProtocolCanvas
+              protocol="websocket"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={340}
+            />
+          </div>
+          <div className="bs-pc-wide">
+            <ProtocolCanvas
+              protocol="websocket"
+              sim={sim}
+              nowMs={nowMs}
+              authoredWidth={680}
+            />
+          </div>
         </>
       }
       controls={
@@ -73,23 +92,6 @@ export function WebSocketStream() {
           <StatLine protocol="websocket" stats={sim.stats} />
         </div>
       }
-    >
-      <div className="bs-pc-narrow">
-        <ProtocolCanvas
-          protocol="websocket"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={340}
-        />
-      </div>
-      <div className="bs-pc-wide">
-        <ProtocolCanvas
-          protocol="websocket"
-          sim={sim}
-          nowMs={nowMs}
-          authoredWidth={680}
-        />
-      </div>
-    </WidgetShell>
+    />
   );
 }

--- a/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/AwaitDesugar.tsx
@@ -264,8 +264,7 @@ export function AwaitDesugar() {
     <WidgetShell
       title="await · the .then in disguise"
       measurements={`step ${step + 1} / ${STEPS.length}`}
-      caption={tick.caption}
-      captionTone="prominent"
+      state={tick.caption}
       controls={
         <div className="flex items-center justify-center w-full">
           <WidgetNav
@@ -276,7 +275,7 @@ export function AwaitDesugar() {
           />
         </div>
       }
-    >
+      canvas={
       <div
         className="grid gap-[var(--spacing-md)]"
         style={{
@@ -317,6 +316,7 @@ export function AwaitDesugar() {
           `}</style>
         </div>
       </div>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/MicrotaskStarvation.tsx
@@ -295,7 +295,7 @@ export function MicrotaskStarvation() {
     <WidgetShell
       title="queue race · microtasks vs macrotasks"
       measurements={`tick ${tick} · output ${output.length}`}
-      caption={
+      state={
         starved ? (
           <>
             <CaptionCue>Microtask starvation.</CaptionCue> Each fired microtask
@@ -320,8 +320,7 @@ export function MicrotaskStarvation() {
           </>
         )
       }
-      captionTone="prominent"
-    >
+      canvas={
       <div className="bs-qrace">
         {/* Tick counter strip — fixed height, aria-live announces ticks. */}
         <div
@@ -369,146 +368,156 @@ export function MicrotaskStarvation() {
           <ConsolePane lines={output} />
         </div>
 
-        {/* Controls strip. Tap targets ≥ 44px; flex-wrap only as last resort
-            — at 360 px the row stays single via short labels. */}
-        <div
-          className="bs-qrace-controls"
-          role="group"
-          aria-label="Queue controls"
-        >
-          <CtrlBtn onClick={addMicro} disabled={running} kind="accent">
-            <span aria-hidden>+</span>
-            <span>micro</span>
-          </CtrlBtn>
-          <CtrlBtn onClick={addMacro} disabled={running} kind="muted">
-            <span aria-hidden>+</span>
-            <span>macro</span>
-          </CtrlBtn>
-          <div className="bs-qrace-self-wrap">
-            <CtrlBtn
-              onClick={addSelf}
-              disabled={running}
-              kind="dashed"
-              ariaLabel="add a self-scheduling microtask"
-            >
-              <span aria-hidden>↻</span>
-              <span>self-sched</span>
-            </CtrlBtn>
-            <AnimatePresence>
-              {selfHintVisible ? (
-                <motion.div
-                  key="hint"
-                  className="bs-qrace-hint"
-                  initial={
-                    reduce ? { opacity: 0 } : { opacity: 0, y: -4 }
-                  }
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0 }}
-                  transition={reduce ? { duration: 0 } : SPRING.smooth}
-                  role="note"
-                >
-                  This microtask schedules another microtask. Hit Run — the
-                  queue never empties.
-                </motion.div>
-              ) : null}
-            </AnimatePresence>
-          </div>
-          <CtrlBtn
-            onClick={run}
-            disabled={!canRun}
-            kind="primary"
-            ariaLabel={running ? "running" : "run one tick"}
-          >
-            {running ? "running…" : "Run ▸"}
-          </CtrlBtn>
-          <CtrlBtn onClick={reset} kind="ghost" ariaLabel="reset queues">
-            reset
-          </CtrlBtn>
-        </div>
-
-        <p className="bs-qrace-rule">
-          Run = drain <em>all</em> microtasks, then <em>one</em> macrotask, then
-          repeat.
-        </p>
-      </div>
-
-      <style>{`
-        .bs-qrace {
-          display: flex;
-          flex-direction: column;
-          gap: var(--spacing-sm);
-        }
-        .bs-qrace-tick {
-          min-height: 24px;
-          line-height: 24px;
-          font-size: 12px;
-          letter-spacing: 0.02em;
-          padding: 0 2px;
-        }
-        .bs-qrace-body {
-          display: grid;
-          grid-template-columns: 1fr;
-          gap: var(--spacing-sm);
-        }
-        .bs-qrace-queues {
-          display: flex;
-          flex-direction: column;
-          gap: var(--spacing-sm);
-        }
-        .bs-qrace-controls {
-          display: flex;
-          flex-wrap: wrap;
-          align-items: center;
-          gap: 6px;
-          padding-top: 4px;
-        }
-        .bs-qrace-self-wrap {
-          position: relative;
-          display: inline-flex;
-        }
-        .bs-qrace-hint {
-          position: absolute;
-          left: 0;
-          top: calc(100% + 6px);
-          z-index: 2;
-          width: max-content;
-          max-width: 240px;
-          padding: 6px 10px;
-          font-family: var(--font-sans);
-          font-size: 11px;
-          line-height: 1.4;
-          color: var(--color-text);
-          background: var(--color-surface);
-          border: 1px solid var(--color-accent);
-          border-radius: var(--radius-sm);
-        }
-        .bs-qrace-hint::before {
-          content: "";
-          position: absolute;
-          top: -5px;
-          left: 18px;
-          width: 8px;
-          height: 8px;
-          background: var(--color-surface);
-          border-top: 1px solid var(--color-accent);
-          border-left: 1px solid var(--color-accent);
-          transform: rotate(45deg);
-        }
-        .bs-qrace-rule {
-          font-family: var(--font-sans);
-          font-size: 11px;
-          color: var(--color-text-muted);
-          text-align: center;
-          margin: 2px 0 0 0;
-          line-height: 1.5;
-        }
-        @container widget (min-width: 720px) {
-          .bs-qrace-body {
-            grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        <style>{`
+          .bs-qrace {
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-sm);
           }
-        }
-      `}</style>
-    </WidgetShell>
+          .bs-qrace-tick {
+            min-height: 24px;
+            line-height: 24px;
+            font-size: 12px;
+            letter-spacing: 0.02em;
+            padding: 0 2px;
+          }
+          .bs-qrace-body {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--spacing-sm);
+          }
+          .bs-qrace-queues {
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-sm);
+          }
+          .bs-qrace-controls-wrap {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            width: 100%;
+          }
+          .bs-qrace-controls {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+          }
+          .bs-qrace-self-wrap {
+            position: relative;
+            display: inline-flex;
+          }
+          .bs-qrace-hint {
+            position: absolute;
+            left: 0;
+            top: calc(100% + 6px);
+            z-index: 2;
+            width: max-content;
+            max-width: 240px;
+            padding: 6px 10px;
+            font-family: var(--font-sans);
+            font-size: 11px;
+            line-height: 1.4;
+            color: var(--color-text);
+            background: var(--color-surface);
+            border: 1px solid var(--color-accent);
+            border-radius: var(--radius-sm);
+          }
+          .bs-qrace-hint::before {
+            content: "";
+            position: absolute;
+            top: -5px;
+            left: 18px;
+            width: 8px;
+            height: 8px;
+            background: var(--color-surface);
+            border-top: 1px solid var(--color-accent);
+            border-left: 1px solid var(--color-accent);
+            transform: rotate(45deg);
+          }
+          .bs-qrace-rule {
+            font-family: var(--font-sans);
+            font-size: 11px;
+            color: var(--color-text-muted);
+            text-align: center;
+            margin: 0;
+            line-height: 1.5;
+          }
+          @container widget (min-width: 720px) {
+            .bs-qrace-body {
+              grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+            }
+          }
+        `}</style>
+      </div>
+      }
+      controls={
+        <div className="bs-qrace-controls-wrap">
+          {/* Controls strip. Tap targets ≥ 44px; flex-wrap only as last resort
+              — at 360 px the row stays single via short labels. */}
+          <div
+            className="bs-qrace-controls"
+            role="group"
+            aria-label="Queue controls"
+          >
+            <CtrlBtn onClick={addMicro} disabled={running} kind="accent">
+              <span aria-hidden>+</span>
+              <span>micro</span>
+            </CtrlBtn>
+            <CtrlBtn onClick={addMacro} disabled={running} kind="muted">
+              <span aria-hidden>+</span>
+              <span>macro</span>
+            </CtrlBtn>
+            <div className="bs-qrace-self-wrap">
+              <CtrlBtn
+                onClick={addSelf}
+                disabled={running}
+                kind="dashed"
+                ariaLabel="add a self-scheduling microtask"
+              >
+                <span aria-hidden>↻</span>
+                <span>self-sched</span>
+              </CtrlBtn>
+              <AnimatePresence>
+                {selfHintVisible ? (
+                  <motion.div
+                    key="hint"
+                    className="bs-qrace-hint"
+                    initial={
+                      reduce ? { opacity: 0 } : { opacity: 0, y: -4 }
+                    }
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0 }}
+                    transition={reduce ? { duration: 0 } : SPRING.smooth}
+                    role="note"
+                  >
+                    This microtask schedules another microtask. Hit Run — the
+                    queue never empties.
+                  </motion.div>
+                ) : null}
+              </AnimatePresence>
+            </div>
+            <CtrlBtn
+              onClick={run}
+              disabled={!canRun}
+              kind="primary"
+              ariaLabel={running ? "running" : "run one tick"}
+            >
+              {running ? "running…" : "Run ▸"}
+            </CtrlBtn>
+            <CtrlBtn onClick={reset} kind="ghost" ariaLabel="reset queues">
+              reset
+            </CtrlBtn>
+          </div>
+
+          <p className="bs-qrace-rule">
+            Run = drain <em>all</em> microtasks, then <em>one</em> macrotask, then
+            repeat.
+          </p>
+        </div>
+      }
+    />
   );
 }
 

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheOutput.tsx
@@ -237,7 +237,7 @@ export function PredictTheOutput({ codeSlots }: Props) {
     <WidgetShell
       title="predict the output"
       measurements={variant.label}
-      caption={
+      state={
         answered ? (
           <>
             <CaptionCue>Revealed.</CaptionCue> {variant.revealNote}
@@ -249,8 +249,7 @@ export function PredictTheOutput({ codeSlots }: Props) {
           </>
         )
       }
-      captionTone="prominent"
-    >
+      canvas={
       <div className="flex flex-col gap-[var(--spacing-sm)]">
         {/* Variant chooser — segmented control above the canvas. */}
         <div
@@ -316,6 +315,7 @@ export function PredictTheOutput({ codeSlots }: Props) {
           randomize
         />
       </div>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/PredictTheStart.tsx
@@ -113,7 +113,7 @@ export function PredictTheStart({ codeSlot }: Props) {
             ? "got it"
             : "most miss this"
       }
-      caption={
+      state={
         answered === null ? (
           <>
             <CaptionCue>Predict the output.</CaptionCue> Pick the order{" "}
@@ -136,8 +136,7 @@ export function PredictTheStart({ codeSlot }: Props) {
           </>
         )
       }
-      captionTone="prominent"
-    >
+      canvas={
       <div className="flex flex-col gap-[var(--spacing-sm)]">
         {codeSlot}
 
@@ -193,6 +192,7 @@ export function PredictTheStart({ codeSlot }: Props) {
           randomize
         />
       </div>
-    </WidgetShell>
+      }
+    />
   );
 }

--- a/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
+++ b/app/posts/the-line-that-waits-its-turn/widgets/RuntimeSimulator.tsx
@@ -670,8 +670,8 @@ export function RuntimeSimulator() {
     <WidgetShell
       title="runtime · scripted stepper"
       measurements={`tick ${step + 1} / ${TICKS.length}`}
-      caption={tick.caption}
-      captionTone="prominent"
+      state={tick.caption}
+      canvas={<MemoCanvas tick={tick} />}
       controls={
         <div className="flex items-center justify-center w-full">
           <WidgetNav
@@ -682,8 +682,6 @@ export function RuntimeSimulator() {
           />
         </div>
       }
-    >
-      <MemoCanvas tick={tick} />
-    </WidgetShell>
+    />
   );
 }


### PR DESCRIPTION
## Summary

Phase 2 batch 1 of the UI revamp (Phase 1 foundation: #88). Migrates 20 widgets across three posts from the legacy `<WidgetShell>{children}</WidgetShell>` + `caption` / `captionTone` API to the strict-slot API codified in Phase 1: **title → canvas → state → controls**.

- **Posts touched**: `the-browser-stopped-asking` (8 widgets), `how-gmail-knows-your-email-is-taken` (7 widgets), `the-line-that-waits-its-turn` (5 widgets).
- **Widgets migrated**: Polling, LongPoll, WebSocketStream, HandshakeSteps, KeyDerivation, CostMatrix, DropTiming, GapDuration, HashLane (BloomProbe rides through it), CacheWalk, NormaliseWalk, TypingPause, RaceMargin, RaceVerdict, NetflixSplit, RuntimeSimulator, PredictTheOutput, PredictTheStart, AwaitDesugar, MicrotaskStarvation.
- **Untouched** (helpers / primitives without WidgetShell): `_pipe-canvas.tsx`, `_pipe-sim.ts`, `_handshake-shared.tsx`, `_reconnect-shared.tsx`, `BitArray.tsx`, `BloomProbe.tsx` (thin wrapper around `HashLane`).

## Changes per widget

The migration is mechanical:

- `caption=…` prop → `state=…`
- `captionTone="prominent"` removed (the new contract is unconditionally prominent; the prop is still accepted by the shell as a deprecated compat hook but is now unused)
- JSX children inside `<WidgetShell>…</WidgetShell>` → `canvas={…}` slot
- Custom controls (`Polling` play button, `KeyDerivation` regenerate, `NetflixSplit` variant chooser, `TypingPause` button cluster, `MicrotaskStarvation` Run / +micro / +macro / self-sched / reset) sit in the `controls` slot at the bottom of the widget.

`MicrotaskStarvation` is the only widget that needed a structural lift: its `.bs-qrace-controls` cluster was previously inside the canvas tree alongside `.bs-qrace-body`. It now lives in the `controls` slot per the layout contract; the in-canvas legend (`.bs-qrace-rule`) was rehomed alongside the controls so the prose stays adjacent to the buttons it explains.

## Frame-stability findings

- All 20 widgets use SVG canvases authored to a fixed `viewBox` with `width: 100%` + `height: auto`, so canvas height is invariant under interaction by construction.
- HTML-flex / CSS-grid widgets (`MicrotaskStarvation`, `AwaitDesugar`) already had per-zone `min-height` floors from earlier R6 work — preserved.
- State-slot height is owned by the shell (Phase 1 set `min-height: 5.25em`), so no caption-length swing reflows the frame.

## Viewport-flip exemptions (per brief §d)

- **CostMatrix**: 4-column protocol grid reflows at `@container widget` breakpoints (`560px`, `380px`). Viewport-driven, EXEMPT from the interaction-stability rule.
- **MicrotaskStarvation**: queue / console pane reflows from 1-col stacked → 2-col side-by-side at `@container widget (min-width: 720px)`. Viewport-driven, EXEMPT.

## Validation

- `npx tsc --noEmit` clean (only pre-existing `@web-kits/audio` resolution noise from the un-installed monorepo dep, identical on origin/main)
- `pnpm lint`: **117 problems / 98 errors / 19 warnings — identical to origin/main** (no new errors introduced; existing `react-hooks/set-state-in-effect` and `Cannot access ref during render` errors pre-date this PR)
- `pnpm build` clean — all 25 static pages prerender, all three batch posts in the SSG list
- `grep -r "from \"./WidgetShell\""` across the three post directories returns **zero hits** — every widget points at the shared `@/components/viz/WidgetShell`
- `pnpm dev` smoke check at `/posts/the-browser-stopped-asking`, `/posts/how-gmail-knows-your-email-is-taken`, `/posts/the-line-that-waits-its-turn` returned HTTP 200 each. Rendered HTML contains the expected `bs-widget-canvas` / `bs-widget-state` / `bs-widget-controls` containers (8/16/7, 7/14/7, 5/10/3 respectively — controls slot is omitted on `CostMatrix`, `PredictTheStart`, `PredictTheOutput` per plan)
- Multi-viewport interactive verification (375 / 768 / 1280) requires browser tooling that wasn't available in this run — flagged as **manual verification recommended** before merge, with the diff inspection as primary evidence (no SVG `viewBox` was changed, no canvas dimensions were touched)

## Reference

- Phase 1 PR: #88 (typography tokens + WidgetShell layout contract)
- Layout contract canon: `docs/interactive-components.md` §0
- Approved overall plan: `/Users/a0y03ix/.claude/plans/i-want-to-revamp-polished-dragon.md`
- Per-task plan: `.orchestrator/plans/t-modu24r9binx9-v1.md`

## Test plan

- [ ] Open `/posts/the-line-that-waits-its-turn` at 375 px, 768 px, 1280 px. For `RuntimeSimulator`, `AwaitDesugar`, `PredictTheOutput`, click through every step and confirm the outer card height is stable.
- [ ] Open `/posts/the-browser-stopped-asking`. Drive `DropTiming` and `GapDuration` scrubbers across their full range; confirm canvas frame stable.
- [ ] Open `/posts/how-gmail-knows-your-email-is-taken`. Step through `HashLane`, `CacheWalk`, `RaceVerdict`; confirm state caption shows under the canvas with the rotated terracotta marker.
- [ ] Confirm `MicrotaskStarvation` Run button still fires correctly with the new control-slot home; tooltip on `+ self-sched` still anchors to its parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)