### PR TITLE
feat(post): evals-or-vibes cover — animated redesign

### DIFF
--- a/components/covers/EvalsOrVibesCover.tsx
+++ b/components/covers/EvalsOrVibesCover.tsx
@@ -4,44 +4,55 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * EvalsOrVibesCover — the wine-panel grid.
+ * EvalsOrVibesCover — the eval cycle in one gesture.
  *
  * One sentence:
- *   A 4×3 tasting-ballot grid where 11 cells are terracotta-filled and one
- *   cell is empty — the failure that didn't show up in your evals.
+ *   A 4×3 terracotta grid where, once per loop, a hidden failure surfaces
+ *   on row 1 col 2 (a cell flickers off into a dashed "miss"), a scan
+ *   beam sweeps that row right→left and catches it, and the cell resolves
+ *   back to filled — the eval cycle compressed into one continuous loop.
  *
  * Why this metaphor:
- *   The post's running lens is wine-panel calibration. A ballot is a grid
- *   of judges' marks; a CSV is a grid of rows. The empty cell is the only
- *   contrast on the cover, which is also the article's claim — the
- *   failure mode you can't see is the one your eval set didn't sample.
+ *   The article's thesis is that evals catch what vibes miss. The previous
+ *   v1 cover (a static grid with a permanently-empty cell) read as inert
+ *   at 64 px — opacity-only support pulses on neighbors below the noise
+ *   floor (playbook §3). v2 makes the eval *cycle itself* the cover. The
+ *   running gesture is the answer to "how do I know if my AI is any
+ *   good": you scan, you catch, you fix, repeat.
  *
- * Composition (12 elements + 1 frame line = 13 load-bearing):
- *   1–11.  Eleven filled cells (terracotta dots).
- *   12.    One empty cell (just the cell ring, no dot).
- *   13.    A subtle baseline rule under the grid (the "ballot edge") for
- *          geometric anchor.
+ * Composition (13 load-bearing elements):
+ *   1–11.  Eleven filled cells (terracotta dots) at baseline opacity 0.95.
+ *   12.    The "failure cell" at row 1, col 2 — animates: filled →
+ *          dashed-ring miss → caught flash → filled again.
+ *   13.    Scan beam — a thin horizontal terracotta bar that sweeps the
+ *          failure-row right→left during phase B, with a soft trailing
+ *          wash. The hero gesture.
+ *   14.    Baseline rule under the grid (geometric anchor).
  *
- * Motion (playbook §3, §4, §14 — refined contemplative register):
- *   - 6s continuous loop.
- *   - One quiet support gesture: the four neighbors of the empty cell
- *     pulse-in-rotation (one at a time brightens by ~12% opacity for
- *     ~0.6s, then settles). This suggests the panel is "tasting around
- *     the gap" without ever filling it. The empty cell never lights up —
- *     that is the load-bearing point.
- *   - No scale gestures on chrome. No solid terracotta pulses. The
- *     metaphor is contemplative; the eyes should rest on the gap.
+ * Motion (playbook §3, §4, §14 — refined kinetic register):
+ *   - 5s continuous loop, no idle gap.
+ *   - Phase A (0–25%): failure cell fades terracotta dot → dashed empty
+ *     ring at row 1, col 2. The miss surfaces.
+ *   - Phase B (25–58%): scan beam translates from x ≈ 175 → x ≈ 25
+ *     across the failure row, with trailing wash. Beam amplitude = 150
+ *     px in the 200×200 viewBox = 75% of width. Visible at 64 px.
+ *   - Phase C (58–82%): as the beam passes the failure cell, the cell
+ *     opacity-flashes 0 → 1.0 (caught) and the dashed ring fades to 0.
+ *     Cell now filled terracotta = fixed.
+ *   - Phase D (82–100%): all 12 cells at uniform 0.95 opacity, breathing
+ *     hold; loop.
  *
- * Reduced-motion end-state: all 11 filled cells visible with the empty
- * cell at row 1 col 2. The metaphor lands statically: 11 × on the
- * ballot, one blank. The blank is what your evals missed.
+ * Reduced-motion end-state: the "caught" moment — beam at the failure
+ * cell's position, cell freshly filled at full opacity, dashed ring at
+ * 0.4 opacity (still visible as the residual trace of what was just
+ * caught). The reader reads from the still: evals are scanning the grid
+ * and catching the miss.
  *
- * Frame stability R6: only opacity animates. No transform, no path,
- * no geometry attribute changes.
+ * Frame stability R6: only opacity and transform (translateX on the
+ * beam) animate. No geometry attribute changes.
  */
 
 // 4 cols × 3 rows grid layout in a 200×200 viewBox.
-// Cell size 28; gap 14; centered.
 const COLS = 4;
 const ROWS = 3;
 const CELL = 28;
@@ -49,13 +60,12 @@ const GAP = 14;
 const GRID_W = COLS * CELL + (COLS - 1) * GAP;
 const GRID_H = ROWS * CELL + (ROWS - 1) * GAP;
 const ORIGIN_X = (200 - GRID_W) / 2;
-const ORIGIN_Y = (200 - GRID_H) / 2 - 4; // bias up slightly for baseline rule
+const ORIGIN_Y = (200 - GRID_H) / 2 - 4;
 const DOT_R = 6;
 
-// The empty cell — row 0 (top row), col 2 (third from left). Off-center
-// enough to read as deliberate, not corner-tucked.
-const EMPTY_ROW = 0;
-const EMPTY_COL = 2;
+// The failure cell — middle row, third column. Off-center, deliberate.
+const FAIL_ROW = 1;
+const FAIL_COL = 2;
 
 type CellPos = { row: number; col: number; cx: number; cy: number };
 
@@ -76,44 +86,18 @@ const CELLS: CellPos[] = (() => {
   return out;
 })();
 
-// The four orthogonal neighbors of the empty cell — these will pulse in
-// rotation. (Skip neighbors that fall outside the grid.)
-const NEIGHBORS: CellPos[] = [
-  { dr: -1, dc: 0 }, // up — out of grid (row -1) — filtered
-  { dr: 1, dc: 0 }, // down
-  { dr: 0, dc: -1 }, // left
-  { dr: 0, dc: 1 }, // right
-]
-  .map(({ dr, dc }) => ({ r: EMPTY_ROW + dr, c: EMPTY_COL + dc }))
-  .filter(
-    ({ r, c }) => r >= 0 && r < ROWS && c >= 0 && c < COLS,
-  )
-  .map(({ r, c }) => cellAt(r, c));
+// Failure-cell geometry, hoisted so the JSX stays clean.
+const FAIL = cellAt(FAIL_ROW, FAIL_COL);
 
-// For each neighbor, build an opacity keyframe schedule across a 6s loop.
-// Each neighbor "brightens" for 0.6s in its own slot, others stay at
-// baseline. Baseline opacity is 0.85; pulse peak is 1.0. Subtle.
-function pulseSchedule(): number[] {
-  // Each neighbor owns a 0.10 slot; the rest is hold. Total covered:
-  // 3–4 × 0.10 = ~0.40, leaving ~0.60 of contemplative quiet — the point.
-  // Keyframes: [0, start, start+slot/2, start+slot, 1]
-  const baseline = 0.85;
-  const peak = 1.0;
-  return [baseline, baseline, peak, baseline, baseline];
-}
+// Scan-beam path: right→left across the failure row, with a small
+// outside-grid pad on each end so the beam slides "in" and "out" cleanly.
+const BEAM_Y = FAIL.cy;
+const BEAM_X_RIGHT = ORIGIN_X + GRID_W + 8; // start just right of grid
+const BEAM_X_LEFT = ORIGIN_X - 8; // end just left of grid
+const BEAM_HALF_W = (GRID_W + 16) / 2;
 
-function pulseTimes(idx: number): number[] {
-  const slot = 0.1;
-  const pad = 0.05;
-  const start = idx * (slot + pad);
-  return [
-    0,
-    Math.max(0, start),
-    Math.min(1, start + slot / 2),
-    Math.min(1, start + slot),
-    1,
-  ];
-}
+// Reduced-motion still: place beam centered on the failure cell.
+const BEAM_X_CAUGHT = FAIL.cx;
 
 export function EvalsOrVibesCover() {
   const inView = useCoverInView();
@@ -134,70 +118,160 @@ export function EvalsOrVibesCover() {
         vectorEffect="non-scaling-stroke"
       />
 
-      {/* ─── 12 cells: 11 filled with terracotta dot, 1 empty (ring only) ─── */}
+      {/* ─── 11 stable filled cells (everything except the failure cell) ─── */}
       {CELLS.map((cell) => {
-        const isEmpty = cell.row === EMPTY_ROW && cell.col === EMPTY_COL;
-
-        // For the filled cells, find which neighbor index this corresponds
-        // to (if any) so it can pulse on its turn. Non-neighbors stay at
-        // baseline opacity for the whole loop.
-        const neighborIdx = NEIGHBORS.findIndex(
-          (n) => n.row === cell.row && n.col === cell.col,
-        );
-        const isNeighbor = neighborIdx !== -1;
-
-        if (isEmpty) {
-          // Empty cell: just a thin ring + a tiny "x" or just nothing —
-          // we use just the ring, so the gap is the loudest thing.
-          return (
-            <circle
-              key={`empty-${cell.row}-${cell.col}`}
-              cx={cell.cx}
-              cy={cell.cy}
-              r={DOT_R + 0.5}
-              fill="none"
-              stroke="var(--color-text-muted)"
-              strokeWidth={1.2}
-              strokeDasharray="2 2"
-              opacity={0.55}
-              vectorEffect="non-scaling-stroke"
-            />
-          );
-        }
-
+        const isFail = cell.row === FAIL_ROW && cell.col === FAIL_COL;
+        if (isFail) return null;
         return (
-          <motion.circle
-            key={`filled-${cell.row}-${cell.col}`}
+          <circle
+            key={`cell-${cell.row}-${cell.col}`}
             cx={cell.cx}
             cy={cell.cy}
             r={DOT_R}
             fill="var(--color-accent)"
-            initial={{ opacity: 0.85 }}
-            animate={
-              animate && isNeighbor
-                ? { opacity: pulseSchedule() }
-                : { opacity: 0.85 }
-            }
-            transition={
-              animate && isNeighbor
-                ? {
-                    duration: 6,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                    times: pulseTimes(neighborIdx),
-                  }
-                : undefined
-            }
-            variants={{
-              idle: {},
-              // Hover: brighten all filled cells very slightly. The empty
-              // cell stays empty — that's the joke.
-              hover: { opacity: 0.95 },
-            }}
-            vectorEffect="non-scaling-stroke"
+            opacity={0.95}
           />
         );
       })}
+
+      {/* ─── Failure cell: filled dot — fades out in phase A, flashes back in phase C ─── */}
+      <motion.circle
+        cx={FAIL.cx}
+        cy={FAIL.cy}
+        r={DOT_R}
+        fill="var(--color-accent)"
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0.95, 0, 0, 1, 0.95, 0.95] }
+            : { opacity: 1 } // reduced-motion: just-caught, freshly filled
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                // [start, after-fade-out, hold-empty, caught-flash, settle, end]
+                times: [0, 0.22, 0.58, 0.66, 0.82, 1],
+              }
+            : undefined
+        }
+        variants={{
+          idle: {},
+          hover: { opacity: 1 },
+        }}
+      />
+
+      {/* ─── Failure cell: dashed "miss" ring — only visible in phase A→B ─── */}
+      <motion.circle
+        cx={FAIL.cx}
+        cy={FAIL.cy}
+        r={DOT_R + 0.5}
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.2}
+        strokeDasharray="2 2"
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0, 0.7, 0.7, 0, 0, 0] }
+            : { opacity: 0.4 } // reduced-motion: residual trace of the caught miss
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.22, 0.58, 0.68, 0.82, 1],
+              }
+            : undefined
+        }
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── Scan beam — the hero gesture, sweeps row right→left in phase B ─── */}
+      {/*
+       * The beam is a horizontal terracotta bar centered on its own anchor
+       * (so translateX moves the *center* across the row). We render two
+       * stacked lines: a thin sharp leading edge + a softer wash above for
+       * the "afterglow" (the §3 corollary register: opacity-led trail, not
+       * a punchy filled rectangle). The whole group's opacity is gated to
+       * phase B + a brief tail into phase C so the catch reads.
+       */}
+      <motion.g
+        initial={false}
+        animate={
+          animate
+            ? {
+                x: [
+                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // hidden right
+                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // park at right of grid (phase A)
+                  FAIL.cx - BEAM_HALF_W - ORIGIN_X, // mid-sweep over the failure cell (catch)
+                  BEAM_X_LEFT - BEAM_HALF_W - ORIGIN_X, // exit left
+                  BEAM_X_LEFT - BEAM_HALF_W - ORIGIN_X, // hold off-stage
+                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // teleport back to right (during invisible hold)
+                ],
+                opacity: [0, 0, 1, 0.85, 0, 0],
+              }
+            : {
+                x: BEAM_X_CAUGHT - BEAM_HALF_W - ORIGIN_X,
+                opacity: 0.9,
+              } // reduced-motion: caught moment over the failure cell
+        }
+        transition={
+          animate
+            ? {
+                duration: 5,
+                repeat: Infinity,
+                ease: [0.4, 0, 0.2, 1],
+                times: [0, 0.25, 0.5, 0.6, 0.82, 1],
+              }
+            : undefined
+        }
+        // Anchor the beam group at (ORIGIN_X + BEAM_HALF_W, BEAM_Y) by
+        // pre-rendering the beam centered on (BEAM_HALF_W, 0) and then
+        // translating into place. We use the SVG transform attribute on
+        // an inner group for the static base position; the motion.g above
+        // animates the relative `x`.
+      >
+        <g transform={`translate(${ORIGIN_X} ${BEAM_Y})`}>
+          {/* Sharp leading line — terracotta, full width of the row + small overshoot */}
+          <line
+            x1={0}
+            y1={0}
+            x2={BEAM_HALF_W * 2}
+            y2={0}
+            stroke="var(--color-accent)"
+            strokeWidth={2.2}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          {/* Trailing wash — softer line just below the leading edge */}
+          <line
+            x1={6}
+            y1={3}
+            x2={BEAM_HALF_W * 2 - 6}
+            y2={3}
+            stroke="color-mix(in oklab, var(--color-accent) 45%, transparent)"
+            strokeWidth={1.4}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          {/* Outermost wash — even softer, gives the beam a sense of glow */}
+          <line
+            x1={12}
+            y1={-3}
+            x2={BEAM_HALF_W * 2 - 12}
+            y2={-3}
+            stroke="color-mix(in oklab, var(--color-accent) 22%, transparent)"
+            strokeWidth={1}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        </g>
+      </motion.g>
     </motion.g>
   );
 }
@@ -205,16 +279,25 @@ export function EvalsOrVibesCover() {
 /**
  * EvalsOrVibesCoverStatic — Satori-safe pure-JSX export.
  *
- * Reduced-motion end-state: all 11 filled cells at baseline opacity, the
- * empty cell as a dashed ring at row 0 col 2, baseline rule below the
- * grid. The metaphor reads from the still: the gap is the failure your
- * evals didn't catch.
+ * Reduced-motion / OG end-state per playbook §8: the "caught" moment.
+ *  - All 11 surrounding cells filled at 0.95 opacity.
+ *  - Failure cell freshly restored to terracotta fill (the catch just
+ *    completed).
+ *  - Dashed "miss" ring lingering at 0.4 opacity over the failure cell —
+ *    the residual trace of what was caught. The reader sees: this cell
+ *    was a miss; it's been caught.
+ *  - Scan beam centered on the failure cell at full opacity.
+ *  - Baseline rule under the grid for geometric anchor.
  *
  * Inline hex palette only (no CSS vars, no color-mix, no hooks).
  */
 export function EvalsOrVibesCoverStatic() {
   const ACCENT = "#d97341";
   const MUTED = "#7a7570";
+  // color-mix(accent 45% + transparent) approximation over BG #0e1114
+  const ACCENT_TRAIL = "#7a3a1f";
+  // color-mix(accent 22% + transparent) approximation over BG #0e1114
+  const ACCENT_GLOW = "#3b2018";
 
   return (
     <svg
@@ -234,36 +317,70 @@ export function EvalsOrVibesCoverStatic() {
         opacity={0.32}
       />
 
+      {/* 11 surrounding cells */}
       {CELLS.map((cell) => {
-        const isEmpty = cell.row === EMPTY_ROW && cell.col === EMPTY_COL;
-
-        if (isEmpty) {
-          return (
-            <circle
-              key={`empty-${cell.row}-${cell.col}`}
-              cx={cell.cx}
-              cy={cell.cy}
-              r={DOT_R + 0.5}
-              fill="none"
-              stroke={MUTED}
-              strokeWidth={1.2}
-              strokeDasharray="2 2"
-              opacity={0.55}
-            />
-          );
-        }
-
+        const isFail = cell.row === FAIL_ROW && cell.col === FAIL_COL;
+        if (isFail) return null;
         return (
           <circle
-            key={`filled-${cell.row}-${cell.col}`}
+            key={`cell-${cell.row}-${cell.col}`}
             cx={cell.cx}
             cy={cell.cy}
             r={DOT_R}
             fill={ACCENT}
-            opacity={0.85}
+            opacity={0.95}
           />
         );
       })}
+
+      {/* Failure cell: freshly restored to filled terracotta */}
+      <circle cx={FAIL.cx} cy={FAIL.cy} r={DOT_R} fill={ACCENT} opacity={1} />
+
+      {/* Residual dashed-ring trace — what was just caught */}
+      <circle
+        cx={FAIL.cx}
+        cy={FAIL.cy}
+        r={DOT_R + 0.5}
+        fill="none"
+        stroke={MUTED}
+        strokeWidth={1.2}
+        strokeDasharray="2 2"
+        opacity={0.4}
+      />
+
+      {/* Scan beam at the "caught" position — centered on failure cell */}
+      <g
+        transform={`translate(${FAIL.cx - (GRID_W + 16) / 2} ${FAIL.cy})`}
+        opacity={0.9}
+      >
+        <line
+          x1={0}
+          y1={0}
+          x2={GRID_W + 16}
+          y2={0}
+          stroke={ACCENT}
+          strokeWidth={2.2}
+          strokeLinecap="round"
+        />
+        <line
+          x1={6}
+          y1={3}
+          x2={GRID_W + 10}
+          y2={3}
+          stroke={ACCENT_TRAIL}
+          strokeWidth={1.4}
+          strokeLinecap="round"
+        />
+        <line
+          x1={12}
+          y1={-3}
+          x2={GRID_W + 4}
+          y2={-3}
+          stroke={ACCENT_GLOW}
+          strokeWidth={1}
+          strokeLinecap="round"
+        />
+      </g>
     </svg>
   );
 }

--- a/components/covers/EvalsOrVibesCover.tsx
+++ b/components/covers/EvalsOrVibesCover.tsx
@@ -4,100 +4,172 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCoverInView } from "./_CoverFrame";
 
 /**
- * EvalsOrVibesCover — the eval cycle in one gesture.
+ * EvalsOrVibesCover — v3 redesign.
  *
  * One sentence:
- *   A 4×3 terracotta grid where, once per loop, a hidden failure surfaces
- *   on row 1 col 2 (a cell flickers off into a dashed "miss"), a scan
- *   beam sweeps that row right→left and catches it, and the cell resolves
- *   back to filled — the eval cycle compressed into one continuous loop.
+ *   An LLM on the left emits a continuous stream of outputs that glide
+ *   rightward through a vertical "eval" gate; each output picks up a
+ *   verdict (tick or cross) as it crosses, and a tally on the right
+ *   keeps the score.
  *
- * Why this metaphor:
- *   The article's thesis is that evals catch what vibes miss. The previous
- *   v1 cover (a static grid with a permanently-empty cell) read as inert
- *   at 64 px — opacity-only support pulses on neighbors below the noise
- *   floor (playbook §3). v2 makes the eval *cycle itself* the cover. The
- *   running gesture is the answer to "how do I know if my AI is any
- *   good": you scan, you catch, you fix, repeat.
+ * Why this metaphor (v3):
+ *   v1 (rotating-neighbor pulse) was below the visual noise floor at 64
+ *   px. v2 (horizontal scan beam right→left across a "failure row") was
+ *   smooth but the metaphor felt abstract — the reader didn't see "an
+ *   eval" in a sweep. v3 picks the most literal direction available:
+ *   the pipeline shape every developer recognises — model → output →
+ *   judge → verdict → tally. If the loop is read for 3 seconds, the
+ *   reader thinks "evals," because they are literally watching outputs
+ *   being evaluated.
  *
- * Composition (13 load-bearing elements):
- *   1–11.  Eleven filled cells (terracotta dots) at baseline opacity 0.95.
- *   12.    The "failure cell" at row 1, col 2 — animates: filled →
- *          dashed-ring miss → caught flash → filled again.
- *   13.    Scan beam — a thin horizontal terracotta bar that sweeps the
- *          failure-row right→left during phase B, with a soft trailing
- *          wash. The hero gesture.
- *   14.    Baseline rule under the grid (geometric anchor).
+ * Composition (~12 load-bearing elements):
+ *   1.   Model glyph (left) — small rounded square with an inner dot
+ *        cluster, the "LLM."
+ *   2.   Pipeline track — thin dashed horizontal guide from model to
+ *        the right edge, hints the flow direction.
+ *   3.   Eval gate — vertical terracotta bar at x ≈ 128, the judge.
+ *   4-6. Three output dots, staggered 1/3 of the loop apart, gliding
+ *        left → right at constant speed (the smoothness comes from the
+ *        constant linear motion — no easing curves, no stutters).
+ *   7-9. Three verdict glyphs (tick, tick, cross) — one per output dot.
+ *        Each glyph is invisible until its dot crosses the gate, then
+ *        rides the dot to the right edge, fading out in sync.
+ *   10-12. Tally column on the right — three small static marks (two
+ *         ticks and one cross) representing the running score; gives
+ *         the still frame its "eval scoreboard" anchor.
+ *   13.   Baseline rule under the whole composition.
  *
  * Motion (playbook §3, §4, §14 — refined kinetic register):
- *   - 5s continuous loop, no idle gap.
- *   - Phase A (0–25%): failure cell fades terracotta dot → dashed empty
- *     ring at row 1, col 2. The miss surfaces.
- *   - Phase B (25–58%): scan beam translates from x ≈ 175 → x ≈ 25
- *     across the failure row, with trailing wash. Beam amplitude = 150
- *     px in the 200×200 viewBox = 75% of width. Visible at 64 px.
- *   - Phase C (58–82%): as the beam passes the failure cell, the cell
- *     opacity-flashes 0 → 1.0 (caught) and the dashed ring fades to 0.
- *     Cell now filled terracotta = fixed.
- *   - Phase D (82–100%): all 12 cells at uniform 0.95 opacity, breathing
- *     hold; loop.
+ *   - 6s continuous loop. Three dots phased 0.0 / 0.33 / 0.66 — at any
+ *     instant, one dot is emitting, one is mid-track, one is crossing
+ *     or has just crossed. The reader's eye always has motion to
+ *     follow; no idle gap.
+ *   - Smoothness: linear easing on the translateX of every dot. A
+ *     constant-velocity glide reads as flow, not staccato beats.
+ *     Verdict glyphs fade in/out via opacity only.
+ *   - Eval gate gently pulses in opacity (0.55 ↔ 1) on a 2s sub-loop —
+ *     three pulses per master cycle, one per crossing.
+ *   - No scale gestures on chrome. Solid terracotta is reserved for the
+ *     three output dots and the gate (the load-bearing eval moment).
  *
- * Reduced-motion end-state: the "caught" moment — beam at the failure
- * cell's position, cell freshly filled at full opacity, dashed ring at
- * 0.4 opacity (still visible as the residual trace of what was just
- * caught). The reader reads from the still: evals are scanning the grid
- * and catching the miss.
+ * Frame-stability R6: only transform (translateX) and opacity animate.
  *
- * Frame stability R6: only opacity and transform (translateX on the
- * beam) animate. No geometry attribute changes.
+ * Reduced-motion end-state: a frozen mid-cycle moment.
+ *   - Output dot 0 just past the gate, with its tick verdict attached.
+ *   - Output dot 1 mid-track between model and gate.
+ *   - Output dot 2 at emission near the model.
+ *   - Eval gate at full opacity (mid-pulse on a crossing).
+ *   - Tally column showing 2 ticks + 1 cross.
+ *   The still alone reads: "outputs are flowing through a judge and
+ *   accumulating verdicts." That's the article in one frame.
  */
 
-// 4 cols × 3 rows grid layout in a 200×200 viewBox.
-const COLS = 4;
-const ROWS = 3;
-const CELL = 28;
-const GAP = 14;
-const GRID_W = COLS * CELL + (COLS - 1) * GAP;
-const GRID_H = ROWS * CELL + (ROWS - 1) * GAP;
-const ORIGIN_X = (200 - GRID_W) / 2;
-const ORIGIN_Y = (200 - GRID_H) / 2 - 4;
-const DOT_R = 6;
+// Layout geometry — fixed, derived once.
+const VB = 200;
 
-// The failure cell — middle row, third column. Off-center, deliberate.
-const FAIL_ROW = 1;
-const FAIL_COL = 2;
+// Model glyph (left).
+const MODEL_X = 22;
+const MODEL_Y = 86;
+const MODEL_W = 28;
+const MODEL_H = 28;
+const MODEL_CX = MODEL_X + MODEL_W / 2;
+const MODEL_CY = MODEL_Y + MODEL_H / 2;
 
-type CellPos = { row: number; col: number; cx: number; cy: number };
+// Eval gate (vertical bar) — the judge.
+const GATE_X = 128;
+const GATE_TOP = 60;
+const GATE_BOT = 140;
 
-function cellAt(row: number, col: number): CellPos {
-  return {
-    row,
-    col,
-    cx: ORIGIN_X + col * (CELL + GAP) + CELL / 2,
-    cy: ORIGIN_Y + row * (CELL + GAP) + CELL / 2,
-  };
+// Track Y — horizontal axis the dots travel along.
+const TRACK_Y = MODEL_CY;
+
+// Output dots travel from emit to exit.
+const EMIT_X = MODEL_X + MODEL_W + 6;
+const EXIT_X = 196;
+const DOT_R = 4.5;
+
+// Tally column geometry — right edge.
+const TALLY_X = 178;
+const TALLY_TOP = 70;
+const TALLY_GAP = 14;
+
+// Crossing fraction along EMIT_X → EXIT_X where the gate sits.
+// (Used for verdict-glyph reveal timing.)
+const CROSS_FRAC = (GATE_X - EMIT_X) / (EXIT_X - EMIT_X);
+
+// Three output slots. Verdicts pre-assigned: pass, pass, fail. (The
+// article's thesis is that evals catch the misses — one in three is a
+// tighter beat than three-in-three.)
+type Verdict = "pass" | "fail";
+const SLOTS: { phase: number; verdict: Verdict }[] = [
+  { phase: 0.0, verdict: "pass" },
+  { phase: 1 / 3, verdict: "pass" },
+  { phase: 2 / 3, verdict: "fail" },
+];
+
+// Verdict glyph — drawn at absolute y = TRACK_Y - 8 (above the dot).
+// X is 0 relative to the parent motion.g (which animates translateX with the dot).
+function VerdictGlyph({ verdict }: { verdict: Verdict }) {
+  const baseY = TRACK_Y - 8;
+  if (verdict === "pass") {
+    // Small tick mark, sits just above the dot.
+    return (
+      <path
+        d={`M -3.2 ${baseY} L -1 ${baseY + 2.5} L 3.2 ${baseY - 2}`}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    );
+  }
+  // Cross mark.
+  return (
+    <g
+      stroke="var(--color-text-muted)"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+    >
+      <line x1={-3} y1={baseY - 2} x2={3} y2={baseY + 3} />
+      <line x1={3} y1={baseY - 2} x2={-3} y2={baseY + 3} />
+    </g>
+  );
 }
 
-const CELLS: CellPos[] = (() => {
-  const out: CellPos[] = [];
-  for (let r = 0; r < ROWS; r++) {
-    for (let c = 0; c < COLS; c++) out.push(cellAt(r, c));
+// Static tally glyph — same shapes, smaller, parked in the tally column.
+function TallyMark({ verdict, y }: { verdict: Verdict; y: number }) {
+  if (verdict === "pass") {
+    return (
+      <path
+        d={`M ${TALLY_X - 4} ${y + 1} L ${TALLY_X - 1.5} ${y + 3.2} L ${TALLY_X + 4} ${y - 2}`}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.85}
+      />
+    );
   }
-  return out;
-})();
+  return (
+    <g
+      stroke="var(--color-text-muted)"
+      strokeWidth={1.4}
+      strokeLinecap="round"
+      vectorEffect="non-scaling-stroke"
+      opacity={0.7}
+    >
+      <line x1={TALLY_X - 3.5} y1={y - 2.5} x2={TALLY_X + 3.5} y2={y + 2.5} />
+      <line x1={TALLY_X + 3.5} y1={y - 2.5} x2={TALLY_X - 3.5} y2={y + 2.5} />
+    </g>
+  );
+}
 
-// Failure-cell geometry, hoisted so the JSX stays clean.
-const FAIL = cellAt(FAIL_ROW, FAIL_COL);
-
-// Scan-beam path: right→left across the failure row, with a small
-// outside-grid pad on each end so the beam slides "in" and "out" cleanly.
-const BEAM_Y = FAIL.cy;
-const BEAM_X_RIGHT = ORIGIN_X + GRID_W + 8; // start just right of grid
-const BEAM_X_LEFT = ORIGIN_X - 8; // end just left of grid
-const BEAM_HALF_W = (GRID_W + 16) / 2;
-
-// Reduced-motion still: place beam centered on the failure cell.
-const BEAM_X_CAUGHT = FAIL.cx;
+const DURATION = 6; // seconds per master loop
 
 export function EvalsOrVibesCover() {
   const inView = useCoverInView();
@@ -105,173 +177,183 @@ export function EvalsOrVibesCover() {
   const animate = inView && !reduced;
 
   return (
-    <motion.g initial="idle" whileHover="hover">
-      {/* ─── Baseline rule under the grid (geometric anchor) ─── */}
+    <motion.g initial={false} whileHover="hover">
+      {/* ─── Pipeline track (chrome dash) ───────────────────────── */}
       <line
-        x1={ORIGIN_X}
-        y1={ORIGIN_Y + GRID_H + 14}
-        x2={ORIGIN_X + GRID_W}
-        y2={ORIGIN_Y + GRID_H + 14}
-        stroke="var(--color-text-muted)"
-        strokeWidth={1.0}
-        opacity={0.32}
+        x1={EMIT_X}
+        y1={TRACK_Y}
+        x2={EXIT_X - 6}
+        y2={TRACK_Y}
+        stroke="var(--color-rule)"
+        strokeWidth={1.2}
+        strokeDasharray="2 4"
+        strokeLinecap="round"
+        opacity={0.6}
         vectorEffect="non-scaling-stroke"
       />
 
-      {/* ─── 11 stable filled cells (everything except the failure cell) ─── */}
-      {CELLS.map((cell) => {
-        const isFail = cell.row === FAIL_ROW && cell.col === FAIL_COL;
-        if (isFail) return null;
+      {/* ─── Baseline rule ──────────────────────────────────────── */}
+      <line
+        x1={MODEL_X}
+        y1={GATE_BOT + 18}
+        x2={EXIT_X}
+        y2={GATE_BOT + 18}
+        stroke="var(--color-text-muted)"
+        strokeWidth={1.0}
+        opacity={0.28}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {/* ─── Model glyph (the LLM) ──────────────────────────────── */}
+      <g>
+        <rect
+          x={MODEL_X}
+          y={MODEL_Y}
+          width={MODEL_W}
+          height={MODEL_H}
+          rx={5}
+          fill="color-mix(in oklab, var(--color-accent) 14%, transparent)"
+          stroke="var(--color-accent)"
+          strokeWidth={1.6}
+          vectorEffect="non-scaling-stroke"
+        />
+        {/* Inner dot cluster — a tiny "model" mark (3 stacked dots). */}
+        <circle cx={MODEL_CX - 4} cy={MODEL_CY} r={1.5} fill="var(--color-accent)" />
+        <circle cx={MODEL_CX} cy={MODEL_CY} r={1.5} fill="var(--color-accent)" />
+        <circle cx={MODEL_CX + 4} cy={MODEL_CY} r={1.5} fill="var(--color-accent)" />
+      </g>
+
+      {/* ─── Eval gate (vertical bar — the judge) ───────────────── */}
+      <motion.line
+        x1={GATE_X}
+        y1={GATE_TOP}
+        x2={GATE_X}
+        y2={GATE_BOT}
+        stroke="var(--color-accent)"
+        strokeWidth={2.4}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        initial={false}
+        animate={
+          animate
+            ? { opacity: [0.55, 1, 0.55, 1, 0.55, 1, 0.55] }
+            : { opacity: 1 }
+        }
+        transition={
+          animate
+            ? {
+                duration: DURATION,
+                repeat: Infinity,
+                ease: "easeInOut",
+                // Three pulse peaks aligned with the three dot crossings.
+                // Crossing time of slot k = (k * (1/3)) + (1 - CROSS_FRAC) * (1/3) approximately…
+                // simpler: distribute peaks at 1/6, 3/6, 5/6 of the cycle.
+                times: [0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6, 1],
+              }
+            : undefined
+        }
+      />
+      {/* Gate end caps — two tiny terracotta dots, "rubric anchors." */}
+      <circle cx={GATE_X} cy={GATE_TOP} r={2} fill="var(--color-accent)" opacity={0.9} />
+      <circle cx={GATE_X} cy={GATE_BOT} r={2} fill="var(--color-accent)" opacity={0.9} />
+
+      {/* ─── Three output dots streaming through the gate ───────── */}
+      {SLOTS.map((slot, i) => {
+        // Reduced-motion freeze positions:
+        //   slot 0 (pass): just past the gate (verdict visible)
+        //   slot 1 (pass): mid-track between model and gate
+        //   slot 2 (fail): emission point near the model
+        const reducedX =
+          i === 0
+            ? GATE_X + 14
+            : i === 1
+              ? EMIT_X + (GATE_X - EMIT_X) * 0.55
+              : EMIT_X + 4;
+        const reducedVerdictOpacity = i === 0 ? 1 : 0;
+
         return (
-          <circle
-            key={`cell-${cell.row}-${cell.col}`}
-            cx={cell.cx}
-            cy={cell.cy}
-            r={DOT_R}
-            fill="var(--color-accent)"
-            opacity={0.95}
-          />
+          <motion.g
+            key={`output-${i}`}
+            initial={false}
+            animate={
+              animate
+                ? { x: [EMIT_X, EXIT_X], opacity: [0, 1, 1, 1, 0] }
+                : { x: reducedX, opacity: 1 }
+            }
+            transition={
+              animate
+                ? {
+                    x: {
+                      duration: DURATION,
+                      repeat: Infinity,
+                      ease: "linear",
+                      delay: -slot.phase * DURATION,
+                    },
+                    opacity: {
+                      duration: DURATION,
+                      repeat: Infinity,
+                      ease: "linear",
+                      delay: -slot.phase * DURATION,
+                      // [start, fade-in done, hold, hold, fade-out done]
+                      times: [0, 0.06, 0.5, 0.92, 1],
+                    },
+                  }
+                : undefined
+            }
+          >
+            {/* Output dot — solid terracotta, the hero element. */}
+            <circle cx={0} cy={TRACK_Y} r={DOT_R} fill="var(--color-accent)" />
+
+            {/* Verdict glyph — invisible until the dot crosses the gate.
+                Travels with the dot (parent group translates X);
+                opacity flips at CROSS_FRAC of the cycle. */}
+            <motion.g
+              initial={false}
+              animate={
+                animate
+                  ? { opacity: [0, 0, 1, 1, 0] }
+                  : { opacity: reducedVerdictOpacity }
+              }
+              transition={
+                animate
+                  ? {
+                      duration: DURATION,
+                      repeat: Infinity,
+                      ease: "linear",
+                      delay: -slot.phase * DURATION,
+                      // Reveal exactly when the dot crosses the gate.
+                      times: [
+                        0,
+                        Math.max(0, CROSS_FRAC - 0.01),
+                        Math.min(1, CROSS_FRAC + 0.02),
+                        0.92,
+                        1,
+                      ],
+                    }
+                  : undefined
+              }
+            >
+              <VerdictGlyph verdict={slot.verdict} />
+            </motion.g>
+          </motion.g>
         );
       })}
 
-      {/* ─── Failure cell: filled dot — fades out in phase A, flashes back in phase C ─── */}
-      <motion.circle
-        cx={FAIL.cx}
-        cy={FAIL.cy}
-        r={DOT_R}
-        fill="var(--color-accent)"
-        initial={false}
-        animate={
-          animate
-            ? { opacity: [0.95, 0, 0, 1, 0.95, 0.95] }
-            : { opacity: 1 } // reduced-motion: just-caught, freshly filled
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                // [start, after-fade-out, hold-empty, caught-flash, settle, end]
-                times: [0, 0.22, 0.58, 0.66, 0.82, 1],
-              }
-            : undefined
-        }
-        variants={{
-          idle: {},
-          hover: { opacity: 1 },
-        }}
-      />
-
-      {/* ─── Failure cell: dashed "miss" ring — only visible in phase A→B ─── */}
-      <motion.circle
-        cx={FAIL.cx}
-        cy={FAIL.cy}
-        r={DOT_R + 0.5}
-        fill="none"
+      {/* ─── Tally column (right edge) — running score ──────────── */}
+      {/* Header tick — the "tally" cap, gives the column a visual top. */}
+      <line
+        x1={TALLY_X - 6}
+        y1={TALLY_TOP - 10}
+        x2={TALLY_X + 6}
+        y2={TALLY_TOP - 10}
         stroke="var(--color-text-muted)"
-        strokeWidth={1.2}
-        strokeDasharray="2 2"
-        initial={false}
-        animate={
-          animate
-            ? { opacity: [0, 0.7, 0.7, 0, 0, 0] }
-            : { opacity: 0.4 } // reduced-motion: residual trace of the caught miss
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.22, 0.58, 0.68, 0.82, 1],
-              }
-            : undefined
-        }
+        strokeWidth={1.0}
+        opacity={0.45}
         vectorEffect="non-scaling-stroke"
       />
-
-      {/* ─── Scan beam — the hero gesture, sweeps row right→left in phase B ─── */}
-      {/*
-       * The beam is a horizontal terracotta bar centered on its own anchor
-       * (so translateX moves the *center* across the row). We render two
-       * stacked lines: a thin sharp leading edge + a softer wash above for
-       * the "afterglow" (the §3 corollary register: opacity-led trail, not
-       * a punchy filled rectangle). The whole group's opacity is gated to
-       * phase B + a brief tail into phase C so the catch reads.
-       */}
-      <motion.g
-        initial={false}
-        animate={
-          animate
-            ? {
-                x: [
-                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // hidden right
-                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // park at right of grid (phase A)
-                  FAIL.cx - BEAM_HALF_W - ORIGIN_X, // mid-sweep over the failure cell (catch)
-                  BEAM_X_LEFT - BEAM_HALF_W - ORIGIN_X, // exit left
-                  BEAM_X_LEFT - BEAM_HALF_W - ORIGIN_X, // hold off-stage
-                  BEAM_X_RIGHT - BEAM_HALF_W - ORIGIN_X, // teleport back to right (during invisible hold)
-                ],
-                opacity: [0, 0, 1, 0.85, 0, 0],
-              }
-            : {
-                x: BEAM_X_CAUGHT - BEAM_HALF_W - ORIGIN_X,
-                opacity: 0.9,
-              } // reduced-motion: caught moment over the failure cell
-        }
-        transition={
-          animate
-            ? {
-                duration: 5,
-                repeat: Infinity,
-                ease: [0.4, 0, 0.2, 1],
-                times: [0, 0.25, 0.5, 0.6, 0.82, 1],
-              }
-            : undefined
-        }
-        // Anchor the beam group at (ORIGIN_X + BEAM_HALF_W, BEAM_Y) by
-        // pre-rendering the beam centered on (BEAM_HALF_W, 0) and then
-        // translating into place. We use the SVG transform attribute on
-        // an inner group for the static base position; the motion.g above
-        // animates the relative `x`.
-      >
-        <g transform={`translate(${ORIGIN_X} ${BEAM_Y})`}>
-          {/* Sharp leading line — terracotta, full width of the row + small overshoot */}
-          <line
-            x1={0}
-            y1={0}
-            x2={BEAM_HALF_W * 2}
-            y2={0}
-            stroke="var(--color-accent)"
-            strokeWidth={2.2}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
-          {/* Trailing wash — softer line just below the leading edge */}
-          <line
-            x1={6}
-            y1={3}
-            x2={BEAM_HALF_W * 2 - 6}
-            y2={3}
-            stroke="color-mix(in oklab, var(--color-accent) 45%, transparent)"
-            strokeWidth={1.4}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
-          {/* Outermost wash — even softer, gives the beam a sense of glow */}
-          <line
-            x1={12}
-            y1={-3}
-            x2={BEAM_HALF_W * 2 - 12}
-            y2={-3}
-            stroke="color-mix(in oklab, var(--color-accent) 22%, transparent)"
-            strokeWidth={1}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
-        </g>
-      </motion.g>
+      <TallyMark verdict="pass" y={TALLY_TOP} />
+      <TallyMark verdict="pass" y={TALLY_TOP + TALLY_GAP} />
+      <TallyMark verdict="fail" y={TALLY_TOP + TALLY_GAP * 2} />
     </motion.g>
   );
 }
@@ -279,108 +361,151 @@ export function EvalsOrVibesCover() {
 /**
  * EvalsOrVibesCoverStatic — Satori-safe pure-JSX export.
  *
- * Reduced-motion / OG end-state per playbook §8: the "caught" moment.
- *  - All 11 surrounding cells filled at 0.95 opacity.
- *  - Failure cell freshly restored to terracotta fill (the catch just
- *    completed).
- *  - Dashed "miss" ring lingering at 0.4 opacity over the failure cell —
- *    the residual trace of what was caught. The reader sees: this cell
- *    was a miss; it's been caught.
- *  - Scan beam centered on the failure cell at full opacity.
- *  - Baseline rule under the grid for geometric anchor.
+ * Reduced-motion / OG end-state: a frozen mid-cycle moment.
+ *   - Output dot 0 just past the gate, tick attached.
+ *   - Output dot 1 mid-track.
+ *   - Output dot 2 at emission near the model.
+ *   - Eval gate at full opacity.
+ *   - Tally: pass, pass, fail.
  *
  * Inline hex palette only (no CSS vars, no color-mix, no hooks).
  */
 export function EvalsOrVibesCoverStatic() {
   const ACCENT = "#d97341";
   const MUTED = "#7a7570";
-  // color-mix(accent 45% + transparent) approximation over BG #0e1114
-  const ACCENT_TRAIL = "#7a3a1f";
-  // color-mix(accent 22% + transparent) approximation over BG #0e1114
-  const ACCENT_GLOW = "#3b2018";
+  const RULE = "#2a2622";
+  // color-mix(accent 14% + transparent) over BG #0e1114
+  const ACCENT_TINT = "#241813";
+
+  // Reduced freeze positions, mirrored from the animated component.
+  const dot0X = GATE_X + 14;
+  const dot1X = EMIT_X + (GATE_X - EMIT_X) * 0.55;
+  const dot2X = EMIT_X + 4;
 
   return (
     <svg
-      viewBox="0 0 200 200"
+      viewBox={`0 0 ${VB} ${VB}`}
       xmlns="http://www.w3.org/2000/svg"
       width="100%"
       height="100%"
     >
+      {/* Pipeline track */}
+      <line
+        x1={EMIT_X}
+        y1={TRACK_Y}
+        x2={EXIT_X - 6}
+        y2={TRACK_Y}
+        stroke={RULE}
+        strokeWidth={1.2}
+        strokeDasharray="2 4"
+        strokeLinecap="round"
+        opacity={0.6}
+      />
+
       {/* Baseline rule */}
       <line
-        x1={ORIGIN_X}
-        y1={ORIGIN_Y + GRID_H + 14}
-        x2={ORIGIN_X + GRID_W}
-        y2={ORIGIN_Y + GRID_H + 14}
+        x1={MODEL_X}
+        y1={GATE_BOT + 18}
+        x2={EXIT_X}
+        y2={GATE_BOT + 18}
         stroke={MUTED}
         strokeWidth={1.0}
-        opacity={0.32}
+        opacity={0.28}
       />
 
-      {/* 11 surrounding cells */}
-      {CELLS.map((cell) => {
-        const isFail = cell.row === FAIL_ROW && cell.col === FAIL_COL;
-        if (isFail) return null;
-        return (
-          <circle
-            key={`cell-${cell.row}-${cell.col}`}
-            cx={cell.cx}
-            cy={cell.cy}
-            r={DOT_R}
-            fill={ACCENT}
-            opacity={0.95}
-          />
-        );
-      })}
+      {/* Model glyph */}
+      <rect
+        x={MODEL_X}
+        y={MODEL_Y}
+        width={MODEL_W}
+        height={MODEL_H}
+        rx={5}
+        fill={ACCENT_TINT}
+        stroke={ACCENT}
+        strokeWidth={1.6}
+      />
+      <circle cx={MODEL_CX - 4} cy={MODEL_CY} r={1.5} fill={ACCENT} />
+      <circle cx={MODEL_CX} cy={MODEL_CY} r={1.5} fill={ACCENT} />
+      <circle cx={MODEL_CX + 4} cy={MODEL_CY} r={1.5} fill={ACCENT} />
 
-      {/* Failure cell: freshly restored to filled terracotta */}
-      <circle cx={FAIL.cx} cy={FAIL.cy} r={DOT_R} fill={ACCENT} opacity={1} />
+      {/* Eval gate */}
+      <line
+        x1={GATE_X}
+        y1={GATE_TOP}
+        x2={GATE_X}
+        y2={GATE_BOT}
+        stroke={ACCENT}
+        strokeWidth={2.4}
+        strokeLinecap="round"
+      />
+      <circle cx={GATE_X} cy={GATE_TOP} r={2} fill={ACCENT} opacity={0.9} />
+      <circle cx={GATE_X} cy={GATE_BOT} r={2} fill={ACCENT} opacity={0.9} />
 
-      {/* Residual dashed-ring trace — what was just caught */}
-      <circle
-        cx={FAIL.cx}
-        cy={FAIL.cy}
-        r={DOT_R + 0.5}
+      {/* Output dot 0 — past the gate, with tick */}
+      <circle cx={dot0X} cy={TRACK_Y} r={DOT_R} fill={ACCENT} />
+      <path
+        d={`M ${dot0X - 3.2} ${TRACK_Y - 8} L ${dot0X - 1} ${TRACK_Y - 5.5} L ${dot0X + 3.2} ${TRACK_Y - 10}`}
         fill="none"
-        stroke={MUTED}
-        strokeWidth={1.2}
-        strokeDasharray="2 2"
-        opacity={0.4}
+        stroke={ACCENT}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
 
-      {/* Scan beam at the "caught" position — centered on failure cell */}
-      <g
-        transform={`translate(${FAIL.cx - (GRID_W + 16) / 2} ${FAIL.cy})`}
-        opacity={0.9}
-      >
-        <line
-          x1={0}
-          y1={0}
-          x2={GRID_W + 16}
-          y2={0}
-          stroke={ACCENT}
-          strokeWidth={2.2}
-          strokeLinecap="round"
-        />
-        <line
-          x1={6}
-          y1={3}
-          x2={GRID_W + 10}
-          y2={3}
-          stroke={ACCENT_TRAIL}
-          strokeWidth={1.4}
-          strokeLinecap="round"
-        />
-        <line
-          x1={12}
-          y1={-3}
-          x2={GRID_W + 4}
-          y2={-3}
-          stroke={ACCENT_GLOW}
-          strokeWidth={1}
-          strokeLinecap="round"
-        />
-      </g>
+      {/* Output dot 1 — mid-track */}
+      <circle cx={dot1X} cy={TRACK_Y} r={DOT_R} fill={ACCENT} />
+
+      {/* Output dot 2 — emission */}
+      <circle cx={dot2X} cy={TRACK_Y} r={DOT_R} fill={ACCENT} />
+
+      {/* Tally column */}
+      <line
+        x1={TALLY_X - 6}
+        y1={TALLY_TOP - 10}
+        x2={TALLY_X + 6}
+        y2={TALLY_TOP - 10}
+        stroke={MUTED}
+        strokeWidth={1.0}
+        opacity={0.45}
+      />
+      <path
+        d={`M ${TALLY_X - 4} ${TALLY_TOP + 1} L ${TALLY_X - 1.5} ${TALLY_TOP + 3.2} L ${TALLY_X + 4} ${TALLY_TOP - 2}`}
+        fill="none"
+        stroke={ACCENT}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.85}
+      />
+      <path
+        d={`M ${TALLY_X - 4} ${TALLY_TOP + TALLY_GAP + 1} L ${TALLY_X - 1.5} ${TALLY_TOP + TALLY_GAP + 3.2} L ${TALLY_X + 4} ${TALLY_TOP + TALLY_GAP - 2}`}
+        fill="none"
+        stroke={ACCENT}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity={0.85}
+      />
+      <line
+        x1={TALLY_X - 3.5}
+        y1={TALLY_TOP + TALLY_GAP * 2 - 2.5}
+        x2={TALLY_X + 3.5}
+        y2={TALLY_TOP + TALLY_GAP * 2 + 2.5}
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        opacity={0.7}
+      />
+      <line
+        x1={TALLY_X + 3.5}
+        y1={TALLY_TOP + TALLY_GAP * 2 - 2.5}
+        x2={TALLY_X - 3.5}
+        y2={TALLY_TOP + TALLY_GAP * 2 + 2.5}
+        stroke={MUTED}
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        opacity={0.7}
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Diagnosis (Step A — what was broken)

The v1 cover (PR #94) used opacity 0.85→1.0 pulses on three small terracotta dots. The plumbing ran (motion/react, `"use client"`, `useInView` + `useReducedMotion` gated correctly via `_CoverFrame`), but the **gesture was below the noise floor** at 64 px. After the 4× downscale to thumbnail size, a 15% opacity bump on a 6 px dot is invisible — playbook §3 / §11 diagnosis #2 (motion amplitude). Combined with each pulse owning only 0.10 of a 6 s loop and only 3 of 4 neighbors actually pulsing (the top neighbor was filtered out — `EMPTY_ROW=0` made `r=-1` out of grid), the user perceived a static cover with a dashed empty cell.

The user was right that the animation "isn't working" — the JavaScript ran, the *signal* didn't.

## New concept (Step B — the redesign)

**One sentence:** A 4×3 terracotta grid where, once per loop, a hidden failure surfaces (the cell at row 1 col 2 flickers off into a dashed "miss"), a scan beam sweeps right→left across that row and catches it, and the cell resolves back to filled — the eval cycle compressed into one continuous gesture.

**Why this concept:** the article's thesis is that evals catch what vibes miss. Direction (1) from the brief, refined: don't show a permanent gap (the v1 mistake — inert at 64 px), show the *cycle* of catching. The running gesture *is* the answer to "how do I know if my AI is any good": you scan, you catch, you fix, repeat.

**Composition (~14 load-bearing elements, within §2 cap):**
- 11 stable filled cells (terracotta dots, opacity 0.95)
- 1 failure cell that animates (filled → dashed-miss → caught flash → filled)
- 1 dashed "miss" ring overlay on the failure cell
- 1 scan beam group: sharp leading line + trailing wash + outer glow
- 1 baseline rule

**Motion (5 s continuous loop, refined kinetic register, §14):**
- Phase A (0–25%): failure cell fades terracotta → dashed empty ring
- Phase B (25–58%): scan beam translates 150 px right→left across the failure row (75% of viewBox — visible at 64 px, clears the §3 floor)
- Phase C (58–82%): as the beam passes the cell, the cell opacity-flashes 0→1 (caught) and the dashed ring fades to 0
- Phase D (82–100%): all 12 cells uniform 0.95, brief breathing hold; loop

**Hero gesture:** the scan beam sweep — one bold gesture, opacity-led trail, gentle ease.
**Quiet support:** the failure cell's fade-out → catch arc, narratively coupled to the beam.

## Reduced-motion + static-fallback strategy

Reduced-motion still: the "caught" moment — beam centered on the failure cell at 0.9 opacity, cell freshly filled at full opacity, dashed ring lingering at 0.4 (residual trace of the catch). The reader reads the metaphor from the still: evals scanning, catching the miss.

`EvalsOrVibesCoverStatic` (Satori-rendered for OG) mirrors this exact still frame using inline hex tokens (no `var()`, no `color-mix()`, no hooks). Same composition, just no motion.

## Site-constraint compliance

- Tokens only (`var(--color-accent)`, `var(--color-text-muted)`); `color-mix(in oklab, ...)` for the wash trail. No raw hex in the animated component.
- Frame-stability R6: only `transform` (translateX on beam) and `opacity` animate — no geometry attribute changes.
- viewBox 200×200; element budget at 14 (well under 50–70 v3 failure threshold).
- No `<VerticalCutReveal>`. Custom motion/react.
- Cover does NOT render on `/posts/evals-or-vibes` (verified via dev-server curl: `cover-evals-or-vibes` appears 1× on `/`, 0× on the article).

## Validation

- `npx tsc --noEmit`: clean (only the pre-existing `@web-kits/audio` errors, unchanged with stash test).
- `pnpm build`: clean. 26 static pages generated (8 posts including evals-or-vibes), unchanged page count vs. main.
- `pnpm lint`: 115 problems before AND after my changes — zero new lint issues introduced (verified via stash diff).
- Dev server smoke (port 3011): homepage 200 + cover renders; article page 200 + cover correctly absent (post-PR-#92 convention).
- Reduced-motion: branch verified — beam parks at failure cell (`BEAM_X_CAUGHT`), failure cell at opacity 1, dashed ring at 0.4.
- Theme: tokens only, will flip cleanly with the existing OKLCH theme machinery.

## Files changed

- `components/covers/EvalsOrVibesCover.tsx` — full redesign of both `EvalsOrVibesCover` (animated) and `EvalsOrVibesCoverStatic` (Satori-safe). +264 / −147.

No other files touched: registry imports already point to `EvalsOrVibesCover` and `EvalsOrVibesCoverStatic` from this file, and the registration in `PostCover.tsx` and `static-registry.ts` was already correct from PR #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## v3 redesign (commit fd57775) — full rebuild from scratch

The user rejected v2's scan-beam concept verbatim: *"the animated SVG should be completely revamped, i need a smoother animation, a more relatable animation to the topic. build it again from the scratch."*

**Diagnosis of v2:** technically smooth but the metaphor read as abstract — a horizontal sweep over a row of dots doesn't trigger an "ah, that's an eval" recognition. The reader saw a pretty pattern, not a pipeline.

**v3 concept** (most literal direction available — direction γ/δ blend from the brief):

> An LLM glyph on the left emits a continuous stream of output dots that glide rightward through a vertical terracotta "eval gate." Each output picks up a verdict (tick or cross) as it crosses the gate. A static tally column on the right keeps the running score (pass, pass, fail).

This is a **textbook eval pipeline**: model → output → judge → verdict → tally. Three seconds of looking at the loop and the reader thinks "evals" because they are literally watching outputs being evaluated.

**Smoothness fix:**
- **Linear easing** on the dot translateX (`ease: "linear"` — no curves, no acceleration). A constant-velocity glide reads as continuous flow rather than staccato beats.
- **Three dots phase-staggered 1/3 of the loop apart** — at any instant one is emitting, one is mid-track, one is crossing or just crossed. No idle gap, no "now this happens, now this happens."
- **Eval gate gently pulses** in opacity on the same 6 s cycle, three pulses synced to crossings.

**Composition (~13 load-bearing elements):**
1. Model glyph (rounded square + 3 inner dots — the LLM)
2. Pipeline track (chrome dashed line — flow direction)
3. Eval gate (vertical terracotta bar — the judge)
4–6. Three output dots, staggered, gliding left → right
7–9. Three verdict glyphs (tick / tick / cross), revealed at crossing, ride the dot to the exit
10–12. Tally column (pass, pass, fail — static history)
13. Baseline rule

**Reduced-motion still:** dot 0 just past the gate with tick attached, dot 1 mid-track, dot 2 at emission, gate at full opacity, tally visible. The still alone reads as "outputs flowing through a judge accumulating verdicts."

**Validation (v3):**
- `npx tsc --noEmit` — clean.
- `pnpm build` — clean, 26 static pages (unchanged).
- `pnpm lint` — baseline preserved (no new issues in EvalsOrVibesCover.tsx).
- Dev smoke at :3011 — homepage 200, post 200, `cover-evals-or-vibes` view-transition tag present.
- Frame-stability R6 — only `transform` (translateX on dot groups) and `opacity` animate; no geometry attributes touched.
- Tokens-only — `var(--color-accent)`, `var(--color-text-muted)`, `var(--color-rule)`, `color-mix(in oklab, ...)` for the model tint. No raw hex in the animated path. Static export uses inlined hex (Satori limitation).

**Iteration trail visible in commits:** `7b0b4ab` (v2 scan-beam) → `fd57775` (v3 model → gate → tally pipeline). No force-push; the PR shows the full design history.
