### PR TITLE
fix(ui): tab spacing + hide article cover + audio default-on

### DIFF
--- a/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
+++ b/app/posts/how-gmail-knows-your-email-is-taken/page.tsx
@@ -9,7 +9,6 @@ import {
   Em,
   Aside,
   A,
-  HeroTile,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
@@ -53,9 +52,6 @@ export default function HowGmailKnowsYourEmailIsTaken() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
-          <HeroTile slug="how-gmail-knows-your-email-is-taken" />
-        </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
           How instant email-availability checks work
         </H1>

--- a/app/posts/how-javascript-reads-its-own-future/page.tsx
+++ b/app/posts/how-javascript-reads-its-own-future/page.tsx
@@ -8,7 +8,6 @@ import {
   Em,
   Aside,
   A,
-  HeroTile,
   Term,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
@@ -70,9 +69,6 @@ export default function HowJavaScriptReadsItsOwnFuture() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex">
-          <HeroTile slug="how-javascript-reads-its-own-future" />
-        </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
           JavaScript Hoisting, the TDZ, and the Call Stack Explained
         </H1>

--- a/app/posts/the-browser-stopped-asking/page.tsx
+++ b/app/posts/the-browser-stopped-asking/page.tsx
@@ -9,7 +9,6 @@ import {
   Em,
   A,
   FullBleed,
-  HeroTile,
   Term,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
@@ -61,9 +60,6 @@ export default function TheBrowserStoppedAsking() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
-          <HeroTile slug="the-browser-stopped-asking" />
-        </div>
         <H1>WebSockets, SSE, and long-polling: how real-time web works</H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"

--- a/app/posts/the-function-that-remembered/page.tsx
+++ b/app/posts/the-function-that-remembered/page.tsx
@@ -9,7 +9,6 @@ import {
   Em,
   Aside,
   A,
-  HeroTile,
   Term,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
@@ -32,9 +31,6 @@ export default function TheFunctionThatRemembered() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
-          <HeroTile slug="the-function-that-remembered" />
-        </div>
         <H1 style={{ fontSize: "clamp(2.5rem, 2rem + 3.5vw, 4rem)" }}>
           JavaScript closures, var vs let, and the loop bug
         </H1>

--- a/app/posts/the-line-that-waits-its-turn/page.tsx
+++ b/app/posts/the-line-that-waits-its-turn/page.tsx
@@ -8,7 +8,6 @@ import {
   A,
   Aside,
   Dots,
-  HeroTile,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
 import { PostNavCards } from "@/components/nav/PostNavCards";
@@ -59,9 +58,6 @@ export default function TheLineThatWaitsItsTurn() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex flex-col items-start gap-[var(--spacing-md)] lg:flex-row lg:items-end">
-          <HeroTile slug="the-line-that-waits-its-turn" />
-        </div>
         <H1>JavaScript Event Loop Explained: Microtasks and the Call Stack</H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"

--- a/app/posts/why-fetch-fails-only-in-browser/page.tsx
+++ b/app/posts/why-fetch-fails-only-in-browser/page.tsx
@@ -10,7 +10,6 @@ import {
   Aside,
   A,
   FullBleed,
-  HeroTile,
   Term,
 } from "@/components/prose";
 import { PostBackLink } from "@/components/nav/PostBackLink";
@@ -46,9 +45,6 @@ export default function WhyFetchFailsOnlyInBrowser() {
     <Prose>
       <div className="pt-[var(--spacing-xl)]">
         <PostBackLink />
-        <div className="mt-[var(--spacing-md)] mb-[var(--spacing-md)] hidden md:flex">
-          <HeroTile slug="why-fetch-fails-only-in-browser" />
-        </div>
         <H1>Why fetch fails in browser but works in curl (CORS)</H1>
         <p
           className="mt-[var(--spacing-sm)] font-mono tabular-nums"

--- a/components/nav/AudioPromptTooltip.tsx
+++ b/components/nav/AudioPromptTooltip.tsx
@@ -10,20 +10,25 @@ const STORAGE_KEY = "lainlog:audio:prompt-dismissed";
 /**
  * AudioPromptTooltip — first-visit hint anchored beside the speaker icon.
  *
+ * Audio is default-on (per the 2026-05-02 flip), so this tooltip's job is
+ * to tell first-time readers HOW TO MUTE — pointer at the speaker toggle.
+ * It is never shown again once dismissed.
+ *
  * Renders ONLY when all four conditions are true:
  *   - hydrated (avoids SSR mismatch — localStorage isn't available on the
  *     server, so the first paint is empty and the tooltip eases in once
  *     the client confirms the user qualifies)
  *   - pathname === "/"  (home page only — article pages stay quiet)
- *   - audio preference is OFF (no point prompting if they're already in)
+ *   - audio preference is ON (the only state where a "click to mute"
+ *     hint makes sense)
  *   - localStorage[STORAGE_KEY] !== "true"  (sticky dismiss)
  *
  * Dismiss paths:
  *   - close button click → persists `prompt-dismissed = "true"` and
  *     unmounts via AnimatePresence.
- *   - AudioToggle parent flips audio ON → `audioEnabled` prop becomes
- *     true → effect persists `prompt-dismissed = "true"` so the tooltip
- *     never reappears, even if the user later turns audio back off.
+ *   - AudioToggle parent flips audio OFF → `audioEnabled` prop becomes
+ *     false → effect persists `prompt-dismissed = "true"` so the tooltip
+ *     never reappears, even if the user later turns audio back on.
  *
  * Visual language: matches `<Callout>` (the canonical "speaking to the
  * reader" element) — rounded radius-md, var(--color-surface) bg, plain
@@ -60,11 +65,11 @@ export function AudioPromptTooltip({
     }
   }, []);
 
-  // Auto-dismiss + persist when audio gets turned on. The user's intent
-  // is clear at that point — keep the tooltip from ever coming back.
+  // Auto-dismiss + persist when audio gets muted. The user has just acted
+  // on the hint — keep the tooltip from ever coming back.
   useEffect(() => {
     if (!hydrated) return;
-    if (audioEnabled && !dismissed) {
+    if (!audioEnabled && !dismissed) {
       try {
         window.localStorage.setItem(STORAGE_KEY, "true");
       } catch {
@@ -84,7 +89,7 @@ export function AudioPromptTooltip({
   };
 
   const shouldShow =
-    hydrated && pathname === "/" && !audioEnabled && !dismissed;
+    hydrated && pathname === "/" && audioEnabled && !dismissed;
 
   return (
     <AnimatePresence>
@@ -117,7 +122,7 @@ export function AudioPromptTooltip({
           >
             ♪
           </span>
-          <span>try it with sounds on</span>
+          <span>Click here to mute the site.</span>
           <button
             type="button"
             onClick={handleDismiss}

--- a/components/viz/WidgetNav.tsx
+++ b/components/viz/WidgetNav.tsx
@@ -1,16 +1,8 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
-import { PRESS, SPRING } from "@/lib/motion";
+import { PRESS } from "@/lib/motion";
 import { useTapPulse } from "@/lib/hooks/use-tap-pulse";
 import { playSound } from "@/lib/audio";
 
@@ -37,30 +29,27 @@ type WidgetNavProps = {
 /**
  * WidgetNav — the canonical step-controls primitive for lainlog widgets.
  *
- * Visual: prev / play / next sit as a joined pill row. A single `motion.div`
- * indicator pill morphs between the active button position via
- * `transform: translateX/scaleX` only (DESIGN.md §9 — no width/height
- * animations, no decorative pulses). The "gooey" feel comes from an inline
- * SVG `<filter>` (`feGaussianBlur` + alpha-snap `feColorMatrix`) scoped per
- * instance via `useId()`, applied to the indicator pill div only — text is
- * rendered outside the filter group so it stays crisp.
+ * Visual: prev / play / next render as a row of self-contained pills with
+ * 6px (`gap-1.5`) breathing room. Each pill carries its own 1px rule
+ * border, surface bg, accent text on hover, and per-button PRESS tap
+ * feedback (DESIGN.md §9 — transform-only, no width/height animation).
  *
- * Behaviour preserved from the legacy `<Stepper>`:
+ * Behaviour preserved:
  * - Auto-play scheduling at `playInterval` ms (1800ms under reduced motion).
  * - `IntersectionObserver` pauses autoplay when the nav scrolls off-screen
  *   (battery-life requirement on mobile when many widgets share a page).
  * - `useTapPulse` ring-pulse on prev / next so heavy-commit actions feel
  *   tactile.
+ * - `Progress-Tick` plays on every user-driven press (prev / play / pause /
+ *   replay / next). Auto-advance ticks stay silent.
  *
  * Accessibility:
- * - The active button carries `aria-current="step"`.
- * - The `n / N` counter is `aria-live="polite"` only when NOT auto-playing,
- *   so screen readers don't get flooded during autoplay.
+ * - The next button carries `aria-current="step"` while there are still
+ *   steps ahead.
+ * - The `n / N` counter is `aria-live="polite"` only after the user has
+ *   moved at least once and is NOT auto-playing, so screen readers don't
+ *   get flooded.
  * - All hit targets are ≥ 44 × 44 (DESIGN.md §11).
- *
- * Reduced motion:
- * - Indicator pill teleports (no spring tail).
- * - Goo filter is dropped entirely.
  */
 export function WidgetNav({
   value,
@@ -75,17 +64,10 @@ export function WidgetNav({
   const [inView, setInView] = useState(true);
   const onChangeRef = useRef(onChange);
   const containerRef = useRef<HTMLDivElement>(null);
-  const trackRef = useRef<HTMLDivElement>(null);
-  const prevBtnRef = useRef<HTMLButtonElement>(null);
-  const playBtnRef = useRef<HTMLButtonElement>(null);
-  const nextBtnRef = useRef<HTMLButtonElement>(null);
   const prefersReducedMotion = useReducedMotion();
   const userMovedRef = useRef(false);
   const prevPulse = useTapPulse<HTMLButtonElement>();
   const nextPulse = useTapPulse<HTMLButtonElement>();
-
-  const filterId = useId();
-  const gooFilter = `bs-goo-${filterId.replace(/:/g, "")}`;
 
   onChangeRef.current = onChange;
 
@@ -97,44 +79,6 @@ export function WidgetNav({
     },
     [total],
   );
-
-  // Indicator-pill geometry: measure the active button each time `value`,
-  // `playing`, or layout changes. Re-measure on resize.
-  const [pill, setPill] = useState({ x: 0, w: 0, ready: false });
-
-  const measure = useCallback(() => {
-    const track = trackRef.current;
-    if (!track) return;
-    let active: HTMLButtonElement | null = null;
-    if (playing && playable && playBtnRef.current) {
-      active = playBtnRef.current;
-    } else {
-      // No "active" tab in the strict tab sense — highlight `next` so the
-      // pill anchors on the most relevant action. When at end, highlight
-      // play (replay). When at start, highlight next.
-      if (value <= 0 && nextBtnRef.current) active = nextBtnRef.current;
-      else if (value >= total - 1 && playBtnRef.current && playable)
-        active = playBtnRef.current;
-      else if (nextBtnRef.current) active = nextBtnRef.current;
-      else active = playBtnRef.current;
-    }
-    if (!active) return;
-    const trackRect = track.getBoundingClientRect();
-    const r = active.getBoundingClientRect();
-    setPill({ x: r.left - trackRect.left, w: r.width, ready: true });
-  }, [value, total, playing, playable]);
-
-  useLayoutEffect(() => {
-    measure();
-  }, [measure]);
-
-  useEffect(() => {
-    const track = trackRef.current;
-    if (!track || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => measure());
-    ro.observe(track);
-    return () => ro.disconnect();
-  }, [measure]);
 
   // Auto-play loop.
   useEffect(() => {
@@ -165,24 +109,17 @@ export function WidgetNav({
   const atEnd = value >= total - 1;
   const onlyOne = total <= 1;
 
-  // Phase 1 visual-weight lift: buttons read as deliberate chips — full
-  // text contrast, 1 px rule border, opaque surface at rest. Hover stays
-  // terracotta (existing behaviour). Disabled keeps the §11 0.4 floor.
+  // Each button is a self-contained pill: full text contrast, 1 px rule
+  // border, opaque surface at rest. Hover lifts the text to terracotta.
+  // Disabled keeps the §11 0.4 floor.
   const btnClass =
-    "relative z-10 inline-flex items-center justify-center min-h-[44px] min-w-[44px] " +
+    "inline-flex items-center justify-center min-h-[44px] min-w-[44px] " +
     "px-[var(--spacing-sm)] py-[var(--spacing-2xs)] rounded-[var(--radius-md)] " +
     "border border-[color:var(--color-rule)] bg-[color:var(--color-surface)] " +
     "text-[color:var(--color-text)] " +
     "transition-colors disabled:opacity-40 disabled:cursor-not-allowed " +
     "hover:enabled:text-[color:var(--color-accent)] focus-visible:outline-none " +
     "focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)]";
-
-  // The pill style. Under reduced motion we drop the filter and let `motion`
-  // teleport (no spring) by passing a non-spring transition.
-  const pillTransition = prefersReducedMotion ? { duration: 0 } : SPRING.snappy;
-  const pillFilter = prefersReducedMotion ? "none" : `url(#${gooFilter})`;
-
-  // Stable variants live in module scope (see end of file).
 
   // Counter live-region: silent during autoplay, polite once the user has
   // taken at least one action. On first mount we keep it `off` so screen
@@ -206,54 +143,9 @@ export function WidgetNav({
       className="flex flex-wrap items-center gap-x-[var(--spacing-sm)] gap-y-[var(--spacing-2xs)] font-sans"
       style={{ fontSize: "var(--text-ui)" }}
     >
-      {/* Inline goo filter, scoped per-instance via useId(). The width:0
-          height:0 SVG keeps it out of layout. */}
-      <svg
-        width="0"
-        height="0"
-        aria-hidden
-        focusable="false"
-        style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}
-      >
-        <defs>
-          <filter id={gooFilter}>
-            <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur" />
-            <feColorMatrix
-              in="blur"
-              type="matrix"
-              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
-              result="goo"
-            />
-            <feBlend in="SourceGraphic" in2="goo" />
-          </filter>
-        </defs>
-      </svg>
-
-      <div
-        ref={trackRef}
-        className="relative inline-flex items-center"
-        style={{ filter: pillFilter }}
-      >
-        {/* Indicator pill — single morphing element that travels via transform. */}
-        <motion.span
-          aria-hidden
-          className="pointer-events-none absolute top-0 left-0 h-full rounded-[var(--radius-md)]"
-          initial={false}
-          animate={
-            pill.ready
-              ? { x: pill.x, width: pill.w, opacity: onlyOne ? 0 : 1 }
-              : { opacity: 0 }
-          }
-          transition={pillTransition}
-          style={{
-            background: "color-mix(in oklab, var(--color-accent) 18%, transparent)",
-            border: "1px solid color-mix(in oklab, var(--color-accent) 45%, transparent)",
-          }}
-        />
-
+      <div className="inline-flex items-center gap-1.5">
         <motion.button
           ref={(node) => {
-            prevBtnRef.current = node;
             prevPulse.ref.current = node;
           }}
           type="button"
@@ -272,7 +164,6 @@ export function WidgetNav({
 
         {playable && !onlyOne ? (
           <motion.button
-            ref={playBtnRef}
             type="button"
             onClick={() => {
               // Progress-Tick on every play/pause/replay press — these
@@ -304,7 +195,6 @@ export function WidgetNav({
 
         <motion.button
           ref={(node) => {
-            nextBtnRef.current = node;
             nextPulse.ref.current = node;
           }}
           type="button"

--- a/docs/audio-playbook.md
+++ b/docs/audio-playbook.md
@@ -12,7 +12,7 @@ This doc is loaded at Phase E of `/new-post` and during any feature build that t
 
 Seven non-negotiables. If a proposal violates any of these, the proposal loses.
 
-1. **Audio is OPT-IN, default OFF.** State persists in `localStorage["lainlog:audio"] = "on" | "off"`. The Header speaker icon is the only way to flip it.
+1. **Audio is default ON.** State persists in `localStorage["lainlog:audio"] = "on" | "off"`. Unset / null reads as ON; only an explicit `"off"` mutes. The Header speaker icon is the only way to flip it. *(Updated 2026-05-02 — the original opt-in default was flipped to opt-out per user direction. The "no autoplay on page load" guarantee in §9 is unchanged: AudioContext is still created lazily inside the first real user-gesture handler.)*
 2. **`prefers-reduced-motion: reduce` → audio off automatically.** No user override in v1. If the OS preference says quiet, we listen.
 3. **Sound is never the sole feedback channel.** Every wire-site already has a visual cue — sound layers onto an existing affordance, never replaces one.
 4. **Same action = same sound everywhere.** A button-press click sounds identical in every widget. Consistency over novelty.
@@ -154,19 +154,19 @@ The preview is also a deliberate confirmation — the user hears the system come
 
 ## 11. First-visit prompt
 
-`<AudioPromptTooltip>` (co-located inside `<AudioToggle>`) renders a small "try it with sounds on" bubble anchored beside the speaker icon. It exists for one job: tell first-time readers the audio system is here and opt-in. It is never shown again once dismissed.
+`<AudioPromptTooltip>` (co-located inside `<AudioToggle>`) renders a small **"Click here to mute the site."** bubble anchored beside the speaker icon. With audio default-on (§1), the tooltip's job is to tell first-time readers HOW TO MUTE — pointer at the speaker toggle. It is never shown again once dismissed.
 
 Render conditions (ALL must be true):
 
 - Component has hydrated (avoids SSR mismatch — `localStorage` isn't available on the server).
 - `usePathname() === "/"` — home page only. Article pages stay quiet.
-- Audio preference is `false` (no point prompting if the reader's already opted in).
+- Audio preference is `true` (the only state where a "click to mute" hint makes sense; if the reader has already muted there's nothing to prompt about).
 - `localStorage["lainlog:audio:prompt-dismissed"] !== "true"`.
 
 Dismiss paths (both persist):
 
 - The `×` close button → `localStorage.setItem("lainlog:audio:prompt-dismissed", "true")` and unmounts via `<AnimatePresence>`.
-- Toggling audio ON without clicking close → the parent `<AudioToggle>` flips `audioEnabled` to true; the tooltip's effect persists `prompt-dismissed = "true"` so it never reappears even if the reader later turns audio back off.
+- Toggling audio OFF without clicking close → the parent `<AudioToggle>` flips `audioEnabled` to false; the tooltip's effect persists `prompt-dismissed = "true"` so it never reappears even if the reader later turns audio back on.
 
 The tooltip is decorative (`role="status"`, non-interruptive). It does not trap focus. Reduced-motion users get the static state via `<MotionConfigProvider reducedMotion="user">`.
 

--- a/lib/audio.ts
+++ b/lib/audio.ts
@@ -2,8 +2,10 @@
  * lib/audio.ts — central play surface for the bytesize audio system.
  *
  * Anchor principles (also enumerated in `docs/audio-playbook.md`):
- *   1. Audio is OPT-IN, default OFF. State persists in
- *      `localStorage["lainlog:audio"] = "on" | "off"`.
+ *   1. Audio is default ON. State persists in
+ *      `localStorage["lainlog:audio"] = "on" | "off"`. Unset / null reads
+ *      as ON; only an explicit `"off"` mutes. (Updated 2026-05-02 — the
+ *      original opt-in default was flipped to opt-out per user direction.)
  *   2. `prefers-reduced-motion: reduce` → audio off automatically.
  *   3. Sound is never the sole feedback channel.
  *   4. Same action = same sound everywhere.
@@ -138,7 +140,9 @@ function isBrowser(): boolean {
 function readPref(): boolean {
   if (!isBrowser()) return false;
   try {
-    return window.localStorage.getItem(STORAGE_KEY) === "on";
+    // Default ON: unset / null reads as on; only an explicit "off" mutes.
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === null ? true : v === "on";
   } catch {
     return false;
   }

--- a/lib/hooks/use-audio-preference.ts
+++ b/lib/hooks/use-audio-preference.ts
@@ -28,19 +28,23 @@ export function useAudioPreference(): {
   const [enabled, setEnabledState] = useState<boolean>(false);
 
   // Hydrate from localStorage post-mount (avoids hydration mismatch).
+  // Default ON: unset / null reads as on; only an explicit "off" mutes.
   useEffect(() => {
     try {
-      setEnabledState(window.localStorage.getItem(STORAGE_KEY) === "on");
+      const v = window.localStorage.getItem(STORAGE_KEY);
+      setEnabledState(v === null ? true : v === "on");
     } catch {
       // Private mode / disabled storage — keep default false.
     }
   }, []);
 
-  // Cross-tab sync via the `storage` event.
+  // Cross-tab sync via the `storage` event. A null `newValue` (the key was
+  // removed in another tab) follows the same default-ON rule as initial
+  // hydration.
   useEffect(() => {
     function onStorage(e: StorageEvent) {
       if (e.key !== STORAGE_KEY) return;
-      setEnabledState(e.newValue === "on");
+      setEnabledState(e.newValue === null ? true : e.newValue === "on");
     }
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);


### PR DESCRIPTION
## Summary

Bundle of four small UI polish follow-ups landing after the Phase 2 typography / WidgetShell merges (#88, #89, #90, #91). Single revertable commit.

## Items

### 1. WidgetNav per-button pills (`components/viz/WidgetNav.tsx`)
- Deleted the inline goo SVG filter (`feGaussianBlur` + alpha-snap `feColorMatrix`), the morphing `motion.span` indicator pill, the `useId` / `gooFilter` / `pillFilter` machinery, the `pill` state, the `useLayoutEffect` + `ResizeObserver` measure block, and `trackRef`.
- Buttons are now self-contained pills inside an `inline-flex items-center gap-1.5` row. Each carries its own 1px rule border, surface bg, accent text on hover, focus-visible ring, and per-button PRESS tap feedback.
- **Preserved**: keyboard nav, `Progress-Tick` sound on every user-driven press (prev / play / pause / replay / next), IntersectionObserver auto-pause-when-offscreen, aria-live counter, ≥ 44 × 44 hit targets, `aria-current="step"` on next, reduced-motion handling.
- Net: -86 lines on this file.

### 2. Hide animated cover on article pages (six `app/posts/<slug>/page.tsx`)
- Removed the `HeroTile,` import and the `<div … hidden md:flex …><HeroTile slug=… /></div>` wrapper from each post page.
- `components/prose/HeroTile.tsx` itself is unchanged — the symbol stays exported for an easy revert. Likely candidate for a follow-up cleanup PR.
- Homepage `<PostCover>` tiles untouched.

### 3. Audio default-on (`lib/audio.ts`, `lib/hooks/use-audio-preference.ts`)
- Flipped `readPref()` and the React hydration block: an unset / null `localStorage["lainlog:audio"]` now reads as on; only an explicit `"off"` mutes.
- Cross-tab `storage` event handler also follows the same default-ON rule on `null` newValue.
- `AudioContext` is still created lazily inside the first real user-gesture handler — no autoplay-on-load regression. The "no autoplay on page load" guarantee in audio-playbook §9 is unchanged.

### 4. AudioPromptTooltip pivot (`components/nav/AudioPromptTooltip.tsx`)
- Render gate flipped: `shouldShow = hydrated && pathname === "/" && audioEnabled && !dismissed`.
- Auto-dismiss effect flipped: persists `prompt-dismissed = "true"` when the user mutes (was: when the user unmutes).
- Copy is now **`Click here to mute the site.`** (was: `try it with sounds on`). Lightly polished imperative — matches the editorial-aside register of the existing tooltip.
- Same `STORAGE_KEY = "lainlog:audio:prompt-dismissed"` so existing dismiss state carries across the deploy.

### Docs
- `docs/audio-playbook.md` §1 anchor 1 rewritten to reflect default-ON with the override note. §11 rewritten end-to-end to match the new tooltip semantics.

## Validation

- `npx tsc --noEmit` — only the two pre-existing `@web-kits/audio` module-resolution errors (present on origin/main; verified by stash + re-run). No new tsc errors.
- `pnpm lint` — 96 errors / 19 warnings, identical to origin/main except for line-number shifts inside the files we edited (verified by stash + diff). No new lint errors.
- `pnpm build` — clean.
- `pnpm dev` on `0.0.0.0:3010`, brief curl smoke (server killed immediately after):
  - `curl /` returns the homepage cover-tile signature (`PostCover` / `cover-` view-transition names present).
  - `curl /posts/the-line-that-waits-its-turn` → 0 `HeroTile` references, 0 `cover-the-line-that-waits-its-turn` view-transition name, 0 `feGaussianBlur` (goo filter gone), 1 `gap-1.5` class hit (new WidgetNav spacing).

## Test plan (interactive — these aren't visible in static HTML)

- [ ] Clear `lainlog:audio` and `lainlog:audio:prompt-dismissed` in DevTools, reload `/` → speaker icon renders in the **on** state, tooltip "Click here to mute the site." eases in beside it.
- [ ] Click the speaker icon to mute → tooltip auto-dismisses, `lainlog:audio:prompt-dismissed = "true"` persists, tooltip never returns even if you unmute later.
- [ ] WidgetNav (any article with widgets, e.g. `/posts/the-line-that-waits-its-turn`): prev / play / next read as three discrete pills with 6px gap; no morph indicator; per-button PRESS tap; hover lifts text to terracotta; counter updates as you step.
- [ ] Homepage `/` still renders the animated cover tiles in the post list.
- [ ] One article page (e.g. `/posts/why-fetch-fails-only-in-browser`) does NOT render the hero cover at the top — title and date sit directly under the back-link.
- [ ] Reduced-motion: WidgetNav buttons still work; auto-play interval bumps to 1800ms; tooltip eases in without y-displacement.

## References

Phase 2 PRs that just merged:
- #88, #89, #90, #91 (typography + WidgetShell migration batch).

This PR is the polish pass on top of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)