### PR TITLE
feat(ui): course-routes background — hybrid DotField + static dots

### DIFF
--- a/app/courses/CourseBackground.tsx
+++ b/app/courses/CourseBackground.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import dynamic from "next/dynamic";
+
+/**
+ * CourseBackground — segment-layout dispatcher for the course-routes
+ * dotted-background system.
+ *
+ * Branches by pathname depth:
+ *   /courses                 → returns null (the courses index, if any,
+ *                              keeps the default body hatch).
+ *   /courses/<slug>          → landing page → mount DotField (cursor-
+ *                              reactive canvas) inside a static-dots
+ *                              fallback wrapper. The fallback gradient
+ *                              shows through if DotField bails out
+ *                              (mobile / localStorage off / SSR).
+ *   /courses/<slug>/<chap>   → chapter page → static radial-gradient dots
+ *                              only, no canvas, no listeners.
+ *
+ * Both wrappers are `position: fixed; inset: 0; z-index: -1;
+ * pointer-events: none` (see app/globals.css `.bs-course-bg-static` and
+ * `.bs-course-bg-canvas`). Cursor events pass through to the content.
+ *
+ * DotField is `next/dynamic({ ssr: false })` — the component is canvas-
+ * heavy and uses `window`/`document`/`getComputedStyle`/`localStorage`
+ * during initialization, none of which exist on the server.
+ */
+
+const DotField = dynamic(
+  () => import("@/components/fancy/dot-field/DotField"),
+  { ssr: false },
+);
+
+export default function CourseBackground() {
+  const pathname = usePathname() ?? "";
+  const segments = pathname.split("/").filter(Boolean);
+  // ["courses"]               → 1 (no background)
+  // ["courses", slug]         → 2 (landing → DotField)
+  // ["courses", slug, chap]   → 3+ (chapter → static dots)
+  const isLanding = segments.length === 2 && segments[0] === "courses";
+  const isChapter = segments.length >= 3 && segments[0] === "courses";
+
+  if (isChapter) {
+    return <div className="bs-course-bg-static" aria-hidden="true" />;
+  }
+  if (isLanding) {
+    return (
+      <div className="bs-course-bg-canvas" aria-hidden="true">
+        <DotField />
+      </div>
+    );
+  }
+  return null;
+}

--- a/app/courses/layout.tsx
+++ b/app/courses/layout.tsx
@@ -1,38 +1,39 @@
 import type { ReactNode } from "react";
 import "@/components/courses/course-canvas.css";
+import { CozyFrameProvider } from "@/components/nav/CozyFrame";
+import CourseBackground from "./CourseBackground";
 
 /**
- * /courses/* segment layout — polish-r5 ITEM 3 + ITEM 4.
+ * /courses/* segment layout — dot-field background system.
  *
- * Two bugs converge on this layout:
+ * Two responsibilities:
  *
- *   ITEM 3 (gridline coverage). Previously the react.gg-style gridline
- *   pattern was painted on `[data-course]` — but that attribute lives on
- *   the inner page-content wrapper inside each course page, which only
- *   spans its own height (post-back-link → hero, or chapter prose). On
- *   short content (course landing) the gridlines stopped well short of
- *   the viewport bottom. The fix is to move the pattern onto a viewport-
- *   spanning surface — this layout's wrapper at `min-h-dvh`.
+ *   1. Render <CourseBackground /> once at the segment root. It dispatches
+ *      by pathname depth — landing pages mount DotField (cursor-reactive
+ *      canvas), chapter pages get a static radial-gradient dot pattern.
+ *      Both wrappers are fixed-position, behind content, pointer-events:none.
  *
- *   ITEM 4 (gridline leak on home). The home pinned course card carries
- *   `data-course` (so the --clay-* tonal range resolves on it). The old
- *   gridline rule `[data-course] { background-image: ... }` therefore
- *   matched the home card too — and after navigating into a course and
- *   back, the gridline pattern showed up under the home card. The fix
- *   below scopes the pattern to `.bs-course-canvas` instead of
- *   `[data-course]`. The home card never carries that class — so the
- *   pattern can't leak.
+ *   2. Wrap children in <CozyFrameProvider transparent>. The root layout's
+ *      <CozyFrame> reads this context and drops its solid --color-bg fill,
+ *      so the dot field shows through behind the centred column. Posts
+ *      and the homepage never see this provider — their CozyFrame paints
+ *      solid as before.
  *
- * The class lives on this layout's <div> which spans `min-h-dvh`, giving
- * us full-viewport coverage on every /courses/* route automatically (no
- * per-page wiring required). The `[data-course]` attribute on the inner
- * page wrapper continues to host the --clay-* token scope; it is not the
- * gridline trigger any more.
+ * The previous react.gg-style 40px gridline pattern (components/courses/
+ * course-canvas.css) is superseded by this system; the rule has been
+ * dropped from that stylesheet. The `bs-course-canvas` class lives on
+ * the inner <div> for backward-compat (no current consumers, but the
+ * class is referenced in upstream comments).
+ *
+ * The `[data-course]` token scope (--clay-* tonal range) is unaffected
+ * — it lives on the inner page wrapper and continues to resolve as
+ * before.
  */
 export default function CoursesLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="bs-course-canvas min-h-dvh">
-      {children}
-    </div>
+    <CozyFrameProvider transparent>
+      <CourseBackground />
+      <div className="bs-course-canvas min-h-dvh">{children}</div>
+    </CozyFrameProvider>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -168,6 +168,14 @@
   --color-accent: var(--color-terra-40);
   --color-accent-pressed: var(--color-terra-50);
   --color-rule: color-mix(in oklab, var(--color-text) 12%, transparent);
+
+  /* Course-routes dot-field background (DotField + static dots).
+     Theme-token mix (NOT terracotta) — muted neutrals derived from
+     --color-text. DotField reads these via getComputedStyle on mount and
+     on data-theme flip. */
+  --course-dot-from: color-mix(in oklab, var(--color-text) 18%, transparent);
+  --course-dot-to:   color-mix(in oklab, var(--color-text) 12%, transparent);
+  --course-glow:     color-mix(in oklab, var(--color-text) 6%, transparent);
 }
 
 [data-theme="dark"] {
@@ -178,6 +186,13 @@
   --color-accent: var(--color-terra-60);
   --color-accent-pressed: var(--color-terra-50);
   --color-rule: color-mix(in oklab, var(--color-text) 10%, transparent);
+
+  /* Dark-mode dot-field tokens — slightly higher contrast since OLED
+     blacks make low-opacity light pixels feel quieter than equivalent
+     light-theme tints. */
+  --course-dot-from: color-mix(in oklab, var(--color-text) 22%, transparent);
+  --course-dot-to:   color-mix(in oklab, var(--color-text) 14%, transparent);
+  --course-glow:     color-mix(in oklab, var(--color-text) 10%, transparent);
 }
 
 html {
@@ -205,6 +220,62 @@ body {
     color-mix(in oklab, var(--color-text) 5%, transparent) 13px,
     color-mix(in oklab, var(--color-text) 5%, transparent) 14px
   );
+}
+
+/* ---------------------------------------------------------------------------
+   Course-routes dot-field background.
+   ------------------------------------------------------------
+   Two fixed-position wrappers rendered by app/courses/CourseBackground.tsx,
+   one of which mounts (depending on the route depth):
+
+     .bs-course-bg-static  — chapter pages (and the DotField fallback for
+                             touch / reduced-motion / localStorage off).
+                             A single radial-gradient dot pattern, 1 px @ 22 px,
+                             tinted ~9% --color-text in light, ~7% in dark.
+
+     .bs-course-bg-canvas  — landing pages. Hosts the <canvas> painted by
+                             DotField. Carries the same static-dots
+                             gradient as a fallback that the canvas
+                             overdraws — so if DotField bails out at
+                             mount (touch / localStorage off), users
+                             still see the dotted background.
+
+   Both are `position: fixed; inset: 0; z-index: -1; pointer-events: none`,
+   so cursor events pass through to content (DotField hooks mousemove on
+   `window` for cursor data) and the body's diagonal hatch is fully
+   occluded under /courses/* routes.
+--------------------------------------------------------------------------- */
+.bs-course-bg-static,
+.bs-course-bg-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--color-text) 9%, transparent) 1px,
+    transparent 1.5px
+  );
+  background-size: 22px 22px;
+  background-color: var(--color-bg);
+}
+
+[data-theme="dark"] .bs-course-bg-static,
+[data-theme="dark"] .bs-course-bg-canvas {
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    color-mix(in oklab, var(--color-text) 7%, transparent) 1px,
+    transparent 1.5px
+  );
+}
+
+/* Print: courses chapters can be exported; suppress both background
+   variants so paper output stays clean. */
+@media print {
+  .bs-course-bg-static,
+  .bs-course-bg-canvas {
+    background-image: none !important;
+  }
 }
 
 /* ---------------------------------------------------------------------------

--- a/components/courses/CourseLandingHero.tsx
+++ b/components/courses/CourseLandingHero.tsx
@@ -199,8 +199,9 @@ export function CourseLandingHero({ course }: { course: CourseMeta }) {
           phase begins. polish-r4: dashed `borderTop` divider removed (user
           directive: scrap all horizontal dividers on /courses/*). The phase
           break is now carried by --spacing-2xl whitespace + the type
-          hierarchy shift (mono small caps vs. serif body) — the gridline
-          canvas reads through the gap and provides ambient structure. */}
+          hierarchy shift (mono small caps vs. serif body) — the DotField
+          (landing) / static-dots (chapter) background reads through the
+          gap and provides ambient structure. */}
       <p
         className="font-mono"
         style={{
@@ -227,7 +228,7 @@ export function CourseLandingHero({ course }: { course: CourseMeta }) {
       {/* polish-r4: <hr> Swiss-grid section divider removed (user directive
           — no horizontal dividers on /courses/*). The phase break from
           metadata → intro is now whitespace-only: --spacing-3xl above the
-          intro section, with the gridline canvas providing ambient
+          intro section, with the dot-field background providing ambient
           structure underneath. */}
       {/* 6. Intro section — phase break carried by --spacing-3xl above. */}
       <section
@@ -236,13 +237,15 @@ export function CourseLandingHero({ course }: { course: CourseMeta }) {
         style={{ scrollMarginTop: "var(--spacing-xl)" }}
       >
         {/* polish-r3 ITEM 3 — dropped the terracotta `borderLeft` accent
-            on this pull-quote. The /courses/* react.gg gridline background
-            already provides vertical structure on the left margin; layering
-            a hard 1-px terracotta vertical on top of a faint gridline read
-            as a duplicated guide. The pull-quote retains its identity via
-            italic serif + muted colour + a quiet leading dash glyph that
-            occupies the same visual slot as the old border without painting
-            a continuous vertical line. */}
+            on this pull-quote. The original rationale was that the
+            /courses/* gridline background already carried vertical
+            structure on the left margin and a hard 1-px terracotta
+            vertical layered on top read as a duplicated guide. Under
+            the dot-field successor that exact concern is gone, but the
+            decision still stands: the pull-quote retains its identity
+            via italic serif + muted colour + a quiet leading dash glyph
+            that occupies the same visual slot as the old border without
+            painting a continuous vertical line. */}
         <blockquote
           className="font-serif italic"
           style={{

--- a/components/courses/course-canvas.css
+++ b/components/courses/course-canvas.css
@@ -37,68 +37,25 @@
 }
 
 /* ---------------------------------------------------------------------------
-   react.gg-style infinite-canvas gridline background.
-
-   polish-r5 ITEM 3 + ITEM 4 — selector scope correction.
+   Course-route background — superseded.
    ------------------------------------------------------------
-   Previously this rule was bound to `[data-course]`, but that attribute
-   also lives on the home pinned course card (it scopes the --clay-*
-   tonal range). The pattern therefore leaked onto the home card after
-   any /courses/* visit (ITEM 4 bug). Additionally, `[data-course]` only
-   covered the inner page-content wrapper — so on short courses the
-   gridlines stopped before the viewport bottom (ITEM 3 bug).
+   The previous react.gg-style 40-px gridline pattern lived here, painted
+   on `.bs-course-canvas` (the segment-layout wrapper). It has been
+   replaced by the dot-field background system:
 
-   The fix: bind the pattern to `.bs-course-canvas` instead. That class
-   lives on the segment-level layout (app/courses/layout.tsx) which
-   wraps every /courses/* route in `min-h-dvh`, giving full-viewport
-   coverage. The home card never carries that class, so the pattern
-   can't leak. The --clay-* tonal range stays on `[data-course]` and
-   continues to resolve on the home card unchanged.
+     - Landing pages    → <DotField/> canvas (cursor-reactive bulge + glow
+                          + diagonal gradient)
+     - Chapter pages    → static radial-gradient dots (1 px @ 22 px)
 
-   Light mode: gridlines at ~6 % --color-text-tinted ink, near-invisible
-   until you look for them. Dark mode: ~10 % so the grid stays
-   perceptible. Static — gridlines never animate, so reduced-motion is
-   irrelevant. Anti-banding at high zoom: keep the line at exactly 1 px.
+   Both surfaces are painted on fixed-position wrappers rendered by
+   `app/courses/CourseBackground.tsx`. The CSS lives in `app/globals.css`
+   (`.bs-course-bg-static` and `.bs-course-bg-canvas`).
+
+   `bs-course-canvas` remains as a className on the segment-layout div for
+   backward-compat with comments that still reference it; no rule binds
+   to it anymore. The `[data-course]` token scope (--clay-*) below is
+   unaffected and continues to resolve on the inner page wrapper.
 --------------------------------------------------------------------------- */
-.bs-course-canvas {
-  background-image:
-    linear-gradient(
-      to right,
-      color-mix(in oklab, var(--color-text) 6%, transparent) 0,
-      color-mix(in oklab, var(--color-text) 6%, transparent) 1px,
-      transparent 1px,
-      transparent 40px
-    ),
-    linear-gradient(
-      to bottom,
-      color-mix(in oklab, var(--color-text) 6%, transparent) 0,
-      color-mix(in oklab, var(--color-text) 6%, transparent) 1px,
-      transparent 1px,
-      transparent 40px
-    );
-  background-size: 40px 40px;
-  background-position: 0 0, 0 0;
-}
-
-[data-theme="dark"] .bs-course-canvas {
-  background-image:
-    linear-gradient(
-      to right,
-      color-mix(in oklab, var(--color-text) 10%, transparent) 0,
-      color-mix(in oklab, var(--color-text) 10%, transparent) 1px,
-      transparent 1px,
-      transparent 40px
-    ),
-    linear-gradient(
-      to bottom,
-      color-mix(in oklab, var(--color-text) 10%, transparent) 0,
-      color-mix(in oklab, var(--color-text) 10%, transparent) 1px,
-      transparent 1px,
-      transparent 40px
-    );
-  background-size: 40px 40px;
-  background-position: 0 0, 0 0;
-}
 
 /* ---------------------------------------------------------------------------
    ITEM-1 polish-r2 stray-line diagnosis (recorded 2026-04-30)

--- a/components/courses/course-canvas.css
+++ b/components/courses/course-canvas.css
@@ -133,7 +133,7 @@
    bars stitched together. Removed entirely. The chapter outline now
    relies on the surface tint (--clay-100 closed / --clay-50 open) +
    item-internal padding + the rounded corners to delineate items. The
-   gridline canvas underneath provides ambient structure without
+   dot-field background underneath provides ambient structure without
    painting any rule lines. The open-state accent is now carried by a
    subtle background shift only (no border-color change, since there
    is no border to colour).

--- a/components/fancy/dot-field/DotField.css
+++ b/components/fancy/dot-field/DotField.css
@@ -1,0 +1,8 @@
+/* Vendored React Bits "DotField" — minimal stylesheet. The canvas fills its
+   parent (which is sized via Tailwind / fixed-inset on the wrapper). */
+
+.bs-dot-field {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/components/fancy/dot-field/DotField.tsx
+++ b/components/fancy/dot-field/DotField.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import "./DotField.css";
+
+/**
+ * DotField — vendored from React Bits, retoned for bytesize course landings.
+ *
+ * Canvas-based dot grid that responds to the cursor with two effects:
+ *   1. **Bulge** — dots within `cursorRadius` push outward, magnitude
+ *      attenuated by distance. Subtle by design (`bulgeStrength={28}` here,
+ *      down from React Bits' default 67).
+ *   2. **Glow** — a soft radial gradient painted at the cursor location,
+ *      using `--course-glow` from the active theme.
+ *   3. A faint diagonal **gradient wash** across the whole field
+ *      (`--course-dot-from` → `--course-dot-to`).
+ *
+ * Modifications vs. the React Bits source:
+ *   - Reduced-motion guard. If `(prefers-reduced-motion: reduce)`: render
+ *     a single static frame (dots + diagonal gradient, no glow), then
+ *     bail out — no RAF, no listeners. Component still mounts so the
+ *     visual baseline is consistent.
+ *   - Mobile / pointer-coarse guard. If `(pointer: coarse), (hover: none)`:
+ *     bail out before mounting any canvas effect; the wrapper's CSS
+ *     fallback static-dots gradient is what users see.
+ *   - localStorage escape hatch. `localStorage["lainlog:dotfield"] === "off"`
+ *     triggers the same fallthrough.
+ *   - IntersectionObserver — pauses the RAF loop when the canvas scrolls
+ *     fully off-screen (mirrors components/viz/WidgetNav.tsx).
+ *   - `document.visibilitychange` — pauses when the tab is backgrounded.
+ *   - Theme-flip handling. A MutationObserver on `<html>` watches the
+ *     `data-theme` attribute; on flip, re-reads the three CSS vars from
+ *     `getComputedStyle` so the next RAF tick paints the new colors.
+ *   - Color resolution from CSS vars (`--course-dot-from`,
+ *     `--course-dot-to`, `--course-glow`) instead of hardcoded RGBA props.
+ *
+ * Defaults match the user-approved calibration (orchestrator brief):
+ *   dotRadius=1.25, dotSpacing=20, cursorRadius=320, bulgeOnly=true,
+ *   bulgeStrength=28, glowRadius=120, sparkle=false, waveAmplitude=0.
+ */
+
+export type DotFieldProps = {
+  dotRadius?: number;
+  dotSpacing?: number;
+  cursorRadius?: number;
+  bulgeOnly?: boolean;
+  bulgeStrength?: number;
+  glowRadius?: number;
+  sparkle?: boolean;
+  waveAmplitude?: number;
+};
+
+const STORAGE_KEY = "lainlog:dotfield";
+
+/** Read the three theme vars off `<html>` computed style. */
+function readThemeColors(): {
+  from: string;
+  to: string;
+  glow: string;
+} {
+  if (typeof window === "undefined") {
+    return { from: "rgba(0,0,0,0.18)", to: "rgba(0,0,0,0.12)", glow: "rgba(0,0,0,0.06)" };
+  }
+  const cs = getComputedStyle(document.documentElement);
+  const from = cs.getPropertyValue("--course-dot-from").trim() || "rgba(0,0,0,0.18)";
+  const to = cs.getPropertyValue("--course-dot-to").trim() || "rgba(0,0,0,0.12)";
+  const glow = cs.getPropertyValue("--course-glow").trim() || "rgba(0,0,0,0.06)";
+  return { from, to, glow };
+}
+
+export default function DotField({
+  dotRadius = 1.25,
+  dotSpacing = 20,
+  cursorRadius = 320,
+  bulgeOnly = true,
+  bulgeStrength = 28,
+  glowRadius = 120,
+  sparkle = false,
+  waveAmplitude = 0,
+}: DotFieldProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Mutable refs the RAF loop reads from. None of these need to trigger
+  // re-renders — the canvas paints them imperatively.
+  const mouseRef = useRef<{ x: number; y: number; active: boolean }>({
+    x: -9999,
+    y: -9999,
+    active: false,
+  });
+  const colorsRef = useRef(readThemeColors());
+  const propsRef = useRef({
+    dotRadius,
+    dotSpacing,
+    cursorRadius,
+    bulgeOnly,
+    bulgeStrength,
+    glowRadius,
+    sparkle,
+    waveAmplitude,
+  });
+  // Keep propsRef in sync with prop changes without writing the ref during
+  // render. The RAF loop reads `propsRef.current` each tick, so the next
+  // frame after a prop change picks up the new values.
+  useEffect(() => {
+    propsRef.current = {
+      dotRadius,
+      dotSpacing,
+      cursorRadius,
+      bulgeOnly,
+      bulgeStrength,
+      glowRadius,
+      sparkle,
+      waveAmplitude,
+    };
+  }, [
+    dotRadius,
+    dotSpacing,
+    cursorRadius,
+    bulgeOnly,
+    bulgeStrength,
+    glowRadius,
+    sparkle,
+    waveAmplitude,
+  ]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    // ── Guard 1: pointer-coarse / hover-none → bail out entirely. ────────
+    const coarseMQ = window.matchMedia(
+      "(pointer: coarse), (hover: none)",
+    );
+    if (coarseMQ.matches) {
+      // Don't mount canvas effects on touch devices; the wrapper's CSS
+      // fallback static-dots gradient handles the visual.
+      return;
+    }
+
+    // ── Guard 2: localStorage escape hatch. ──────────────────────────────
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === "off") return;
+    } catch {
+      /* localStorage may throw in privacy modes — proceed as if not set */
+    }
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let dpr = Math.max(1, window.devicePixelRatio || 1);
+    let width = 0;
+    let height = 0;
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      dpr = Math.max(1, window.devicePixelRatio || 1);
+      width = rect.width;
+      height = rect.height;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const drawFrame = (now: number, animated: boolean) => {
+      const p = propsRef.current;
+      const c = colorsRef.current;
+      ctx.clearRect(0, 0, width, height);
+
+      // Diagonal gradient wash.
+      const grad = ctx.createLinearGradient(0, 0, width, height);
+      grad.addColorStop(0, c.from);
+      grad.addColorStop(1, c.to);
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, width, height);
+
+      // Cursor glow (skip under reduced-motion / when cursor unknown).
+      if (animated && mouseRef.current.active) {
+        const { x: mx, y: my } = mouseRef.current;
+        const radial = ctx.createRadialGradient(mx, my, 0, mx, my, p.glowRadius);
+        radial.addColorStop(0, c.glow);
+        radial.addColorStop(1, "transparent");
+        ctx.fillStyle = radial;
+        ctx.fillRect(0, 0, width, height);
+      }
+
+      // Dots — paint each at its grid position, displaced by bulge.
+      const spacing = p.dotSpacing;
+      const r = p.dotRadius;
+      const cr = p.cursorRadius;
+      const bulge = p.bulgeStrength;
+      const wave = animated ? p.waveAmplitude : 0;
+      const t = now / 1000;
+
+      // Use the gradient's mid-stop opacity for the dots — derived from
+      // the same theme tokens, so dots co-tone with the wash.
+      ctx.fillStyle = c.from;
+
+      const cols = Math.ceil(width / spacing) + 2;
+      const rows = Math.ceil(height / spacing) + 2;
+      const mx = mouseRef.current.x;
+      const my = mouseRef.current.y;
+      const haveCursor = animated && mouseRef.current.active;
+
+      for (let i = 0; i < cols; i++) {
+        for (let j = 0; j < rows; j++) {
+          let dx = i * spacing;
+          let dy = j * spacing;
+
+          // Optional wave (we keep waveAmplitude=0 by default; included
+          // for parity with the React Bits source).
+          if (wave > 0) {
+            dy += Math.sin(t * 1.2 + i * 0.4) * wave;
+          }
+
+          // Cursor bulge — push outward when within cursorRadius.
+          if (haveCursor) {
+            const ex = dx - mx;
+            const ey = dy - my;
+            const dist = Math.hypot(ex, ey);
+            if (dist > 0 && dist < cr) {
+              const falloff = 1 - dist / cr;
+              const push = (bulge * falloff * falloff) / dist;
+              if (p.bulgeOnly) {
+                dx += ex * push;
+                dy += ey * push;
+              } else {
+                // Inverse "pull" mode — rare, included for parity.
+                dx -= ex * push;
+                dy -= ey * push;
+              }
+            }
+          }
+
+          // Sparkle — 3% of dots randomly larger. Disabled by default.
+          let radius = r;
+          if (p.sparkle && (i * 31 + j * 17) % 33 === 0) {
+            radius = r * 2;
+          }
+
+          ctx.beginPath();
+          ctx.arc(dx, dy, radius, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    };
+
+    resize();
+
+    // ── Guard 3: prefers-reduced-motion → one static frame, then exit. ──
+    const reducedMQ = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (reducedMQ.matches) {
+      drawFrame(performance.now(), false);
+      // Still respond to resize so the static frame stays correct.
+      const ro = new ResizeObserver(() => {
+        resize();
+        drawFrame(performance.now(), false);
+      });
+      ro.observe(canvas);
+      return () => ro.disconnect();
+    }
+
+    // Mark canvas as active so :has-style fallback rules know to suppress
+    // the CSS fallback gradient (cosmetic — not strictly required since
+    // the canvas paints over the wrapper).
+    canvas.dataset.active = "true";
+
+    // ── Animated path: full RAF loop with all listeners. ─────────────────
+
+    let raf = 0;
+    let inView = true;
+    let visible = !document.hidden;
+    let running = false;
+
+    const tick = (now: number) => {
+      drawFrame(now, true);
+      if (running) raf = requestAnimationFrame(tick);
+    };
+    const start = () => {
+      if (running) return;
+      running = true;
+      raf = requestAnimationFrame(tick);
+    };
+    const stop = () => {
+      if (!running) return;
+      running = false;
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+    };
+    const evaluateRunState = () => {
+      if (inView && visible) start();
+      else stop();
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouseRef.current = {
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top,
+        active: true,
+      };
+    };
+    window.addEventListener("mousemove", onMouseMove, { passive: true });
+
+    const onVisibility = () => {
+      visible = !document.hidden;
+      evaluateRunState();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting;
+        evaluateRunState();
+      },
+      { threshold: 0 },
+    );
+    io.observe(canvas);
+
+    const ro = new ResizeObserver(() => {
+      resize();
+    });
+    ro.observe(canvas);
+
+    // Theme-flip handling: re-read CSS vars when [data-theme] mutates.
+    const mo = new MutationObserver(() => {
+      colorsRef.current = readThemeColors();
+    });
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    evaluateRunState();
+
+    return () => {
+      stop();
+      window.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("visibilitychange", onVisibility);
+      io.disconnect();
+      ro.disconnect();
+      mo.disconnect();
+      delete canvas.dataset.active;
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="bs-dot-field"
+      aria-hidden="true"
+    />
+  );
+}

--- a/components/nav/CozyFrame.tsx
+++ b/components/nav/CozyFrame.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from "react";
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
 
 /**
  * CozyFrame — the centred content container. Paints a solid --color-bg
@@ -15,12 +17,41 @@ import type { ReactNode } from "react";
  *
  * Max-width 1360px: wider than a prose column, narrow enough to keep
  * long content from feeling unmoored on 4K monitors.
+ *
+ * Course-routes `transparent` variant (added with the dot-field background
+ * system). When an ancestor wraps the tree in `<CozyFrameProvider transparent>`
+ * the inner solid-bg rectangle is dropped, letting the fixed-position
+ * dot-field (canvas on landings, static gradient on chapters) show
+ * through behind the centered column. Default behaviour is unchanged for
+ * posts and the homepage — if no provider exists, transparent is `false`.
  */
+
+type CozyFrameContextValue = { transparent: boolean };
+
+const CozyFrameContext = createContext<CozyFrameContextValue>({
+  transparent: false,
+});
+
+export function CozyFrameProvider({
+  transparent,
+  children,
+}: {
+  transparent: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <CozyFrameContext.Provider value={{ transparent }}>
+      {children}
+    </CozyFrameContext.Provider>
+  );
+}
+
 export function CozyFrame({ children }: { children: ReactNode }) {
+  const { transparent } = useContext(CozyFrameContext);
   return (
     <div
       className="bs-cozy-frame relative mx-auto w-full max-w-[1360px]"
-      style={{ background: "var(--color-bg)" }}
+      style={{ background: transparent ? "transparent" : "var(--color-bg)" }}
     >
       <div className="relative flex min-h-screen flex-col">{children}</div>
     </div>

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -718,3 +718,96 @@ deprecated emergency override path. It is not consumed by `<PostCover>`
 today; if a future post needs a hand-cropped raster, wire it through
 the registry by adding a static-image cover component instead of
 re-introducing the field.
+
+## 11. Course-route backgrounds — the hybrid dot field
+
+The `/courses/*` segment paints its own background under the centred
+content column, signalling "you've left the blog, you're in a playground
+now." The system is **hybrid by design**: landing pages get a cursor-
+reactive canvas, chapter pages get a static radial-gradient dot pattern.
+Both surfaces are scoped to `/courses/*` — posts and the homepage are
+unaffected.
+
+### Architecture (1 paragraph)
+
+`app/courses/layout.tsx` renders `<CourseBackground />` once at the
+segment root. `CourseBackground.tsx` reads `usePathname()` and dispatches:
+two-segment paths (`/courses/<slug>`) mount `<DotField />` (loaded via
+`next/dynamic({ ssr: false })`); three-or-more segment paths
+(`/courses/<slug>/<chapter>`) render a marker div whose CSS paints a
+1-px-at-22-px radial-gradient. Both wrappers are
+`position: fixed; inset: 0; z-index: -1; pointer-events: none`. The
+courses layout also wraps children in `<CozyFrameProvider transparent>`
+so the root layout's `<CozyFrame>` drops its solid `--color-bg` fill,
+letting the dots show through behind the centered column.
+
+### DotField (vendored from React Bits, retoned)
+
+Source: `components/fancy/dot-field/DotField.tsx`. The user-blessed
+calibration is hard-coded by the call site:
+
+```tsx
+<DotField />  /* defaults match the calibration below */
+```
+
+| Prop | Default (vs. React Bits') | Why |
+|------|---------------------------|-----|
+| `dotRadius` | 1.25 (1.5) | Reads as background, not foreground |
+| `dotSpacing` | 20 (14) | Looser grid, less density |
+| `cursorRadius` | 320 (500) | Local effect, not page-wide |
+| `bulgeOnly` | true (true) | Bulge mode, not physics push |
+| `bulgeStrength` | 28 (67) | Subtle response, not a tractor beam |
+| `glowRadius` | 120 (160) | Tighter cursor glow |
+| `sparkle` | false (false) | Off — feels gimmicky on a static landing |
+| `waveAmplitude` | 0 (0) | Off — wave is always-running motion |
+
+Colors come from CSS vars (`--course-dot-from`, `--course-dot-to`,
+`--course-glow`) defined in `app/globals.css` for both light + dark
+themes. Tokens use `color-mix(in oklab, var(--color-text) Nx%, transparent)`
+— **muted neutral, never accent**. DotField re-reads these on
+`MutationObserver` of the `<html>` `data-theme` attribute, so theme
+flip is a smooth one-frame transition.
+
+### Performance + a11y guards (added to the vendored source)
+
+- `prefers-reduced-motion: reduce` — single static frame, no RAF loop,
+  no listeners. Component still mounts so the visual baseline is
+  consistent.
+- `(pointer: coarse), (hover: none)` — bails out before mounting any
+  effect; the wrapper's CSS fallback gradient is what touch users see.
+- `localStorage["lainlog:dotfield"] === "off"` — same fallthrough. Set
+  this in DevTools and reload to test, or wire a future toggle UI.
+- `IntersectionObserver` — pauses RAF when the canvas scrolls fully
+  off-screen (mirrors `components/viz/WidgetNav.tsx`).
+- `document.visibilitychange` — pauses RAF when the tab is backgrounded.
+- `mousemove` listener (passive: true) updates a ref; no work happens
+  until the next RAF tick reads it.
+
+### Static-dots fallback (chapter pages + DotField fall-through)
+
+`.bs-course-bg-static` paints a 1-px-at-22-px radial-gradient tinted
+~9% `--color-text` in light, ~7% in dark. The same gradient is also
+painted on `.bs-course-bg-canvas` as a fallback the canvas overdraws —
+so if DotField bails out, the static dots are still there. `@media print`
+suppresses both wrappers so chapter exports stay clean.
+
+### CSS vars
+
+```
+--course-dot-from   gradient + dot color (top-left corner of the wash)
+--course-dot-to     gradient color (bottom-right corner of the wash)
+--course-glow       cursor glow centre color
+```
+
+All three are `color-mix(in oklab, var(--color-text) N%, transparent)` —
+the percentage is the only thing that varies between light and dark.
+Tune the percentages in `app/globals.css` if the field reads too quiet
+or too loud.
+
+### CozyFrame transparent variant
+
+`CozyFrame` reads a `transparent` flag from `CozyFrameContext`. Default
+is `false` (solid `--color-bg` fill, as before). The courses layout
+wraps in `<CozyFrameProvider transparent>` so the column doesn't paint
+over the dots. Posts and the homepage never see this provider; their
+default `false` is unchanged.


### PR DESCRIPTION
## Summary

Adds a Figma/Excalidraw-style dotted background scoped to `/courses/*`. The architecture is **hybrid by user direction**:

- **Landing pages** (`/courses/<slug>`) mount `<DotField />` — a vendored React Bits canvas with cursor-reactive bulge, soft glow, and a faint diagonal gradient.
- **Chapter pages** (`/courses/<slug>/<chapter>`) get a **static radial-gradient** (1 px @ 22 px) — same visual primitive, no canvas, no listeners, calm reading surface.
- Posts and the homepage are untouched (the body's diagonal hatch still paints there).

Rationale: WidgetShell makes chapter widget canvases fully opaque, so a cursor-reactive surface would only be visible in margins anyway. Hybrid is the only architecture that respects what each surface needs.

## The five user-approved decisions, honoured

1. **Hybrid architecture** — `app/courses/CourseBackground.tsx` dispatches by `usePathname()` depth.
2. **Calibrated DotField props** — `dotRadius=1.25, dotSpacing=20, cursorRadius=320, bulgeOnly=true, bulgeStrength=28, glowRadius=120, sparkle=false, waveAmplitude=0`. Hard-coded as defaults so the call site is a bare `<DotField />`.
3. **Theme-token color, not terracotta** — three new CSS vars (`--course-dot-from`, `--course-dot-to`, `--course-glow`) defined for both light + dark in `app/globals.css`. All derive from `--color-text` via `color-mix(in oklab, …)`. Tunable in one place.
4. **Mobile fallback** — `(pointer: coarse), (hover: none)` returns from the effect before any canvas work; the wrapper's CSS fallback gradient (same one chapter pages use) is what touch users see.
5. **localStorage escape hatch** — `localStorage["lainlog:dotfield"] === "off"` triggers the same fallthrough. Documented in `docs/interactive-components.md` §11. ~5 LOC.

## Performance + a11y guards added to the vendored source

- `prefers-reduced-motion: reduce` — single static frame, no RAF loop, no listeners. Component still mounts so visual baseline is consistent.
- `IntersectionObserver` on the canvas — RAF paused when fully off-screen (mirrors `components/viz/WidgetNav.tsx` precedent).
- `document.visibilitychange` — RAF paused when tab is backgrounded.
- `MutationObserver` on `<html data-theme>` — re-reads CSS vars on theme flip; next RAF tick paints new colors. Smooth one-frame transition.
- `mousemove` listener is `passive: true` and only updates a ref; all paint work is RAF-tied.

## CozyFrame transparent variant

`CozyFrame` now reads a `transparent` flag from `CozyFrameContext` (default `false`, so posts and the homepage are unchanged). The courses layout wraps in `<CozyFrameProvider transparent>` so the centred column doesn't paint a solid `--color-bg` rectangle over the dots. Opt-in only — no impact on existing surfaces.

## Files

**New**:
- `components/fancy/dot-field/DotField.tsx` — modified React Bits canvas (~270 LOC).
- `components/fancy/dot-field/DotField.css` — 6 lines.
- `app/courses/CourseBackground.tsx` — pathname-based dispatcher.

**Modified**:
- `app/courses/layout.tsx` — wraps with `<CozyFrameProvider transparent>` and renders `<CourseBackground />`.
- `components/nav/CozyFrame.tsx` — `"use client"`, context-driven transparent variant.
- `components/courses/course-canvas.css` — drops the previous react.gg-style 40-px gridline rules (superseded by this PR).
- `app/globals.css` — adds three CSS vars in light + dark scopes; adds `.bs-course-bg-static` and `.bs-course-bg-canvas` rules; adds `@media print` suppressor.
- `docs/interactive-components.md` — new §11 documenting the architecture, props, escape hatch, mobile fallback, reduced-motion guarantee, and CSS vars.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — clean (25 static pages, all course routes generated)
- [x] `pnpm lint` — 0 new errors vs. origin/main (115-problem baseline preserved; verified via stash + re-run)
- [x] Dev smoke (port 3012, killed immediately):
  - `GET /courses/mcps` → 200, HTML contains `bs-course-bg-canvas` wrapper
  - `GET /courses/mcps/the-room-before-the-protocol` → 200, HTML contains `bs-course-bg-static` only (no canvas tag — DotField is `dynamic({ ssr: false })`, but the chapter route doesn't request it)
  - `GET /posts/the-line-that-waits-its-turn` → 200, neither wrapper present (post routes unaffected)
- [ ] Manual interactive pass (recommended before merge):
  - Visit `/courses/mcps` in browser → confirm gentle bulge on cursor move; theme flip animates dot color smoothly (~1 frame)
  - DevTools Rendering → emulate `prefers-reduced-motion: reduce` → bulge/glow freeze; static frame remains
  - DevTools device-mode mobile (or `pointer: coarse` emulation) → static dots fall-through, no canvas paint
  - DevTools console → `localStorage["lainlog:dotfield"] = "off"; location.reload()` → static dots fall-through
  - DevTools Performance → 5s capture on landing → scripting < 8 ms/frame target

## DESIGN.md compliance

- §3 single-accent rule: dot colors are derived from `--color-text`, never `--color-accent`.
- §9 motion ban list: no DOM width/height animations. Canvas paints per-pixel offsets and a glow radial-gradient — equivalent to canvas transforms, not DOM property animations.
- §11 a11y: reduced-motion killed; pointer-coarse falls through; canvas wrapper is `aria-hidden` and `pointer-events: none`.
- §12 decoration bans: no decorative box-shadow / drop-shadow / CSS filters. The cursor glow is a canvas radial-gradient paint.

---

## Reconnaissance findings — resolutions

Followup commit `7d58ba6` walks each of the 4 reconnaissance findings surfaced before merge.

### Finding #1 — gridlines-vs-dots swap (the architectural call)

**Status: confirmed (a). Stale comments refreshed.**

Investigated PR #69's polish-r5 commit message (the "react.gg gridline" originator):

- ITEM 7 (polish-r2): `"40×40 px grid of 1-px lines… visible enough to feel like drafting canvas, quiet enough to vanish on first read. CSS-only, zero JS, zero DOM, no animation. Scoped to /courses/* via [data-course]."`
- ITEM 4 (polish-r5): the gridline was rebound from `[data-course]` → `.bs-course-canvas` *specifically* to prevent leaking onto the home pinned course card. Selector was already known to be cosmetically scoped, not a measurement grid.
- No `/courses/*` component snaps to or measures against the 40-px grid (verified via `grep -rn "40px\|40 px"` across `components/courses/` + `app/courses/`).
- Downstream comments in `CourseLandingHero.tsx` and `course-canvas.css` already treat the gridline as "ambient structure that lets us drop horizontal dividers" — interchangeable with any subtle field.
- DESIGN.md line 13 explicitly flags `react.gg` as an anti-reference (`"too playful"`).

The dot-field successor preserves the exact role (ambient, scoped, pointer-events-none, fixed coverage via segment-layout `min-h-dvh`) while moving away from a literal react.gg motif. Verdict: **clean swap**.

Code action: refreshed three stale "gridline canvas" / "react.gg gridline" inline comments so future readers trace the current background system rather than the superseded one. No behavioural change. See:
- `components/courses/CourseLandingHero.tsx:198–203` (meta-strip rationale)
- `components/courses/CourseLandingHero.tsx:227–231` (intro-section phase break)
- `components/courses/CourseLandingHero.tsx:238–246` (pull-quote borderLeft rationale)
- `components/courses/course-canvas.css:130–139` (accordion divider scrap rationale)

Options (b)–(d) (restore on chapter pages / stack-with-restraint / localStorage opt-in) parked — not justified by evidence; the gridline was decorative-only, and DotField + static dots already cover landing and chapter respectively.

### Finding #2 — selector correction

**Status: already correct in code + docs. No change needed.**

Verified:
- `app/globals.css:248–270` paints the static-dots `radial-gradient` on `.bs-course-bg-static, .bs-course-bg-canvas` (compound selector, both classes), with the shared rule setting `position: fixed; inset: 0; z-index: -1; pointer-events: none; background-color: var(--color-bg)`.
- `app/courses/CourseBackground.tsx:45` mounts the chapter-page marker as `<div className="bs-course-bg-static" aria-hidden="true" />` — class matches.
- `docs/interactive-components.md:788` references `.bs-course-bg-static` directly.
- `grep -rn "data-bs-bg"` across the entire repo: zero matches. The original brief's broken `[data-bs-bg="dots-static"] body` selector never made it into shipped code or docs.

### Finding #3 — course slug correction

**Status: already correct everywhere. No change needed.**

Verified:
- `content/courses-manifest.ts` — canonical slug is `mcps`.
- `grep -rn "mcps-explained\|mcps_explained"` across the entire repo (every extension): zero matches.
- `docs/interactive-components.md` §11, `app/courses/CourseBackground.tsx`, `app/courses/layout.tsx` all use the canonical slug or are slug-agnostic.

### Finding #4 — globals.css conflict status

**Status: rebased clean onto current `origin/main`.**

- `git fetch origin main` → main had advanced by one commit since PR #93 was opened: `3eb5a79 fix(ui): tab spacing + hide article cover + audio default-on (#92)`.
- PR #92 touched `WidgetNav.tsx`, six post pages, `AudioPromptTooltip`, `lib/audio.ts`, `lib/hooks/use-audio-preference.ts`, `docs/audio-playbook.md`. **Zero overlap** with `/courses/*` surfaces, `app/globals.css` course-route block, or `components/fancy/dot-field/`.
- `git rebase origin/main` — clean, zero conflicts. Branch now sits two commits ahead of main: the original PR #93 commit + the followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)