### PR TITLE
fix(ui): hide courses (flag) + latest-article chip with StarBorder + glitter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { CourseCard } from "@/components/nav/CourseCard";
 import { BorderGlow } from "@/components/courses/BorderGlow";
 import { POSTS_NEWEST_FIRST } from "@/content/posts-manifest";
 import { PINNED_COURSE } from "@/content/courses-manifest";
+import { COURSES_VISIBLE } from "@/lib/site-flags";
 import { getUniqueReaderCount } from "@/lib/stats";
 
 /**
@@ -55,7 +56,7 @@ export default async function Home() {
           }}
         />
         <div>
-          {PINNED_COURSE ? (
+          {COURSES_VISIBLE && PINNED_COURSE ? (
             // polish-r5 ITEM 1 + ITEM 2 — neo-brutalism wrapper around
             // re-vendored BorderGlow.
             //

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { POSTS } from "@/content/posts-manifest";
 import { COURSES } from "@/content/courses-manifest";
 import { SITE_URL as SITE } from "@/lib/site";
+import { COURSES_VISIBLE } from "@/lib/site-flags";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -20,25 +21,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const courseRoutes: MetadataRoute.Sitemap = COURSES.flatMap((c) => {
-    const updated = c.updatedAt
-      ? new Date(c.updatedAt + "T00:00:00Z")
-      : new Date();
-    return [
-      {
-        url: `${SITE}/courses/${c.slug}`,
-        lastModified: updated,
-        changeFrequency: "monthly" as const,
-        priority: 0.7,
-      },
-      ...c.chapters.map((ch) => ({
-        url: `${SITE}/courses/${c.slug}/${ch.slug}`,
-        lastModified: updated,
-        changeFrequency: "monthly" as const,
-        priority: 0.7,
-      })),
-    ];
-  });
+  // Course routes are advertised in the sitemap only when COURSES_VISIBLE.
+  // The routes themselves remain accessible directly — this gate controls
+  // discoverability, not reachability.
+  const courseRoutes: MetadataRoute.Sitemap = COURSES_VISIBLE
+    ? COURSES.flatMap((c) => {
+        const updated = c.updatedAt
+          ? new Date(c.updatedAt + "T00:00:00Z")
+          : new Date();
+        return [
+          {
+            url: `${SITE}/courses/${c.slug}`,
+            lastModified: updated,
+            changeFrequency: "monthly" as const,
+            priority: 0.7,
+          },
+          ...c.chapters.map((ch) => ({
+            url: `${SITE}/courses/${c.slug}/${ch.slug}`,
+            lastModified: updated,
+            changeFrequency: "monthly" as const,
+            priority: 0.7,
+          })),
+        ];
+      })
+    : [];
 
   return [...staticRoutes, ...postRoutes, ...courseRoutes];
 }

--- a/components/fancy/Glitter.tsx
+++ b/components/fancy/Glitter.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import type { CSSProperties } from "react";
+
+/**
+ * Glitter — a small cluster of shimmer dots that fade in and out around
+ * the bounds of a parent element. Lifted from the original `<Note>` glitter
+ * (PR #36) and extracted so any "look-at-me" affordance can reuse the
+ * exact same shimmer vocabulary.
+ *
+ * Visual contract:
+ *   - 3-5 terracotta dots (`--color-accent`) positioned around the
+ *     parent's bounds via percentage / pixel offsets.
+ *   - Each dot fades opacity 0 → 0.85 → 0 over `duration` (default 3.6s),
+ *     with staggered `delay` so the eye catches on the cluster without it
+ *     feeling spinny.
+ *   - Tiny y-drift (3px) gives life without committing to motion.
+ *
+ * Reduced-motion contract:
+ *   - When `prefers-reduced-motion: reduce`, the dots disappear entirely
+ *     (`return null`). This matches the original Note behavior and keeps
+ *     the "no decoration motion under reduced-motion" rule absolute.
+ *
+ * Composition:
+ *   - The parent must establish positioning context (`position: relative`).
+ *     Glitter renders an absolutely positioned <span aria-hidden> and
+ *     paints dots inside it.
+ *   - The component is `pointer-events: none`; it never intercepts hover
+ *     or click on the parent.
+ *
+ * Tuning notes (from the Note → Chip extraction review):
+ *   - Default 4 dots is the sweet spot for a Note-trigger-sized parent
+ *     (~360 × 44 px). For smaller surfaces (e.g. chips ~80 × 28 px), pass
+ *     a 3-dot `dots` array so the cluster doesn't crowd the perimeter.
+ *   - Dot size: 5 px default; for chips, 3-4 px reads better.
+ */
+
+export type GlitterDot = {
+  /** Horizontal position. CSS length or percentage. */
+  x: string;
+  /** Vertical position. CSS length or percentage. */
+  y: string;
+  /** Animation delay in seconds. Stagger across dots so the cluster
+   *  twinkles asynchronously. */
+  delay: number;
+};
+
+export type GlitterProps = {
+  /** Dot positions + delays. Default: 4 dots arranged at the corners of
+   *  the parent's bounds. */
+  dots?: GlitterDot[];
+  /** Dot diameter in px. Default 5. Use 3-4 for chips. */
+  size?: number;
+  /** Color. Default `var(--color-accent)`. */
+  color?: string;
+  /** Per-dot animation duration. Default 3.6s. */
+  duration?: number;
+};
+
+const DEFAULT_DOTS: GlitterDot[] = [
+  { x: "6%", y: "-8px", delay: 0 },
+  { x: "92%", y: "-6px", delay: 0.7 },
+  { x: "20%", y: "calc(100% - 2px)", delay: 1.4 },
+  { x: "78%", y: "calc(100% - 2px)", delay: 2.1 },
+];
+
+export function Glitter({
+  dots = DEFAULT_DOTS,
+  size = 5,
+  color = "var(--color-accent)",
+  duration = 3.6,
+}: GlitterProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  // Reduced-motion: render nothing. Decoration motion is opt-out by
+  // default (a stricter contract than the global animation-killer, which
+  // would just freeze the dots in place).
+  if (prefersReducedMotion) return null;
+
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        overflow: "visible",
+      }}
+    >
+      {dots.map((dot, i) => (
+        <Spark
+          key={i}
+          x={dot.x}
+          y={dot.y}
+          delay={dot.delay}
+          size={size}
+          color={color}
+          duration={duration}
+        />
+      ))}
+    </span>
+  );
+}
+
+function Spark({
+  x,
+  y,
+  delay,
+  size,
+  color,
+  duration,
+}: {
+  x: string;
+  y: string;
+  delay: number;
+  size: number;
+  color: string;
+  duration: number;
+}) {
+  const style: CSSProperties = {
+    position: "absolute",
+    left: x,
+    top: y,
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    background: color,
+    filter: "blur(0.3px)",
+    willChange: "transform, opacity",
+  };
+
+  return (
+    <motion.span
+      style={style}
+      initial={{ opacity: 0, scale: 0.6 }}
+      animate={{
+        opacity: [0, 0.85, 0],
+        scale: [0.6, 1, 0.6],
+        y: [0, -3, 0],
+      }}
+      transition={{
+        duration,
+        delay,
+        repeat: Infinity,
+        ease: "easeInOut",
+      }}
+    />
+  );
+}
+
+export default Glitter;

--- a/components/fancy/index.ts
+++ b/components/fancy/index.ts
@@ -5,3 +5,5 @@ export { VerticalCutReveal, type VerticalCutRevealRef } from "./vertical-cut-rev
 export { ScrambleIn, type ScrambleInRef } from "./scramble-in";
 export { ClickSpark, default as ClickSparkDefault } from "./click-spark";
 export { Stack, type StackProps } from "./stack-cards";
+export { StarBorder, type StarBorderProps } from "./star-border/StarBorder";
+export { Glitter, type GlitterProps, type GlitterDot } from "./Glitter";

--- a/components/fancy/star-border/StarBorder.css
+++ b/components/fancy/star-border/StarBorder.css
@@ -1,0 +1,95 @@
+/* Vendored React Bits "StarBorder" — theme-integrated.
+   See StarBorder.tsx JSDoc for the list of modifications vs. the upstream
+   source (theme tokens, currentColor default, reduced-motion guard). */
+
+.star-border-container {
+  display: inline-block;
+  padding: 1px 0;
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  /* Reset native button affordances so this primitive works whether it's
+     rendered as a <button> (interactive) or a <div>/<span> (decorative). */
+  background: transparent;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  cursor: inherit;
+  /* When rendered as a button, restore pointer cursor explicitly. */
+}
+button.star-border-container {
+  cursor: pointer;
+}
+
+.border-gradient-bottom {
+  position: absolute;
+  width: 300%;
+  height: 50%;
+  opacity: 0.7;
+  bottom: -11px;
+  right: -250%;
+  border-radius: 50%;
+  animation: star-movement-bottom linear infinite alternate;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.border-gradient-top {
+  position: absolute;
+  opacity: 0.7;
+  width: 300%;
+  height: 50%;
+  top: -10px;
+  left: -250%;
+  border-radius: 50%;
+  animation: star-movement-top linear infinite alternate;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.inner-content {
+  position: relative;
+  /* Theme-integrated: vars instead of hardcoded #000/#222/white. */
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-rule);
+  font-size: var(--text-small, 14px);
+  text-align: center;
+  padding: 8px 14px;
+  border-radius: 20px;
+  z-index: 1;
+}
+
+@keyframes star-movement-bottom {
+  0% {
+    transform: translate(0%, 0%);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-100%, 0%);
+    opacity: 0;
+  }
+}
+
+@keyframes star-movement-top {
+  0% {
+    transform: translate(0%, 0%);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(100%, 0%);
+    opacity: 0;
+  }
+}
+
+/* Reduced-motion guard. The inline animationDuration on each gradient layer
+   (set by the TSX) bypasses the global animation-killer rule in globals.css,
+   so we add an explicit `animation: none` here. The orbit becomes a static
+   glow at 0.4 opacity — preserving the visual presence without the motion. */
+@media (prefers-reduced-motion: reduce) {
+  .border-gradient-bottom,
+  .border-gradient-top {
+    animation: none;
+    opacity: 0.4;
+  }
+}

--- a/components/fancy/star-border/StarBorder.tsx
+++ b/components/fancy/star-border/StarBorder.tsx
@@ -1,0 +1,95 @@
+import type { ElementType, ComponentPropsWithoutRef, ReactNode, CSSProperties } from "react";
+import "./StarBorder.css";
+
+/**
+ * StarBorder — vendored from React Bits.
+ *
+ * A pill-shaped element with two radial-gradient "stars" orbiting along the
+ * top and bottom perimeter. The orbit is purely CSS (linear translation
+ * loops), so the primitive is a server component by default — no client
+ * hooks, no JS animation cost.
+ *
+ * Modifications vs. the React Bits source:
+ *   - Theme integration. The vendor CSS hardcoded the inner content's
+ *     `background: #000; color: white; border: 1px solid #222`. Replaced
+ *     with `--color-surface` / `--color-text` / `--color-rule` so the
+ *     primitive renders correctly on both light and dark themes.
+ *   - Default `color` prop. Changed from `"white"` (which collapses on a
+ *     light theme) to `"currentColor"` so the orbiting gradient inherits
+ *     the surrounding text color by default. Pass an explicit value (e.g.
+ *     `"var(--color-accent)"`) when you want a fixed tone.
+ *   - Reduced-motion guard. The React Bits source applied the orbit
+ *     duration via inline `animationDuration`, which bypasses the global
+ *     `prefers-reduced-motion` rule in `globals.css`. The CSS file now
+ *     ships an explicit `@media (prefers-reduced-motion: reduce)` block
+ *     that sets `animation: none` on the gradient layers, so the primitive
+ *     respects user preference.
+ *
+ * Composition contract:
+ *   - The component accepts an `as` polymorphic prop. Default is `"button"`
+ *     to match the React Bits demo. For non-interactive uses (badges,
+ *     chips, ornaments), pass `as="div"` or `as="span"` so screen readers
+ *     don't announce a phantom button.
+ *   - Any extra props are forwarded to the rendered element. The two
+ *     gradient layers are absolutely positioned children that ignore
+ *     pointer events.
+ */
+
+export type StarBorderProps<T extends ElementType = "button"> = {
+  /** Polymorphic element. Default `"button"`. Use `"div"` or `"span"` for
+   *  decorative chips so the chip isn't announced as a button. */
+  as?: T;
+  /** Color of the orbiting radial gradients. Default `"currentColor"` so
+   *  the orbit inherits the surrounding text color. Pass a CSS-var-friendly
+   *  token (e.g. `"var(--color-accent)"`) for a fixed tone. */
+  color?: string;
+  /** Orbit period as a CSS duration. Default `"6s"`. Larger = slower. */
+  speed?: string;
+  /** Outer wrapper className — applied to the rotating frame. */
+  className?: string;
+  /** ClassName for the inner content slot (where children render). */
+  innerClassName?: string;
+  /** Inner content. */
+  children?: ReactNode;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "color" | "children" | "className">;
+
+export function StarBorder<T extends ElementType = "button">({
+  as,
+  color = "currentColor",
+  speed = "6s",
+  className = "",
+  innerClassName = "",
+  children,
+  ...rest
+}: StarBorderProps<T>) {
+  const Component = (as ?? "button") as ElementType;
+
+  return (
+    <Component
+      className={`star-border-container ${className}`.trim()}
+      {...rest}
+    >
+      <div
+        className="border-gradient-bottom"
+        style={
+          {
+            background: `radial-gradient(circle, ${color}, transparent 10%)`,
+            animationDuration: speed,
+          } as CSSProperties
+        }
+      />
+      <div
+        className="border-gradient-top"
+        style={
+          {
+            background: `radial-gradient(circle, ${color}, transparent 10%)`,
+            animationDuration: speed,
+          } as CSSProperties
+        }
+      />
+      <div className={`inner-content ${innerClassName}`.trim()}>{children}</div>
+    </Component>
+  );
+}
+
+export default StarBorder;

--- a/components/nav/NewestChip.tsx
+++ b/components/nav/NewestChip.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { StarBorder } from "@/components/fancy/star-border/StarBorder";
+import { Glitter } from "@/components/fancy/Glitter";
+
+/**
+ * NewestChip — a small "New" sticker that sits on top of the most recent
+ * post tile in <PostList>.
+ *
+ * Composition:
+ *   - Outer: a <StarBorder> rendered as a non-interactive `<span>` (the
+ *     parent <a> already owns the click target — we don't want a nested
+ *     interactive element). The orbiting radial gradient uses the site
+ *     accent (`var(--color-accent)`).
+ *   - Inner: the chip text + a 3-dot <Glitter> cluster sized down for the
+ *     chip's smaller bounds (4 px dots vs the Note's 5 px).
+ *
+ * Visual restraint:
+ *   - StarBorder + Glitter is a deliberate double-up. The orbit traces the
+ *     perimeter; the glitter sparkles the corners. They complement instead
+ *     of competing because the orbit is continuous (never punctuated) and
+ *     the glitter is asynchronous (each dot off-beat from the orbit).
+ *   - Glitter dots are dialed down to 3 (vs Note's 4) and made smaller so
+ *     the chip doesn't read as "loudest thing on the page."
+ *
+ * Reduced-motion:
+ *   - StarBorder freezes its orbit (handled in StarBorder.css).
+ *   - Glitter returns null entirely (handled in Glitter.tsx).
+ *   - The chip stays visible as static text with a soft glow ring.
+ *
+ * Placement:
+ *   - The chip is positioned absolutely top-right of the post-tile cover
+ *     thumbnail; that positioning is the responsibility of the call site
+ *     (see PostList.tsx). The chip itself does not assume a position.
+ */
+export function NewestChip() {
+  return (
+    <>
+      <style>{`
+        /* Chip-specific tightening of the StarBorder inner content.
+           StarBorder's default padding (8px / 14px) is sized for a button;
+           the chip wants a denser 3px / 8px box and an accent-tinted halo
+           so the "New" reads as a sticker, not a control. The 999px radius
+           mirrors the chip's pill silhouette over StarBorder's default 20px
+           rounded-rect — the chip is small enough that 20px reads square. */
+        .bs-newest-chip-inner {
+          padding: 3px 8px !important;
+          border-radius: 999px !important;
+          background: color-mix(in oklab, var(--color-accent) 10%, var(--color-surface)) !important;
+          border-color: color-mix(in oklab, var(--color-accent) 40%, var(--color-rule)) !important;
+        }
+      `}</style>
+      <StarBorder
+      as="span"
+      color="var(--color-accent)"
+      speed="6s"
+      // Override the default 8px/14px padding for a denser chip.
+      innerClassName="bs-newest-chip-inner"
+      // The chip is decorative — the surrounding <a> announces the post.
+      // Mark it aria-hidden so screen readers don't announce "New" twice.
+      aria-hidden="true"
+    >
+      <span
+        style={{
+          position: "relative",
+          fontFamily: "var(--font-mono)",
+          fontSize: "10px",
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--color-accent)",
+        }}
+      >
+        New
+        {/* 3-dot glitter cluster — smaller dots, tight perimeter. */}
+        <Glitter
+          dots={[
+            { x: "-6px", y: "-6px", delay: 0 },
+            { x: "calc(100% - 0px)", y: "-4px", delay: 1.2 },
+            { x: "50%", y: "calc(100% - 0px)", delay: 2.4 },
+          ]}
+          size={3}
+        />
+      </span>
+    </StarBorder>
+    </>
+  );
+}
+
+export default NewestChip;

--- a/components/nav/PostList.tsx
+++ b/components/nav/PostList.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { PostMeta } from "@/content/posts-manifest";
 import { PostCover } from "@/components/covers/PostCover";
+import { NewestChip } from "@/components/nav/NewestChip";
 
 function formatDate(iso: string): string {
   const d = new Date(iso + "T00:00:00Z");
@@ -43,8 +44,24 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
                 snapshot while ambient animation continues underneath.
                 The hover-lift wraps the cover so the morph target is
                 stable. */}
-            <div className="transition-transform duration-[200ms] will-change-transform group-hover:-translate-y-[2px]">
+            <div className="relative transition-transform duration-[200ms] will-change-transform group-hover:-translate-y-[2px]">
               <PostCover slug={p.slug} size="thumb" />
+              {/* "New" sticker — only on the first (newest) post in the
+                  date-sorted list. Positioned top-right of the thumbnail,
+                  slightly overlapping so it reads as a sticker on top of
+                  the artwork rather than a label beside it. The chip is
+                  aria-hidden; the post link's aria-label still announces
+                  the post itself. */}
+              {i === 0 ? (
+                <span
+                  className="absolute -top-2 -right-2 z-10"
+                  // Pointer-events disabled so the chip doesn't intercept
+                  // hover state on the parent <Link>.
+                  style={{ pointerEvents: "none" }}
+                >
+                  <NewestChip />
+                </span>
+              ) : null}
             </div>
 
             {/* Title + date stacked */}

--- a/components/nav/PostList.tsx
+++ b/components/nav/PostList.tsx
@@ -35,33 +35,33 @@ export function PostList({ posts }: { posts: PostMeta[] }) {
         >
           <Link
             href={`/posts/${p.slug}`}
-            className="grid grid-cols-[64px_minmax(0,1fr)_24px] lg:grid-cols-[80px_minmax(0,1.1fr)_minmax(0,1.2fr)_32px] items-center gap-[var(--spacing-md)] lg:gap-[var(--spacing-lg)] px-[var(--spacing-sm)] py-[var(--spacing-lg)] no-underline transition-colors hover:bg-[color:color-mix(in_oklab,var(--color-accent)_4%,transparent)]"
+            className="relative grid grid-cols-[64px_minmax(0,1fr)_24px] lg:grid-cols-[80px_minmax(0,1.1fr)_minmax(0,1.2fr)_32px] items-center gap-[var(--spacing-md)] lg:gap-[var(--spacing-lg)] px-[var(--spacing-sm)] py-[var(--spacing-lg)] no-underline transition-colors hover:bg-[color:color-mix(in_oklab,var(--color-accent)_4%,transparent)]"
             aria-label={`${p.title} — ${p.hook}`}
           >
+            {/* "New" sticker — only on the first (newest) post in the
+                date-sorted list. Positioned at the top-right of the row
+                itself (the article's border), not the cover thumbnail, so
+                it reads as a row-level marker that the article is the
+                latest entry. Aria-hidden; the post link's aria-label
+                still announces the post itself. */}
+            {i === 0 ? (
+              <span
+                className="absolute -top-2 right-[var(--spacing-sm)] z-10"
+                // Pointer-events disabled so the chip doesn't intercept
+                // hover state on the parent <Link>.
+                style={{ pointerEvents: "none" }}
+              >
+                <NewestChip />
+              </span>
+            ) : null}
             {/* Cover thumbnail — bespoke per-post animated SVG.
                 `view-transition-name` lives on PostCover's outer wrapper
                 (CoverFrame) so home → post morphs work on the still
                 snapshot while ambient animation continues underneath.
                 The hover-lift wraps the cover so the morph target is
                 stable. */}
-            <div className="relative transition-transform duration-[200ms] will-change-transform group-hover:-translate-y-[2px]">
+            <div className="transition-transform duration-[200ms] will-change-transform group-hover:-translate-y-[2px]">
               <PostCover slug={p.slug} size="thumb" />
-              {/* "New" sticker — only on the first (newest) post in the
-                  date-sorted list. Positioned top-right of the thumbnail,
-                  slightly overlapping so it reads as a sticker on top of
-                  the artwork rather than a label beside it. The chip is
-                  aria-hidden; the post link's aria-label still announces
-                  the post itself. */}
-              {i === 0 ? (
-                <span
-                  className="absolute -top-2 -right-2 z-10"
-                  // Pointer-events disabled so the chip doesn't intercept
-                  // hover state on the parent <Link>.
-                  style={{ pointerEvents: "none" }}
-                >
-                  <NewestChip />
-                </span>
-              ) : null}
             </div>
 
             {/* Title + date stacked */}

--- a/components/prose/Note.tsx
+++ b/components/prose/Note.tsx
@@ -3,6 +3,7 @@
 import { useId, useState, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { playSound } from "@/lib/audio";
+import { Glitter } from "@/components/fancy/Glitter";
 
 /**
  * <Note> — a collapsed-by-default disclosure for "tactical aside" content.
@@ -127,21 +128,6 @@ export function Note({ summary, children, defaultOpen = false }: NoteProps) {
           transform: rotate(90deg);
           color: var(--color-accent);
         }
-        .bs-note-glitter {
-          position: absolute;
-          inset: 0;
-          pointer-events: none;
-          overflow: visible;
-        }
-        .bs-note-spark {
-          position: absolute;
-          width: 5px;
-          height: 5px;
-          border-radius: 50%;
-          background: var(--color-accent);
-          filter: blur(0.3px);
-          will-change: transform, opacity;
-        }
         .bs-note-body {
           overflow: hidden;
           background: color-mix(in oklab, var(--color-surface) 60%, transparent);
@@ -157,7 +143,6 @@ export function Note({ summary, children, defaultOpen = false }: NoteProps) {
           color: var(--color-text);
         }
         @media (prefers-reduced-motion: reduce) {
-          .bs-note-glitter { display: none; }
           .bs-note-chevron { transition: none; }
         }
       `}</style>
@@ -185,17 +170,10 @@ export function Note({ summary, children, defaultOpen = false }: NoteProps) {
           <path d="M5 3 L9 7 L5 11" />
         </svg>
 
-        {/* Glitter prompt — only shown when closed and motion is allowed.
-            Four slow shimmer dots orbiting the trigger; staggered so the
-            eye catches on it without it feeling spinny. */}
-        {!open && !prefersReducedMotion ? (
-          <span className="bs-note-glitter" aria-hidden>
-            <Spark x="6%" y="-8px" delay={0} />
-            <Spark x="92%" y="-6px" delay={0.7} />
-            <Spark x="20%" y="calc(100% - 2px)" delay={1.4} />
-            <Spark x="78%" y="calc(100% - 2px)" delay={2.1} />
-          </span>
-        ) : null}
+        {/* Glitter prompt — only shown when closed. The shared <Glitter>
+            primitive handles reduced-motion internally (returns null), so
+            we only gate on `!open` here. */}
+        {!open ? <Glitter /> : null}
       </button>
 
       <AnimatePresence initial={false}>
@@ -226,35 +204,5 @@ export function Note({ summary, children, defaultOpen = false }: NoteProps) {
         ) : null}
       </AnimatePresence>
     </aside>
-  );
-}
-
-/** A single shimmer dot. 3.6s loop; opacity 0 → 0.9 → 0; tiny y drift. */
-function Spark({
-  x,
-  y,
-  delay,
-}: {
-  x: string;
-  y: string;
-  delay: number;
-}) {
-  return (
-    <motion.span
-      className="bs-note-spark"
-      style={{ left: x, top: y }}
-      initial={{ opacity: 0, scale: 0.6 }}
-      animate={{
-        opacity: [0, 0.85, 0],
-        scale: [0.6, 1, 0.6],
-        y: [0, -3, 0],
-      }}
-      transition={{
-        duration: 3.6,
-        delay,
-        repeat: Infinity,
-        ease: "easeInOut",
-      }}
-    />
   );
 }

--- a/docs/interactive-components.md
+++ b/docs/interactive-components.md
@@ -855,3 +855,94 @@ is `false` (solid `--color-bg` fill, as before). The courses layout
 wraps in `<CozyFrameProvider transparent>` so the column doesn't paint
 over the dots. Posts and the homepage never see this provider; their
 default `false` is unchanged.
+
+## 12. Site-wide feature flags
+
+Single source of truth: [`lib/site-flags.ts`](../lib/site-flags.ts). Flags
+in this file are typed `const` exports (literal `true` / `false`), which
+lets the compiler tree-shake unreachable branches at build time. Flipping
+a flag and rebuilding fully removes the gated code from the client bundle.
+
+Current flags:
+
+| Flag | Default | Effect when `false` |
+|---|---|---|
+| `COURSES_VISIBLE` | `false` | Pinned course card on the home page is hidden; sitemap excludes course routes. The `/courses/<slug>` and `/courses/<slug>/<chapter>` routes themselves remain reachable for preview. |
+
+When adding a new flag:
+1. Add the `export const` to `lib/site-flags.ts` with a JSDoc explaining
+   what `false` means and how to re-enable.
+2. Document it in the table above.
+3. Gate every consumer at the call site (don't bury the flag inside a
+   helper — the grep should be obvious).
+
+## 13. Sticker primitives — `StarBorder` + `Glitter` + `NewestChip`
+
+The home page surfaces a "New" sticker on the most recent post tile. The
+sticker is composed of two reusable primitives plus a thin call-site
+component that wires them together.
+
+### `<StarBorder>` — vendored from React Bits
+
+Source: [`components/fancy/star-border/StarBorder.tsx`](../components/fancy/star-border/StarBorder.tsx) +
+[`StarBorder.css`](../components/fancy/star-border/StarBorder.css). A pill
+with two radial-gradient "stars" orbiting along the top and bottom
+perimeter. Pure CSS animation — no client hooks, no JS animation cost.
+
+Modifications vs. the React Bits source:
+- **Theme integration.** The vendor CSS hardcoded `background: #000;
+  color: white; border: 1px solid #222` on the inner content. Replaced
+  with `--color-surface` / `--color-text` / `--color-rule` so the
+  primitive renders correctly on both light and dark themes.
+- **`color` prop default.** Changed from `"white"` to `"currentColor"`
+  so the orbiting gradient inherits the surrounding text color by default
+  on a light theme. Pass `"var(--color-accent)"` for a fixed accent tone.
+- **Reduced-motion guard.** The React Bits source applied the orbit
+  duration via inline `animationDuration`, which bypasses the global
+  animation-killer rule in `globals.css`. The CSS file now ships an
+  explicit `@media (prefers-reduced-motion: reduce)` block that sets
+  `animation: none` and dims the gradient layers to 0.4 opacity — the
+  primitive becomes a static glow ring under user pref.
+- **Polymorphic `as` prop.** Default is `"button"` (matching the React
+  Bits demo) but consumers can pass `"div"` / `"span"` for decorative
+  uses where the chip shouldn't be announced as a button.
+
+### `<Glitter>` — extracted from `<Note>`
+
+Source: [`components/fancy/Glitter.tsx`](../components/fancy/Glitter.tsx).
+A small cluster of shimmer dots that fade in and out around the bounds
+of a parent element. Originally inlined inside `<Note>` (PR #36); extracted
+in PR #95 so the chip and the Note share the exact same shimmer
+vocabulary.
+
+Default contract: 4 terracotta dots positioned at the parent's corners,
+each fading opacity 0 → 0.85 → 0 over 3.6s with staggered delays so the
+cluster twinkles asynchronously. Returns `null` under
+`prefers-reduced-motion` — decoration motion is opt-out by default.
+
+The parent must establish positioning context (`position: relative`).
+
+Tuning:
+- Default 4 dots fits a Note-trigger-sized parent (~360 × 44 px).
+- For chips (~80 × 28 px), pass a 3-dot `dots` array and `size={3}` or
+  `size={4}` so the cluster doesn't crowd the perimeter.
+
+### `<NewestChip>` — composition
+
+Source: [`components/nav/NewestChip.tsx`](../components/nav/NewestChip.tsx).
+A "New" sticker rendered on top of the most recent post tile in
+`<PostList>`. Composes `<StarBorder>` (orbiting accent ring) with
+`<Glitter>` (3-dot cluster) inside the chip's bounds.
+
+Why the double-up isn't visual noise:
+- The orbit is *continuous* (never punctuated).
+- The glitter is *asynchronous* (each dot off-beat from the orbit).
+- They complement instead of competing.
+
+Placement contract: the chip is `aria-hidden` and decorative — the parent
+post `<a>` already announces the post. Positioning (top-right, slightly
+offset over the cover thumbnail) is the responsibility of the call site
+in `PostList.tsx`. The chip itself does not assume a position.
+
+Visibility: rendered only on the first item in the date-sorted post list
+(`POSTS_NEWEST_FIRST`), via `i === 0` in `PostList.tsx`.

--- a/lib/site-flags.ts
+++ b/lib/site-flags.ts
@@ -1,0 +1,26 @@
+/**
+ * Site-wide feature flags.
+ *
+ * Toggleable visibility constants that gate user-facing surfaces without
+ * deleting underlying routes or content. Flipping a flag here is the
+ * single source of truth — every consumer reads from this module so a
+ * grep for the flag name lands every call site.
+ *
+ * Why a typed constant and not env vars:
+ *   - These flags affect static output (sitemap, home rendering); resolving
+ *     them at build time keeps the bundle deterministic.
+ *   - The compiler tree-shakes unreachable branches when the flag is a
+ *     literal `false`, so gating a feature OFF removes its code entirely
+ *     from the client bundle.
+ */
+
+/**
+ * When `false`, courses are hidden from listings, the home pinned card,
+ * and the sitemap. The course routes themselves (`/courses/<slug>` and
+ * `/courses/<slug>/<chapter>`) remain accessible — flipping this flag is
+ * a visibility toggle, not a takedown. Useful for previewing course work
+ * before announcing it.
+ *
+ * To re-enable: set this to `true` and rebuild. No other code changes.
+ */
+export const COURSES_VISIBLE = false;


### PR DESCRIPTION
## Summary

Three related changes bundled into one PR:

### 1. Hide courses behind a single feature flag

The user is not ready to publish any course on the public site, but wants to keep the work toggleable rather than deleted. New module: [`lib/site-flags.ts`](./lib/site-flags.ts) exporting `COURSES_VISIBLE = false`.

- **Home page** (`app/page.tsx`) — pinned course card gated. The card is gone; the page now reads as articles-only.
- **Sitemap** (`app/sitemap.ts`) — course routes excluded when the flag is off, so search engines stop seeing them.
- **Routes preserved** — `/courses/mcps` and `/courses/mcps/<chapter>` still resolve (curl 200 verified). Direct-link preview access intact.
- **No header/footer changes** — the existing nav doesn't link courses, so nothing to gate there.

To re-enable: flip the constant to `true` and rebuild. No other code changes.

### 2. New `<StarBorder>` primitive (vendored from React Bits)

Source: [`components/fancy/star-border/StarBorder.tsx`](./components/fancy/star-border/StarBorder.tsx) + [`StarBorder.css`](./components/fancy/star-border/StarBorder.css).

A pill with two radial-gradient stars orbiting along the top and bottom perimeter. Pure CSS animation — no client hooks, no JS animation cost.

Modifications vs. the React Bits source:
- **Theme integration.** Hardcoded `#000`/`#222`/white replaced with `--color-surface`/`--color-rule`/`--color-text` so the primitive renders correctly on both light and dark themes.
- **Default `color` prop changed** from `"white"` to `"currentColor"` so the orbit inherits the surrounding text color on a light theme. Pass `"var(--color-accent)"` for a fixed terracotta tone.
- **Reduced-motion guard** — the inline `animationDuration` would otherwise bypass the global animation-killer. The CSS file now ships an explicit `@media (prefers-reduced-motion: reduce)` block that sets `animation: none` and dims the gradient layers to 0.4 opacity.
- **Polymorphic `as` prop** so decorative consumers (chips, badges) can render as `<span>` instead of a phantom `<button>`.

### 3. "New" chip on the most recent post tile

The home post list now stickers the first item (currently `evals-or-vibes` after #94) with a "New" chip. Composition:

- **Outer**: `<StarBorder>` rendered as a non-interactive `<span>`, `color="var(--color-accent)"`, `speed="6s"`. The orbiting ring is terracotta.
- **Inner**: chip text + a 3-dot `<Glitter>` cluster (smaller than Note's default 4 dots so it doesn't crowd the chip's perimeter).
- **Position**: absolute top-right of the post-tile cover thumbnail, slightly offset so it reads as a sticker on top of the artwork.
- **Logic**: bound to `i === 0` in `<PostList>` — independent of courses visibility. Always the newest post, whatever it is.

The shimmer-dot pattern was lifted from `<Note>` and **extracted into a shared `<Glitter>` primitive** ([`components/fancy/Glitter.tsx`](./components/fancy/Glitter.tsx)) so both call sites share one implementation. `<Note>` was refactored to consume `<Glitter />`; visible behavior is identical.

Why the orbit + glitter double-up isn't visual noise: the orbit is *continuous* (never punctuated), the glitter is *asynchronous* (each dot off-beat from the orbit), so they complement rather than compete.

## Files

- `lib/site-flags.ts` (new) — `COURSES_VISIBLE` flag.
- `app/page.tsx` — gate home pinned card.
- `app/sitemap.ts` — gate course-route emission.
- `components/fancy/star-border/StarBorder.{tsx,css}` (new) — vendored primitive.
- `components/fancy/Glitter.tsx` (new) — extracted shimmer cluster.
- `components/prose/Note.tsx` — refactored to consume `<Glitter>`.
- `components/nav/NewestChip.tsx` (new) — chip composition.
- `components/nav/PostList.tsx` — render chip on first tile.
- `components/fancy/index.ts` — barrel exports for new primitives.
- `docs/interactive-components.md` — §12 (feature flags) + §13 (sticker primitives).

## Test plan

- [x] `npx tsc --noEmit` — no new errors (two pre-existing `@web-kits/audio` errors are unrelated, identical on baseline).
- [x] `pnpm lint` — no new errors (115 problems baseline, 115 problems after).
- [x] `pnpm build` — clean. Course routes still pre-render at build (preview access preserved).
- [x] `curl localhost:3010/` — homepage HTML contains zero "course" matches; "star-border-container" appears once (only on the first post tile).
- [x] `curl localhost:3010/courses/mcps` — 200 OK.
- [x] `curl localhost:3010/courses/mcps/the-handshake` — 200 OK.
- [x] `curl localhost:3010/sitemap.xml | grep -c "courses"` → 0.
- [x] Reduced-motion guards verified in CSS (`StarBorder.css`) and JSX (`Glitter.tsx`).

## Notes

- Cross-task awareness: a sibling task on `feat/evals-cover-svg-redesign` only touches `EvalsOrVibesCover.tsx` — no file conflict.
- The chip targets `evals-or-vibes` as the latest post (head of `POSTS_NEWEST_FIRST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)